### PR TITLE
fix(pm): accept GitHub PR opener identity for PM-CHORE auto-approve

### DIFF
--- a/.github/workflows/pm-chore-approve.yml
+++ b/.github/workflows/pm-chore-approve.yml
@@ -91,7 +91,7 @@ jobs:
               reviewerTokenSecret = 'CLAUDE_BOT_TOKEN';
             } else if (author === 'elis-claude-bot') {
               reviewerTokenSecret = 'CODEX_BOT_TOKEN';
-            } else if (author === 'elis-pm-bot') {
+            } else if (author === 'elis-pm-bot' || author === 'rochasamurai') {
               reviewerTokenSecret = 'CODEX_BOT_TOKEN';
             } else {
               core.setOutput('eligible', 'false');


### PR DESCRIPTION
## Fix

PM-CHORE auto-approve keyed reviewer selection to `pr.user.login`, assuming PR authors would be bot accounts. In practice PRs are opened by the authenticated GitHub account `rochasamurai`, so the workflow skipped with `Unsupported PM-CHORE author rochasamurai`.

This PR treats `rochasamurai` the same as `elis-pm-bot` and routes approval through `CODEX_BOT_TOKEN`.