### PR TITLE
fix(ci): move agent runners to elis-server

### DIFF
--- a/.github/workflows/bot-auth-verify.yml
+++ b/.github/workflows/bot-auth-verify.yml
@@ -1,4 +1,4 @@
-# Classification: Orchestration — dispatches agent sessions, manages PRs/labels, or pushes commits; may use bot tokens; not a code-validation gate.
+# Classification: Orchestration — verifies agent CLI auth on the elis-server self-hosted runner; may use bot tokens; not a code-validation gate.
 name: PE-AUTO-01 — Bot Auth Verification
 
 # =============================================================================
@@ -29,7 +29,7 @@ permissions:
 jobs:
   verify-codex-auth:
     name: Verify Codex CLI auth (AC-3a)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, elis-server]
     steps:
       - uses: actions/checkout@v4
 
@@ -51,7 +51,7 @@ jobs:
 
   verify-claude-auth:
     name: Verify Claude Code auth (AC-3b)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, elis-server]
     steps:
       - uses: actions/checkout@v4
 
@@ -74,7 +74,7 @@ jobs:
 
   verify-bot-tokens:
     name: Verify bot token identities (AC-4)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, elis-server]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-gates.yml
+++ b/.github/workflows/ci-gates.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e . --no-deps
           pip install -r requirements.txt
-          pip install black==24.8.0 ruff==0.6.9
+          pip install black==24.8.0 ruff==0.6.9 pytest
 
       - name: Run black
         run: python -m black --check .

--- a/.github/workflows/ci-gates.yml
+++ b/.github/workflows/ci-gates.yml
@@ -32,6 +32,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e . --no-deps
           pip install -r requirements.txt
+          pip install pytest
           pip install black==24.8.0 ruff==0.6.9 pytest
 
       - name: Run black
@@ -57,6 +58,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e . --no-deps
           pip install -r requirements.txt
+          pip install pytest
 
       - name: Run pytest
         run: python -m pytest -q

--- a/.github/workflows/ci-gates.yml
+++ b/.github/workflows/ci-gates.yml
@@ -1,0 +1,62 @@
+# Classification: CI — bounded quality gates only; no agent coding.
+name: ELIS — CI Gates
+
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . --no-deps
+          pip install -r requirements.txt
+          pip install black==24.8.0 ruff==0.6.9
+
+      - name: Run black
+        run: python -m black --check .
+
+      - name: Run ruff
+        run: python -m ruff check .
+
+  tests:
+    name: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . --no-deps
+          pip install -r requirements.txt
+
+      - name: Run pytest
+        run: python -m pytest -q

--- a/.github/workflows/implementer-runner.yml
+++ b/.github/workflows/implementer-runner.yml
@@ -1,4 +1,4 @@
-# Classification: Orchestration — dispatches agent sessions and mutates repo; uses bot tokens; not a code-validation gate.
+# Classification: Orchestration — dispatches agent sessions on the elis-server self-hosted runner; uses bot tokens; not a code-validation gate.
 name: Implementer Agent Runner
 
 on:
@@ -30,7 +30,7 @@ permissions:
 jobs:
   run-implementer:
     name: Run implementer for ${{ inputs.pe_id }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, elis-server]
     timeout-minutes: 240
     env:
       MAX_COMMITS: "20"

--- a/.github/workflows/validator-runner.yml
+++ b/.github/workflows/validator-runner.yml
@@ -1,4 +1,4 @@
-# Classification: Orchestration — dispatches agent sessions and mutates repo; uses bot tokens; not a code-validation gate.
+# Classification: Orchestration — dispatches agent sessions on the elis-server self-hosted runner; may use bot tokens; not a code-validation gate.
 name: Validator Agent Runner
 
 on:
@@ -33,7 +33,7 @@ permissions:
 jobs:
   run-validator:
     name: Run validator for ${{ inputs.pe_id }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, elis-server]
     timeout-minutes: 120
 
     steps:

--- a/ELIS_SLR_AI_Platform_Conceptual_Architecture_v1_8.md
+++ b/ELIS_SLR_AI_Platform_Conceptual_Architecture_v1_8.md
@@ -174,6 +174,9 @@ Implication:
 ## 5.1 Development Domain
 
 Development agents for PM, Programs, and Infrastructure are local-first on `elis-server`.
+Operationally, that means Implementer and Validator sessions run on an `elis-server`
+self-hosted runner or equivalent local execution surface; GitHub-hosted runners are
+reserved for bounded CI gates, not agent coding.
 
 Rationale:
 - persistent repo/worktree context

--- a/scripts/implementer_runner_common.py
+++ b/scripts/implementer_runner_common.py
@@ -353,7 +353,10 @@ def default_cli_command(engine: str, prompt: str) -> list[str]:
         # cleanly after completing the task instead of looping for more input.
         # -q: suppress "Script started" banner  -e: propagate codex exit code.
         return [
-            "script", "-q", "-e", "-c",
+            "script",
+            "-q",
+            "-e",
+            "-c",
             'codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox "$CODEX_PROMPT"',
             "/dev/null",
         ]


### PR DESCRIPTION
## Summary\n- Move implementer, validator, and auth-verify workflows onto the elis-server self-hosted runner\n- Keep GitHub Actions limited to CI-only gates\n- Clarify the architecture note so agent coding runs on elis-server\n\n## Validation\n- YAML parse check for changed workflows\n- python scripts/check_agent_scope.py\n