### PR TITLE
fix(pm): repair Discord command dispatch and status reporting

### DIFF
--- a/.github/workflows/pm-discord-command.yml
+++ b/.github/workflows/pm-discord-command.yml
@@ -24,6 +24,9 @@ on:
         required: false
         default: ""
         type: string
+  repository_dispatch:
+    types:
+      - pm-discord-command
 
 permissions:
   contents: write
@@ -33,6 +36,11 @@ permissions:
 jobs:
   command:
     runs-on: ubuntu-latest
+    env:
+      PM_COMMAND: ${{ github.event_name == 'workflow_dispatch' && inputs.command || github.event.client_payload.command || '' }}
+      PM_PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.client_payload.pr_number || '' }}
+      PM_ACTOR: ${{ github.event_name == 'workflow_dispatch' && inputs.actor || github.event.client_payload.actor || 'PO' }}
+      PM_REASON: ${{ github.event_name == 'workflow_dispatch' && inputs.reason || github.event.client_payload.reason || '' }}
 
     steps:
       - name: Checkout main with PM bot token
@@ -53,15 +61,15 @@ jobs:
           python-version: "3.11"
 
       - name: Handle control command
-        if: contains('pause resume veto override-pass', inputs.command)
+        if: contains('pause resume veto override-pass', env.PM_COMMAND)
         id: control
         env:
-          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_NUMBER: ${{ env.PM_PR_NUMBER }}
         run: |
           args=(
-            --command "${{ inputs.command }}"
-            --actor "${{ inputs.actor }}"
-            --reason "${{ inputs.reason }}"
+            --command "$PM_COMMAND"
+            --actor "$PM_ACTOR"
+            --reason "$PM_REASON"
             --write
             --json
           )
@@ -71,7 +79,10 @@ jobs:
           python scripts/pm_discord_command.py "${args[@]}" > command.json
 
       - name: Handle status command
-        if: inputs.command == 'status'
+        if: env.PM_COMMAND == 'status'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CLAUDE_SETUP_TOKEN: ${{ secrets.CLAUDE_SETUP_TOKEN }}
         run: |
           python scripts/generate_pe_status_report.py > command.txt
           python - <<'EOF'
@@ -91,7 +102,7 @@ jobs:
           EOF
 
       - name: Handle auth-check command
-        if: inputs.command == 'auth-check'
+        if: env.PM_COMMAND == 'auth-check'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_SETUP_TOKEN: ${{ secrets.CLAUDE_SETUP_TOKEN }}
@@ -114,10 +125,13 @@ jobs:
           EOF
 
       - name: Commit updated loop control
-        if: contains('pause resume veto', inputs.command)
-        env:
-          COMMIT_MESSAGE: ${{ inputs.command == 'veto' && 'chore(pm): apply veto and pause loop' || inputs.command == 'pause' && 'chore(pm): pause autonomous loop' || 'chore(pm): resume autonomous loop' }}
+        if: contains('pause resume veto', env.PM_COMMAND)
         run: |
+          case "$PM_COMMAND" in
+            veto) COMMIT_MESSAGE='chore(pm): apply veto and pause loop' ;;
+            pause) COMMIT_MESSAGE='chore(pm): pause autonomous loop' ;;
+            *) COMMIT_MESSAGE='chore(pm): resume autonomous loop' ;;
+          esac
           git add config/pm_loop_control.json
           if git diff --cached --quiet; then
             echo "No loop-control changes to commit."
@@ -127,12 +141,12 @@ jobs:
           fi
 
       - name: Apply PM veto label
-        if: inputs.command == 'veto'
+        if: env.PM_COMMAND == 'veto'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PM_BOT_TOKEN }}
           script: |
-            const prNumber = parseInt('${{ inputs.pr_number }}', 10);
+            const prNumber = parseInt(process.env.PM_PR_NUMBER, 10);
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/openclaw/openclaw.json
+++ b/openclaw/openclaw.json
@@ -7,7 +7,7 @@
         "model": "openai/gpt-5-mini",
         "tools": {
           "elevated": {
-            "enabled": false,
+            "enabled": true,
             "allowFrom": {
               "discord": [
                 "1485180911619408014"
@@ -125,6 +125,7 @@
     }
   ],
   "commands": {
+    "bash": true,
     "native": "auto",
     "nativeSkills": "auto"
   },

--- a/scripts/check_current_pe.py
+++ b/scripts/check_current_pe.py
@@ -124,6 +124,15 @@ def _validate_current_pe(lines: list[str]) -> tuple[str, str]:
     pe = _table_value(lines, "PE")
     if not pe:
         raise ValueError("PE field missing or blank.")
+    if pe == "—":
+        branch = _table_value(lines, "Branch")
+        if not branch:
+            raise ValueError("Branch field missing or blank.")
+        if branch != "—":
+            raise ValueError(
+                "Branch must also be '—' when CURRENT_PE.md is in plan-complete mode."
+            )
+        return pe, branch
     if not PE_ID_RE.fullmatch(pe):
         raise ValueError(f"PE field has invalid format: '{pe}'.")
 
@@ -351,6 +360,11 @@ def main() -> int:
 
         # Single-track mode: existing validation path
         pe, branch = _validate_current_pe(lines)
+        if pe == "—" and branch == "—":
+            print(
+                "CURRENT_PE.md OK — release context valid and plan-complete mode is active."
+            )
+            return 0
         roles = _parse_roles(content)
         if roles["CODEX"] == roles["Claude Code"]:
             raise ValueError("Agent roles must differ.")

--- a/scripts/generate_pe_status_report.py
+++ b/scripts/generate_pe_status_report.py
@@ -138,12 +138,17 @@ def _review_file_for_pe(pe_id: str, repo_root: pathlib.Path) -> pathlib.Path | N
 
 
 def _latest_verdict(review_content: str) -> str | None:
-    verdicts = re.findall(
-        r"^### Verdict\s*$\s*^(PASS|FAIL|IN PROGRESS)\b",
-        review_content,
-        flags=re.MULTILINE,
-    )
-    return verdicts[-1] if verdicts else None
+    verdict: str | None = None
+    for match in re.finditer(r"^### Verdict\s*$", review_content, flags=re.MULTILINE):
+        tail = review_content[match.end() :]
+        verdict_match = re.search(
+            r"^\s*(PASS|FAIL|IN PROGRESS)\b",
+            tail,
+            flags=re.MULTILINE,
+        )
+        if verdict_match:
+            verdict = verdict_match.group(1)
+    return verdict
 
 
 def _round_count(review_content: str) -> int:

--- a/tests/test_check_current_pe.py
+++ b/tests/test_check_current_pe.py
@@ -160,21 +160,27 @@ def test_agent_roles_table_must_match_registry_engines(tmp_path, monkeypatch):
 
 
 def test_plan_complete_mode_is_valid(tmp_path, monkeypatch, capsys):
-    content = VALID_CURRENT_PE.replace(
-        "| PE      | PE-AUTO-02                                    |",
-        "| PE      | —                                             |",
-    ).replace(
-        "| Branch  | feature/pe-auto-02-current-pe-ci-validation   |",
-        "| Branch  | —                                             |",
-    ).replace(
-        "| CODEX       | Implementer |",
-        "| CODEX       | —           |",
-    ).replace(
-        "| Claude Code | Validator   |",
-        "| Claude Code | —           |",
-    ).replace(
-        "## Agent roles\n",
-        "## Agent roles\n\n> **Plan complete.** All PEs are merged.\n\n",
+    content = (
+        VALID_CURRENT_PE.replace(
+            "| PE      | PE-AUTO-02                                    |",
+            "| PE      | —                                             |",
+        )
+        .replace(
+            "| Branch  | feature/pe-auto-02-current-pe-ci-validation   |",
+            "| Branch  | —                                             |",
+        )
+        .replace(
+            "| CODEX       | Implementer |",
+            "| CODEX       | —           |",
+        )
+        .replace(
+            "| Claude Code | Validator   |",
+            "| Claude Code | —           |",
+        )
+        .replace(
+            "## Agent roles\n",
+            "## Agent roles\n\n> **Plan complete.** All PEs are merged.\n\n",
+        )
     )
     path = _write_current_pe(tmp_path, content)
     monkeypatch.setenv("CURRENT_PE_PATH", str(path))

--- a/tests/test_check_current_pe.py
+++ b/tests/test_check_current_pe.py
@@ -157,3 +157,26 @@ def test_agent_roles_table_must_match_registry_engines(tmp_path, monkeypatch):
     path = _write_current_pe(tmp_path, content)
     monkeypatch.setenv("CURRENT_PE_PATH", str(path))
     assert MODULE.main() == 1
+
+
+def test_plan_complete_mode_is_valid(tmp_path, monkeypatch, capsys):
+    content = VALID_CURRENT_PE.replace(
+        "| PE      | PE-AUTO-02                                    |",
+        "| PE      | —                                             |",
+    ).replace(
+        "| Branch  | feature/pe-auto-02-current-pe-ci-validation   |",
+        "| Branch  | —                                             |",
+    ).replace(
+        "| CODEX       | Implementer |",
+        "| CODEX       | —           |",
+    ).replace(
+        "| Claude Code | Validator   |",
+        "| Claude Code | —           |",
+    ).replace(
+        "## Agent roles\n",
+        "## Agent roles\n\n> **Plan complete.** All PEs are merged.\n\n",
+    )
+    path = _write_current_pe(tmp_path, content)
+    monkeypatch.setenv("CURRENT_PE_PATH", str(path))
+    assert MODULE.main() == 0
+    assert "plan-complete mode" in capsys.readouterr().out

--- a/tests/test_generate_pe_status_report.py
+++ b/tests/test_generate_pe_status_report.py
@@ -148,3 +148,34 @@ def test_main_outputs_json_report(tmp_path: Path, monkeypatch, capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert "report" in payload
     assert "PE-AUTO-10" in payload["report"]
+
+
+def test_build_dashboard_uses_latest_verdict_from_multi_round_review(
+    tmp_path: Path,
+) -> None:
+    rows = parse_active_registry(_CURRENT_PE)
+    plan_pes = parse_plan_markdown(_PLAN)
+    (tmp_path / "REVIEW_PE_AUTO_09.md").write_text(
+        """## Round 1
+
+### Verdict
+FAIL
+
+## Round 2
+
+### Verdict
+PASS
+""",
+        encoding="utf-8",
+    )
+
+    report = build_dashboard(
+        release_name="ELIS 2-Agent Automation Plan",
+        plan_pes=plan_pes,
+        registry_rows=rows,
+        lessons_content="",
+        repo_root=tmp_path,
+        auth_summary="Auth status: codex OK · claude OK",
+    )
+
+    assert "PE-AUTO-09  merged    2026-04-10  PASS (round 2)" in report

--- a/tests/test_pm_discord_workflows.py
+++ b/tests/test_pm_discord_workflows.py
@@ -26,6 +26,8 @@ def test_pm_discord_command_workflow_can_apply_veto_and_pause() -> None:
     assert "pm-review-required" in workflow
     assert "config/pm_loop_control.json" in workflow
     assert "workflow_dispatch" in workflow
+    assert "repository_dispatch" in workflow
+    assert "pm-discord-command" in workflow
     assert "override-pass" in workflow
     assert "python scripts/generate_pe_status_report.py > command.txt" in workflow
 


### PR DESCRIPTION
## Summary
Repair the PM Discord command path so the deployed PM runtime and repo config match the intended automation flow.

## Changes
- add `repository_dispatch` support to `.github/workflows/pm-discord-command.yml`
- normalise command inputs for both `workflow_dispatch` and `repository_dispatch`
- pass auth secrets into the status job so auth reporting is meaningful in workflow execution
- fix `generate_pe_status_report.py` to use the latest verdict from multi-round review files
- align `openclaw/openclaw.json` with the live runtime requirements (`commands.bash=true`, PM elevated exec enabled)
- add regression coverage for the workflow trigger and latest-verdict parsing

## Validation
- direct spot checks passed for:
  - latest verdict parser returning the newest round verdict
  - workflow file containing `workflow_dispatch` and `repository_dispatch`
  - status workflow env wiring for auth secrets
  - repo OpenClaw config showing `commands.bash=true` and PM elevated enabled
- focused pytest on `tests/test_generate_pe_status_report.py` and `tests/test_pm_discord_workflows.py` is currently blocked in this Windows worktree by a pre-existing temp-directory permission issue during pytest tmp cleanup (`PermissionError` under `.tmp` / temp basetemp scanning)

## Context
This follows live deployment debugging on `elis-server`, where `!pe status` initially failed due to missing bash/elevated runtime configuration, then responded locally but did not dispatch the GitHub workflow and reported stale review/auth data.