### PR TITLE
feat(pe-auto-08): Discord loop for autonomous operation

### DIFF
--- a/.github/workflows/implementer-runner.yml
+++ b/.github/workflows/implementer-runner.yml
@@ -103,6 +103,36 @@ jobs:
           CLAUDE_SETUP_TOKEN: ${{ secrets.CLAUDE_SETUP_TOKEN }}
         run: python scripts/verify_claude_auth.py
 
+      - name: Notify PM Agent webhook — PE started
+        if: env.PM_AGENT_WEBHOOK_URL != ''
+        env:
+          PM_AGENT_WEBHOOK_URL: ${{ secrets.PM_AGENT_WEBHOOK_URL }}
+        run: |
+          python - <<'EOF'
+          import json
+          import os
+          import urllib.request
+
+          payload = {
+              "event": "pe-lifecycle",
+              "stage": "started",
+              "pe_id": "${{ inputs.pe_id }}",
+              "branch": "${{ inputs.branch }}",
+              "engine": "${{ inputs.engine }}",
+              "base_branch": "${{ inputs.base_branch }}",
+              "message": "[AUTO] ${{ inputs.pe_id }} started · Implementer: ${{ inputs.engine }}",
+          }
+          data = json.dumps(payload).encode("utf-8")
+          req = urllib.request.Request(
+              os.environ["PM_AGENT_WEBHOOK_URL"],
+              data=data,
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+          with urllib.request.urlopen(req, timeout=30) as response:
+              print(f"Webhook status: {response.status}")
+          EOF
+
       - name: Run CODEX implementer
         if: inputs.engine == 'codex'
         env:

--- a/.github/workflows/pe-sequencer.yml
+++ b/.github/workflows/pe-sequencer.yml
@@ -88,6 +88,13 @@ jobs:
                 'Automatic advance halted because the next PE is not ready.',
                 reason
               ].join('\n');
+            } else if (action === 'halt_paused') {
+              body = [
+                '## PM sequencer',
+                '',
+                'Automatic advance halted because the autonomous loop is paused.',
+                reason
+              ].join('\n');
             } else if (action === 'skip') {
               body = [
                 '## PM sequencer',

--- a/.github/workflows/pm-arbiter.yml
+++ b/.github/workflows/pm-arbiter.yml
@@ -6,7 +6,28 @@ on:
   schedule:
     # Run every 6h to detect PRs with `blocked` status older than 24h.
     - cron: '0 */6 * * *'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to arbitrate when triggered manually'
+        required: false
+      trigger_type:
+        description: 'Optional arbitration trigger override'
+        required: false
+      head_branch:
+        description: 'Optional PR head branch override'
+        required: false
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: string
+      trigger_type:
+        required: false
+        type: string
+      head_branch:
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -20,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only fire on the arbitration trigger labels.
     if: |
+      github.event_name == 'workflow_call' ||
       github.event.label.name == 'pm-arbitration-required' ||
       github.event.label.name == 'scope-dispute' ||
       github.event.label.name == 'pm-escalation' ||
@@ -29,7 +51,7 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || inputs.head_branch || github.event.inputs.head_branch || github.ref_name }}
           fetch-depth: 0
           token: ${{ secrets.PM_BOT_TOKEN }}
 
@@ -51,8 +73,23 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const label = context.payload.label.name;
-            const prNumber = context.payload.pull_request.number;
+            const isWorkflowCall = context.eventName === 'workflow_call';
+            const isWorkflowDispatch = context.eventName === 'workflow_dispatch';
+            const label = context.payload.label?.name || '';
+            const triggerOverride =
+              (isWorkflowCall ? '${{ inputs.trigger_type }}' : '') ||
+              (isWorkflowDispatch ? '${{ github.event.inputs.trigger_type }}' : '');
+            const prNumberRaw =
+              (isWorkflowCall ? '${{ inputs.pr_number }}' : '') ||
+              (isWorkflowDispatch ? '${{ github.event.inputs.pr_number }}' : '') ||
+              context.payload.pull_request?.number;
+            const prNumber = Number(prNumberRaw);
+
+            if (!prNumber) {
+              core.setFailed('PR number is required for workflow_call/workflow_dispatch arbitration runs.');
+              return;
+            }
+
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -60,10 +97,12 @@ jobs:
             });
 
             // Map label to trigger type.
-            let triggerType = 'fail_round_3';
-            if (label === 'scope-dispute') triggerType = 'scope_dispute';
-            if (label === 'pm-escalation') triggerType = 'technical_blocker';
-            if (label === 'timeout') triggerType = 'timeout';
+            let triggerType = triggerOverride || 'fail_round_3';
+            if (!triggerOverride) {
+              if (label === 'scope-dispute') triggerType = 'scope_dispute';
+              if (label === 'pm-escalation') triggerType = 'technical_blocker';
+              if (label === 'timeout') triggerType = 'timeout';
+            }
 
             // Count fail-round-* labels to determine fail round.
             const failLabels = pr.labels
@@ -86,7 +125,12 @@ jobs:
             core.setOutput('trigger_type', triggerType);
             core.setOutput('fail_round', String(failRound));
             core.setOutput('pr_number', String(prNumber));
-            core.setOutput('head_branch', pr.head.ref);
+            core.setOutput(
+              'head_branch',
+              (isWorkflowCall ? '${{ inputs.head_branch }}' : '') ||
+              (isWorkflowDispatch ? '${{ github.event.inputs.head_branch }}' : '') ||
+              pr.head.ref
+            );
             core.setOutput('arbiter_iteration', String(arbIterations));
 
       - name: Find REVIEW file for this branch
@@ -200,6 +244,7 @@ jobs:
         if: steps.arbiter.outputs.decision == 'ESCALATE_PO'
         env:
           PM_AGENT_WEBHOOK_URL: ${{ secrets.PM_AGENT_WEBHOOK_URL }}
+          PM_AGENT_PO_MENTION: ${{ secrets.PM_AGENT_PO_MENTION }}
         run: |
           python - <<'EOF'
           import json, os, urllib.request
@@ -214,6 +259,11 @@ jobs:
               "justification": "${{ steps.arbiter.outputs.justification }}",
               "pr_number": "${{ steps.ctx.outputs.pr_number }}",
               "ll_id": "${{ steps.arbiter.outputs.ll_id }}",
+              "po_mention": os.environ.get("PM_AGENT_PO_MENTION", "@PO"),
+              "message": (
+                  f"{os.environ.get('PM_AGENT_PO_MENTION', '@PO')} "
+                  f"[ESCALATE] ${{ steps.pe.outputs.pe_id }} requires PO decision"
+              ),
           }
           data = json.dumps(payload).encode("utf-8")
           req = urllib.request.Request(

--- a/.github/workflows/pm-discord-command.yml
+++ b/.github/workflows/pm-discord-command.yml
@@ -1,0 +1,165 @@
+name: PM Discord Command
+
+on:
+  workflow_dispatch:
+    inputs:
+      command:
+        required: true
+        type: choice
+        options:
+          - status
+          - auth-check
+          - pause
+          - resume
+          - veto
+          - override-pass
+      pr_number:
+        required: false
+        type: string
+      actor:
+        required: false
+        default: PO
+        type: string
+      reason:
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  command:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main with PM bot token
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.PM_BOT_TOKEN }}
+
+      - name: Configure PM bot git identity
+        run: |
+          git config user.name "elis-pm-bot"
+          git config user.email "elis-pm-bot@users.noreply.github.com"
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Handle control command
+        if: contains('pause resume veto override-pass', inputs.command)
+        id: control
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          args=(
+            --command "${{ inputs.command }}"
+            --actor "${{ inputs.actor }}"
+            --reason "${{ inputs.reason }}"
+            --write
+            --json
+          )
+          if [ -n "$PR_NUMBER" ]; then
+            args+=(--pr-number "$PR_NUMBER")
+          fi
+          python scripts/pm_discord_command.py "${args[@]}" > command.json
+
+      - name: Handle status command
+        if: inputs.command == 'status'
+        run: |
+          python scripts/pm_status_reporter.py --command status > command.txt
+          python - <<'EOF'
+          import json
+          from pathlib import Path
+          Path("command.json").write_text(
+              json.dumps(
+                  {
+                      "command": "status",
+                      "message": Path("command.txt").read_text(encoding="utf-8").strip(),
+                  },
+                  indent=2,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          EOF
+
+      - name: Handle auth-check command
+        if: inputs.command == 'auth-check'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CLAUDE_SETUP_TOKEN: ${{ secrets.CLAUDE_SETUP_TOKEN }}
+        run: |
+          python scripts/pm_status_reporter.py --command auth-check > command.txt
+          python - <<'EOF'
+          import json
+          from pathlib import Path
+          Path("command.json").write_text(
+              json.dumps(
+                  {
+                      "command": "auth-check",
+                      "message": Path("command.txt").read_text(encoding="utf-8").strip(),
+                  },
+                  indent=2,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          EOF
+
+      - name: Commit updated loop control
+        if: contains('pause resume veto', inputs.command)
+        env:
+          COMMIT_MESSAGE: ${{ inputs.command == 'veto' && 'chore(pm): apply veto and pause loop' || inputs.command == 'pause' && 'chore(pm): pause autonomous loop' || 'chore(pm): resume autonomous loop' }}
+        run: |
+          git add config/pm_loop_control.json
+          if git diff --cached --quiet; then
+            echo "No loop-control changes to commit."
+          else
+            git commit -m "$COMMIT_MESSAGE"
+            git push origin HEAD:main
+          fi
+
+      - name: Apply PM veto label
+        if: inputs.command == 'veto'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PM_BOT_TOKEN }}
+          script: |
+            const prNumber = parseInt('${{ inputs.pr_number }}', 10);
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['pm-review-required'],
+            });
+
+      - name: Post Discord command payload to PM Agent webhook
+        if: env.PM_AGENT_WEBHOOK_URL != ''
+        env:
+          PM_AGENT_WEBHOOK_URL: ${{ secrets.PM_AGENT_WEBHOOK_URL }}
+        run: |
+          python - <<'EOF'
+          import json
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          payload = json.loads(Path("command.json").read_text(encoding="utf-8"))
+          payload["event"] = "pm-discord-command"
+          data = json.dumps(payload).encode("utf-8")
+          req = urllib.request.Request(
+              os.environ["PM_AGENT_WEBHOOK_URL"],
+              data=data,
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+          with urllib.request.urlopen(req, timeout=30) as response:
+              print(f"Webhook status: {response.status}")
+          EOF

--- a/REVIEW_PE_AUTO_08.md
+++ b/REVIEW_PE_AUTO_08.md
@@ -1,0 +1,116 @@
+# REVIEW_PE_AUTO_08 — Validator Review
+
+**PE:** PE-AUTO-08 — Discord Loop for Autonomous Operation
+**PR:** #315
+**Validator:** infra-val-claude (Claude Code)
+**Date:** 2026-04-08
+
+---
+
+### Verdict
+
+PASS
+
+---
+
+### Gate results
+
+| Gate | Result |
+|------|--------|
+| `python -m black --check .` | ✅ PASS — 156 files unchanged |
+| `python -m ruff check .` | ✅ PASS — all checks passed |
+| `python -m pytest -q` | ✅ PASS — 713 passed, 17 warnings |
+| CI checks (`gh pr checks 315`) | ⚠️ `tests` was FAIL on CI at HEAD `18d731d` — root cause found and fixed (see below) |
+| Scope (`git diff --name-status origin/main..HEAD`) | ✅ Clean — 16 files; 14 match HANDOFF `Files Changed`, plus `HANDOFF.md` and `handoffs/HANDOFF_PE-AUTO-08.md` |
+
+---
+
+### Scope
+
+```
+M  .github/workflows/implementer-runner.yml
+M  .github/workflows/pe-sequencer.yml
+M  .github/workflows/pm-arbiter.yml
+A  .github/workflows/pm-discord-command.yml
+M  HANDOFF.md
+A  config/pm_loop_control.json
+M  docs/openclaw/workspace-pm/AGENTS.md
+M  docs/openclaw/workspace-pm/MEMORY.md
+A  handoffs/HANDOFF_PE-AUTO-08.md
+M  scripts/pe_sequencer.py
+A  scripts/pm_discord_command.py
+M  scripts/pm_status_reporter.py
+M  tests/test_pe_sequencer.py
+A  tests/test_pm_discord_command.py
+A  tests/test_pm_discord_workflows.py
+M  tests/test_pm_status_reporter.py
+```
+
+All 14 functional files match HANDOFF `Files Changed`. `HANDOFF.md` and `handoffs/HANDOFF_PE-AUTO-08.md` are standard Implementer deliverables.
+
+---
+
+### Required fixes
+
+None.
+
+---
+
+### Evidence
+
+**CI failure root cause and fix**
+
+`test_main_auth_check_command` failed on CI (`tests` check, run 24161432511) with:
+```
+AssertionError: assert 'Auth status: codex OK · claude OK' in
+  'Auth status: codex unavailable · claude unavailable'
+```
+
+Root cause: `auth_status_summary(which=shutil.which)` has `which` as a default parameter
+bound at **definition time**. `monkeypatch.setattr("scripts.pm_status_reporter.shutil.which", ...)`
+replaces the module attribute, but `main()` called `auth_status_summary()` with no args, so
+the pre-bound original `shutil.which` was used — returning `None` for `codex`/`claude` on CI
+where neither CLI is installed.
+
+Fix applied: `main()` now calls `auth_status_summary(which=shutil.which)` explicitly at both
+call sites, evaluating `shutil.which` at call time (picking up any monkeypatch).
+
+This is a Validator scope-safe fix in `scripts/pm_status_reporter.py` — the same file the
+Implementer modified.
+
+**§6.4 — Quality gates (post-fix)**
+
+```text
+python -m black --check .
+All done! ✨ 🍰 ✨
+156 files would be left unchanged.
+
+python -m ruff check .
+All checks passed!
+
+python -m pytest -q
+713 passed, 17 warnings in 12.55s
+```
+
+**§6.5 — CI checks**
+
+```text
+gh pr checks 315
+tests           fail   16s   (HEAD 18d731d — pre-fix)
+quality         pass    9s
+validate        pass   16s
+current-pe-check pass   7s
+review-evidence-check pass 5s
+secrets-scope-check   pass  6s
+...
+```
+
+**AC verification**
+
+| AC | Criterion | Verdict |
+|----|-----------|---------|
+| AC-1 | PE lifecycle event posted to Discord within 60s | ✅ `implementer-runner.yml` posts `pe-lifecycle` webhook at PE start; `pm-discord-command.yml` posts structured responses immediately |
+| AC-2 | `!pe status` returns current state with autonomy rate | ✅ `pm_status_reporter.py --command status` includes `Autonomy rate:`; verified by `test_pm_status_reporter.py` |
+| AC-3 | `!pe veto` applies label and stops sequencer in <30s | ✅ `pm_discord_command.py` returns `pm-review-required` + paused state; `pe_sequencer.py` halts on paused control file; covered by `test_pm_discord_command.py` |
+| AC-4 | `!pe auth-check` reports token status without exposing values | ✅ `auth_status_summary()` reports OK/unavailable only; `test_auth_status_summary_hides_values` asserts no raw values in output |
+| AC-5 | `ESCALATE_PO` mentions PO's `@` on Discord | ✅ `pm-arbiter.yml` includes `PM_AGENT_PO_MENTION` in webhook payload; `test_pm_discord_workflows.py` verifies mention field present |

--- a/config/pm_loop_control.json
+++ b/config/pm_loop_control.json
@@ -1,0 +1,6 @@
+{
+  "paused": false,
+  "updated_at": "",
+  "updated_by": "",
+  "reason": ""
+}

--- a/docs/openclaw/workspace-pm/AGENTS.md
+++ b/docs/openclaw/workspace-pm/AGENTS.md
@@ -153,6 +153,25 @@ When the PO asks about active worktrees:
 
 Never state that a worktree exists based solely on registry data.
 
+### 5.4 Discord Loop Commands
+
+The autonomous loop commands are backed by repository automation and a loop-control file
+at `config/pm_loop_control.json`.
+
+Use these commands as follows:
+
+- `!pe status` → report the active loop state, autonomy rate, and auth summary using the
+  same status-report format as the repo command layer
+- `!pe auth-check` → report token health as `OK` / `unavailable` only; never expose token
+  values, lengths, or prefixes
+- `!pe veto` → apply `pm-review-required` to the active PR and pause the sequencer
+- `!pe pause` → set loop control to paused; the sequencer must halt on the next advance trigger
+- `!pe resume` → clear the paused state and allow the sequencer to continue
+- `!pe override PASS` → requires an audit entry in `LESSONS_LEARNED.md` before force-merge
+
+When reporting an `ESCALATE_PO` event on Discord, include the configured PO mention in the
+message body.
+
 ---
 
 ## 6. Exec Commands

--- a/docs/openclaw/workspace-pm/MEMORY.md
+++ b/docs/openclaw/workspace-pm/MEMORY.md
@@ -13,6 +13,10 @@ This file records the durable corrections that must survive session drift.
 - PR status must be reported only from `gh pr`.
 - Registry branch names do not prove worktrees exist — always verify with `git worktree list`.
 - Full PE registry in Discord: compact bullet format (one line per PE), max 25 entries per message, labeled (1/N). Never the raw 7-column table.
+- Sequencer pause state lives in `config/pm_loop_control.json`; `!pe veto` and `!pe pause`
+  must set it, and `!pe resume` must clear it.
+- `!pe auth-check` reports only safe status words such as `OK` / `unavailable`; never print
+  token values or derived secrets.
 
 ---
 

--- a/handoffs/HANDOFF_PE-AUTO-08.md
+++ b/handoffs/HANDOFF_PE-AUTO-08.md
@@ -219,4 +219,4 @@ gh pr list --state open --base main
 
 ---
 
-*ELIS SLR Agent · HANDOFF.md · Codex · 2026-04-08*
+*ELIS SLR Agent · handoffs/HANDOFF_PE-AUTO-08.md · Codex · 2026-04-08*

--- a/scripts/pe_sequencer.py
+++ b/scripts/pe_sequencer.py
@@ -21,6 +21,7 @@ REGISTRY_HEADING = "## Active PE Registry"
 SECTION_BREAK_RE = re.compile(r"^---\s*$", re.MULTILINE)
 PE_SECTION_RE = re.compile(r"^###\s+(PE-[A-Z]+-[0-9]+)\s+·\s+(.+?)\s*$", re.MULTILINE)
 TABLE_FIELD_RE = re.compile(r"^\|\s*(?P<field>[^|]+?)\s*\|\s*(?P<value>[^|]+?)\s*\|$")
+DEFAULT_CONTROL_FILE = Path("config/pm_loop_control.json")
 
 
 @dataclass(frozen=True)
@@ -60,6 +61,15 @@ class SequencerDecision:
 
 class SequencerError(RuntimeError):
     """Raised when the sequencer cannot update CURRENT_PE.md safely."""
+
+
+def _load_loop_control(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {"paused": False, "reason": "", "updated_by": "", "updated_at": ""}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SequencerError(f"Loop control file is malformed: {path}")
+    return data
 
 
 def _extract_table_value(content: str, heading: str, field: str) -> str:
@@ -359,6 +369,7 @@ def advance_current_pe(
     current_pe_path: Path,
     merged_pe: str | None = None,
     merged_branch: str | None = None,
+    control_file: Path | None = None,
 ) -> SequencerDecision:
     content = current_pe_path.read_text(encoding="utf-8")
     active_pe = _current_pe_id(content)
@@ -378,6 +389,25 @@ def advance_current_pe(
             reason=(
                 f"Merged branch {merged_branch} does not match active branch "
                 f"{active_branch}; skipping sequencer advance."
+            ),
+            updated_content=None,
+            implementer_engine=None,
+            validator_engine=None,
+            pm_chore_id=None,
+        )
+
+    loop_control = _load_loop_control(control_file or DEFAULT_CONTROL_FILE)
+    if bool(loop_control.get("paused")):
+        reason = str(loop_control.get("reason", "")).strip()
+        return SequencerDecision(
+            action="halt_paused",
+            merged_pe=merged_pe,
+            next_pe=None,
+            next_branch=None,
+            reason=(
+                "Sequencer is paused by PM control."
+                if not reason
+                else f"Sequencer is paused by PM control: {reason}"
             ),
             updated_content=None,
             implementer_engine=None,
@@ -495,6 +525,11 @@ def main() -> int:
         action="store_true",
         help="Print the decision as JSON.",
     )
+    parser.add_argument(
+        "--control-file",
+        default=str(DEFAULT_CONTROL_FILE),
+        help="Path to the sequencer loop-control file.",
+    )
     args = parser.parse_args()
 
     try:
@@ -503,6 +538,7 @@ def main() -> int:
             current_pe_path,
             args.merged_pe,
             args.merged_branch,
+            Path(args.control_file),
         )
         if args.write and decision.updated_content is not None:
             current_pe_path.write_text(decision.updated_content, encoding="utf-8")

--- a/scripts/pm_discord_command.py
+++ b/scripts/pm_discord_command.py
@@ -1,0 +1,235 @@
+"""PE-AUTO-08 Discord loop command handler for the PM Agent."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import sys
+from dataclasses import asdict, dataclass
+
+
+DEFAULT_CONTROL = {
+    "paused": False,
+    "updated_at": "",
+    "updated_by": "",
+    "reason": "",
+}
+DEFAULT_CONTROL_PATH = pathlib.Path("config/pm_loop_control.json")
+
+
+@dataclass(frozen=True)
+class LoopControl:
+    paused: bool
+    updated_at: str
+    updated_by: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    command: str
+    message: str
+    label_to_apply: str
+    pause_loop: bool
+    force_merge: bool
+    audit_entry_required: bool
+    control: LoopControl
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "command": self.command,
+            "message": self.message,
+            "label_to_apply": self.label_to_apply,
+            "pause_loop": self.pause_loop,
+            "force_merge": self.force_merge,
+            "audit_entry_required": self.audit_entry_required,
+            "control": asdict(self.control),
+        }
+
+
+class CommandError(RuntimeError):
+    """Raised when a Discord command cannot be handled safely."""
+
+
+def load_loop_control(path: pathlib.Path) -> LoopControl:
+    if not path.exists():
+        return LoopControl(**DEFAULT_CONTROL)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise CommandError(f"Loop control file must contain a JSON object: {path}")
+    merged = {**DEFAULT_CONTROL, **data}
+    return LoopControl(
+        paused=bool(merged.get("paused")),
+        updated_at=str(merged.get("updated_at", "")),
+        updated_by=str(merged.get("updated_by", "")),
+        reason=str(merged.get("reason", "")),
+    )
+
+
+def write_loop_control(path: pathlib.Path, control: LoopControl) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(asdict(control), indent=2) + "\n", encoding="utf-8")
+
+
+def _timestamp() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat()
+
+
+def _updated_control(
+    *,
+    paused: bool,
+    actor: str,
+    reason: str,
+) -> LoopControl:
+    return LoopControl(
+        paused=paused,
+        updated_at=_timestamp(),
+        updated_by=actor,
+        reason=reason,
+    )
+
+
+def handle_command(
+    *,
+    command: str,
+    control: LoopControl,
+    actor: str,
+    pr_number: int | None = None,
+    reason: str = "",
+) -> CommandResult:
+    normalised = command.strip().lower()
+    if normalised == "pause":
+        updated = _updated_control(
+            paused=True,
+            actor=actor,
+            reason=reason or "PO paused the autonomous loop.",
+        )
+        return CommandResult(
+            command="pause",
+            message="Loop paused. Sequencer will stop after the current PE.",
+            label_to_apply="",
+            pause_loop=True,
+            force_merge=False,
+            audit_entry_required=False,
+            control=updated,
+        )
+    if normalised == "resume":
+        updated = _updated_control(
+            paused=False,
+            actor=actor,
+            reason=reason or "PO resumed the autonomous loop.",
+        )
+        return CommandResult(
+            command="resume",
+            message="Loop resumed. Sequencer may advance on the next eligible trigger.",
+            label_to_apply="",
+            pause_loop=False,
+            force_merge=False,
+            audit_entry_required=False,
+            control=updated,
+        )
+    if normalised == "veto":
+        if pr_number is None:
+            raise CommandError("veto command requires --pr-number")
+        updated = _updated_control(
+            paused=True,
+            actor=actor,
+            reason=reason or f"PO veto applied on PR #{pr_number}.",
+        )
+        return CommandResult(
+            command="veto",
+            message=(
+                f"PM veto applied to PR #{pr_number}. Added `pm-review-required` "
+                "and paused the sequencer."
+            ),
+            label_to_apply="pm-review-required",
+            pause_loop=True,
+            force_merge=False,
+            audit_entry_required=False,
+            control=updated,
+        )
+    if normalised == "override-pass":
+        if pr_number is None:
+            raise CommandError("override-pass command requires --pr-number")
+        return CommandResult(
+            command="override-pass",
+            message=(
+                f"PO override recorded for PR #{pr_number}. Force-merge may proceed "
+                "only with a mandatory audit entry in LESSONS_LEARNED.md."
+            ),
+            label_to_apply="",
+            pause_loop=control.paused,
+            force_merge=True,
+            audit_entry_required=True,
+            control=control,
+        )
+    raise CommandError(f"Unsupported Discord command: {command}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Handle PM Discord loop commands that mutate automation state."
+    )
+    parser.add_argument(
+        "--command",
+        required=True,
+        choices=["pause", "resume", "veto", "override-pass"],
+    )
+    parser.add_argument(
+        "--control-file",
+        default=str(DEFAULT_CONTROL_PATH),
+        help="Path to the loop control JSON file.",
+    )
+    parser.add_argument(
+        "--actor",
+        default="PO",
+        help="Actor issuing the command.",
+    )
+    parser.add_argument(
+        "--pr-number",
+        type=int,
+        help="PR number for veto / override-pass commands.",
+    )
+    parser.add_argument(
+        "--reason",
+        default="",
+        help="Optional reason to record in loop control state.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Persist control-file updates for pause/resume/veto commands.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of plain text.",
+    )
+    args = parser.parse_args()
+
+    try:
+        control_path = pathlib.Path(args.control_file)
+        control = load_loop_control(control_path)
+        result = handle_command(
+            command=args.command,
+            control=control,
+            actor=args.actor,
+            pr_number=args.pr_number,
+            reason=args.reason,
+        )
+        if args.write and args.command in {"pause", "resume", "veto"}:
+            write_loop_control(control_path, result.control)
+        if args.json:
+            print(json.dumps(result.as_dict(), indent=2))
+        else:
+            print(result.message)
+        return 0
+    except (CommandError, OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pm_status_reporter.py
+++ b/scripts/pm_status_reporter.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 
 import argparse
 import datetime
+import os
 import pathlib
+import re
+import shutil
 import sys
 
 # ---------------------------------------------------------------------------
@@ -33,6 +36,7 @@ VALID_STATUSES = {
 ACTIVE_STATUSES = VALID_STATUSES - {"merged"}
 
 _DEFAULT_REGISTRY = pathlib.Path("CURRENT_PE.md")
+_DEFAULT_LESSONS = pathlib.Path("LESSONS_LEARNED.md")
 
 
 def parse_active_registry(
@@ -129,7 +133,59 @@ def _merged_this_week(rows: list[dict[str, str]], now: datetime.date) -> int:
     return count
 
 
-def format_status_response(rows: list[dict[str, str]], now: datetime.date) -> str:
+def _intervention_pe_ids(lessons_content: str) -> set[str]:
+    pe_ids: set[str] = set()
+    for block in re.split(r"(?=^## LL-\d+\b)", lessons_content, flags=re.MULTILINE):
+        if "PM Arbitration" not in block and "ESCALATE_PO" not in block:
+            continue
+        pe_ids.update(re.findall(r"\bPE-[A-Z]+-[0-9]+\b", block))
+    return pe_ids
+
+
+def autonomy_rate_summary(
+    rows: list[dict[str, str]],
+    lessons_content: str,
+) -> str:
+    merged_ids = {
+        row["pe-id"]
+        for row in rows
+        if row.get("status", "").lower() == "merged" and row.get("pe-id")
+    }
+    if not merged_ids:
+        return "Autonomy rate: 0/0 PEs merged without escalation (0%)"
+
+    intervention_ids = _intervention_pe_ids(lessons_content) & merged_ids
+    autonomous = len(merged_ids) - len(intervention_ids)
+    rate = round((autonomous / len(merged_ids)) * 100)
+    return (
+        f"Autonomy rate: {autonomous}/{len(merged_ids)} PEs merged without "
+        f"escalation ({rate}%)"
+    )
+
+
+def auth_status_summary(
+    env: dict[str, str] | None = None,
+    *,
+    which=shutil.which,
+) -> str:
+    if env is None:
+        env = os.environ
+
+    codex_ok = bool(env.get("OPENAI_API_KEY")) and which("codex") is not None
+    claude_ok = bool(env.get("CLAUDE_SETUP_TOKEN")) and which("claude") is not None
+
+    codex_text = "codex OK" if codex_ok else "codex unavailable"
+    claude_text = "claude OK" if claude_ok else "claude unavailable"
+    return f"Auth status: {codex_text} · {claude_text}"
+
+
+def format_status_response(
+    rows: list[dict[str, str]],
+    now: datetime.date,
+    *,
+    lessons_content: str = "",
+    auth_summary: str | None = None,
+) -> str:
     """Format Active PE Registry for PO consumption (AGENTS.md §4.1).
 
     When more than one domain is present, active PEs are grouped under labelled
@@ -167,6 +223,8 @@ def format_status_response(rows: list[dict[str, str]], now: datetime.date) -> st
 
     lines.append("")
     lines.append(f"{len(active)} PEs active. {merged_week} merged this week.")
+    lines.append(autonomy_rate_summary(rows, lessons_content))
+    lines.append(auth_summary or auth_status_summary())
     return "\n".join(lines)
 
 
@@ -255,6 +313,12 @@ def load_registry(registry_path: pathlib.Path) -> list[dict[str, str]]:
     return rows
 
 
+def load_lessons(lessons_path: pathlib.Path) -> str:
+    if not lessons_path.exists():
+        return ""
+    return lessons_path.read_text(encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -269,7 +333,7 @@ def main() -> int:
     parser.add_argument(
         "--command",
         required=True,
-        choices=["status", "escalate"],
+        choices=["status", "escalate", "auth-check"],
         help="Command to execute",
     )
     parser.add_argument(
@@ -281,6 +345,11 @@ def main() -> int:
         default=str(_DEFAULT_REGISTRY),
         help="Path to CURRENT_PE.md (default: CURRENT_PE.md)",
     )
+    parser.add_argument(
+        "--lessons",
+        default=str(_DEFAULT_LESSONS),
+        help="Path to LESSONS_LEARNED.md (default: LESSONS_LEARNED.md)",
+    )
     args = parser.parse_args()
 
     try:
@@ -289,9 +358,22 @@ def main() -> int:
         print(f"ERROR: {exc}")
         return 1
 
+    lessons_content = load_lessons(pathlib.Path(args.lessons))
+
     if args.command == "status":
         now = datetime.date.today()
-        print(format_status_response(rows, now))
+        print(
+            format_status_response(
+                rows,
+                now,
+                lessons_content=lessons_content,
+                auth_summary=auth_status_summary(),
+            )
+        )
+        return 0
+
+    if args.command == "auth-check":
+        print(auth_status_summary())
         return 0
 
     if args.command == "escalate":

--- a/scripts/pm_status_reporter.py
+++ b/scripts/pm_status_reporter.py
@@ -367,13 +367,13 @@ def main() -> int:
                 rows,
                 now,
                 lessons_content=lessons_content,
-                auth_summary=auth_status_summary(),
+                auth_summary=auth_status_summary(which=shutil.which),
             )
         )
         return 0
 
     if args.command == "auth-check":
-        print(auth_status_summary())
+        print(auth_status_summary(which=shutil.which))
         return 0
 
     if args.command == "escalate":

--- a/tests/test_pe_sequencer.py
+++ b/tests/test_pe_sequencer.py
@@ -171,3 +171,20 @@ def test_skips_when_merged_branch_does_not_match_active_branch(tmp_path: Path) -
 
     assert decision.action == "skip"
     assert "skipping sequencer advance" in decision.reason
+
+
+def test_halts_when_loop_control_is_paused(tmp_path: Path) -> None:
+    current_pe = tmp_path / "CURRENT_PE.md"
+    plan = tmp_path / "ELIS_2Agent_Automation_Plan_v2_0.md"
+    control = tmp_path / "pm_loop_control.json"
+    _write(current_pe, CURRENT_PE_BODY)
+    _write(plan, PLAN_BODY)
+    control.write_text(
+        '{"paused": true, "reason": "PO pause requested"}\n',
+        encoding="utf-8",
+    )
+
+    decision = pe_sequencer.advance_current_pe(current_pe, control_file=control)
+
+    assert decision.action == "halt_paused"
+    assert "PO pause requested" in decision.reason

--- a/tests/test_pm_discord_command.py
+++ b/tests/test_pm_discord_command.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from scripts.pm_discord_command import (
+    handle_command,
+    load_loop_control,
+    main,
+    write_loop_control,
+)
+
+
+def test_veto_command_requires_label_and_pause() -> None:
+    control = load_loop_control(Path("missing.json"))
+    result = handle_command(
+        command="veto",
+        control=control,
+        actor="PO",
+        pr_number=314,
+    )
+    assert result.label_to_apply == "pm-review-required"
+    assert result.pause_loop is True
+    assert result.control.paused is True
+    assert "PR #314" in result.message
+
+
+def test_resume_command_clears_pause() -> None:
+    control = load_loop_control(Path("missing.json"))
+    result = handle_command(
+        command="resume",
+        control=control,
+        actor="PO",
+    )
+    assert result.pause_loop is False
+    assert result.control.paused is False
+
+
+def test_write_and_reload_control_file(tmp_path: Path) -> None:
+    path = tmp_path / "pm_loop_control.json"
+    control = load_loop_control(path)
+    result = handle_command(
+        command="pause",
+        control=control,
+        actor="PO",
+        reason="Manual pause for review",
+    )
+    write_loop_control(path, result.control)
+    reloaded = load_loop_control(path)
+    assert reloaded.paused is True
+    assert reloaded.reason == "Manual pause for review"
+
+
+def test_main_writes_json_for_pause(tmp_path: Path, capsys) -> None:
+    control_path = tmp_path / "pm_loop_control.json"
+    old_argv = sys.argv
+    sys.argv = [
+        "pm_discord_command.py",
+        "--command",
+        "pause",
+        "--actor",
+        "PO",
+        "--control-file",
+        str(control_path),
+        "--write",
+        "--json",
+    ]
+    try:
+        rc = main()
+    finally:
+        sys.argv = old_argv
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["command"] == "pause"
+    assert payload["control"]["paused"] is True
+    assert json.loads(control_path.read_text(encoding="utf-8"))["paused"] is True

--- a/tests/test_pm_discord_workflows.py
+++ b/tests/test_pm_discord_workflows.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_pm_arbiter_escalate_payload_mentions_po() -> None:
+    workflow = Path(".github/workflows/pm-arbiter.yml").read_text(encoding="utf-8")
+    assert "PM_AGENT_PO_MENTION" in workflow
+    assert '"po_mention": os.environ.get("PM_AGENT_PO_MENTION", "@PO")' in workflow
+    assert "[ESCALATE]" in workflow
+
+
+def test_implementer_runner_notifies_started_event() -> None:
+    workflow = Path(".github/workflows/implementer-runner.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "Notify PM Agent webhook — PE started" in workflow
+    assert '"event": "pe-lifecycle"' in workflow
+    assert '"stage": "started"' in workflow
+
+
+def test_pm_discord_command_workflow_can_apply_veto_and_pause() -> None:
+    workflow = Path(".github/workflows/pm-discord-command.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "pm-review-required" in workflow
+    assert "config/pm_loop_control.json" in workflow
+    assert "workflow_dispatch" in workflow
+    assert "override-pass" in workflow

--- a/tests/test_pm_status_reporter.py
+++ b/tests/test_pm_status_reporter.py
@@ -10,6 +10,8 @@ import pytest
 
 from scripts.pm_status_reporter import (
     _engine_display,
+    auth_status_summary,
+    autonomy_rate_summary,
     build_escalation_message,
     format_status_response,
     handle_escalate,
@@ -102,6 +104,8 @@ def test_status_format_contains_required_fields() -> None:
     assert "Active PEs" in result
     assert "PEs active" in result
     assert "merged this week" in result
+    assert "Autonomy rate:" in result
+    assert "Auth status:" in result
 
 
 def test_status_format_active_count() -> None:
@@ -149,6 +153,44 @@ def test_status_format_no_active_pes() -> None:
     result = format_status_response(rows, datetime.date(2026, 2, 22))
     assert "no active PEs" in result
     assert "0 PEs active" in result
+
+
+def test_autonomy_rate_summary_counts_interventions_by_pe() -> None:
+    _, rows = parse_active_registry(
+        """\
+# Current PE Assignment
+
+## Active PE Registry
+
+| PE-ID | Domain | Implementer-agentId | Validator-agentId | Branch | Status | Last-updated |
+|---|---|---|---|---|---|---|
+| PE-OC-07 | openclaw-infra | prog-impl-codex | prog-val-claude | feature/x | merged | 2026-02-20 |
+| PE-OC-08 | openclaw-infra | prog-impl-claude | prog-val-codex | feature/y | merged | 2026-02-21 |
+"""
+    )
+    lessons = """\
+## LL-20 — Arbitration
+
+## PM Arbitration
+
+PE-OC-08 required escalation.
+"""
+    assert (
+        autonomy_rate_summary(rows, lessons)
+        == "Autonomy rate: 1/2 PEs merged without escalation (50%)"
+    )
+
+
+def test_auth_status_summary_hides_values() -> None:
+    env = {"OPENAI_API_KEY": "sk-live-secret", "CLAUDE_SETUP_TOKEN": "token-value"}
+
+    def fake_which(name: str) -> str | None:
+        return name
+
+    result = auth_status_summary(env, which=fake_which)
+    assert result == "Auth status: codex OK · claude OK"
+    assert "sk-live-secret" not in result
+    assert "token-value" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -257,6 +299,29 @@ def test_main_escalate_command(tmp_path: Path, capsys) -> None:
     out = capsys.readouterr().out
     assert "PE-OC-08" in out
     assert "PM recommendation" in out
+
+
+def test_main_auth_check_command(tmp_path: Path, capsys, monkeypatch) -> None:
+    p = _make_registry_file(tmp_path)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-redacted")
+    monkeypatch.setenv("CLAUDE_SETUP_TOKEN", "setup-redacted")
+    monkeypatch.setattr("scripts.pm_status_reporter.shutil.which", lambda name: name)
+    old_argv = sys.argv
+    sys.argv = [
+        "pm_status_reporter.py",
+        "--command",
+        "auth-check",
+        "--registry",
+        str(p),
+    ]
+    try:
+        rc = main()
+    finally:
+        sys.argv = old_argv
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Auth status: codex OK · claude OK" in out
+    assert "sk-redacted" not in out
 
 
 def test_main_escalate_missing_pe_id_returns_1(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- add the PM Discord control loop for pause, resume, veto, override-pass, status, and auth-check flows
- wire PE lifecycle and ESCALATE_PO webhook payloads into the automation workflows
- add sequencer pause control, PM workspace documentation, and regression tests

## Test plan
- c:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\black.exe --check .
- c:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\ruff.exe check .
- c:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\pytest.exe tests/test_pm_status_reporter.py -q
- c:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\pytest.exe tests/test_pm_discord_command.py -q
- c:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\pytest.exe tests/test_pe_sequencer.py -q
- c:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\pytest.exe tests/test_pm_discord_workflows.py -q
- c:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\pytest.exe tests/test_pm_arbiter.py -q
- c:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\pytest.exe -q
- c:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe scripts/check_agent_scope.py
