### PR TITLE
feat(pe-infra-slr-06): workflow state machine formalisation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,50 @@ Gate 1 and Gate 2 are enforced by CI automation after PE-INFRA-04.
 - Agent role rotation
 - Any CI job that exits with the `pm-escalation` flag
 
+### 2.10.1 Workflow state machine contract
+
+Every PE moves through the canonical workflow state machine. The human-readable
+contract is `docs/workflow/PE_STATE_MACHINE.md`; the machine-readable mirror is
+`elis/workflow_state_machine.py`.
+
+Canonical states:
+
+| State | Meaning |
+|-------|---------|
+| `planning` | PE is defined, but no implementer work has started yet. |
+| `implementing` | Implementer is actively coding on `elis-server`. |
+| `gate-1-pending` | Implementer has finished; `HANDOFF.md` and Status Packet evidence are complete; ready for validator assignment. |
+| `validating` | Validator is actively reviewing on `elis-server`. |
+| `gate-2-pending` | Validator has posted evidence and verdict; awaiting formal approval or merge automation. |
+| `merged` | PR merged; PE complete. |
+| `blocked` | A guard failed, a runner is unavailable, or an external dependency prevents progress. |
+| `superseded` | PE was replaced by a newer governance decision. |
+
+Allowed transitions:
+
+```text
+planning -> implementing
+implementing -> gate-1-pending
+gate-1-pending -> validating
+gate-1-pending -> blocked
+validating -> gate-2-pending
+gate-2-pending -> merged
+gate-2-pending -> blocked
+any active state -> superseded
+```
+
+Transition guards:
+
+- Implementer completion (`implementing -> gate-1-pending`) requires `HANDOFF.md` is present and complete, Status Packet sections are complete, handoff artefacts are committed on the PE branch, and the runner observes a matching PE/branch pair.
+- Validator authorisation (`gate-1-pending -> validating`) requires explicit PM authorisation is recorded, validator assignment evidence is present, and the PE remains active in `CURRENT_PE.md`.
+- Review completion (`validating -> gate-2-pending`) requires REVIEW evidence is present, a formal verdict is recorded in the REVIEW file, and CI gates are not broken by validator artefacts.
+- Merge approval (`gate-2-pending -> merged`) requires CI is green, required review approval is satisfied, and no `pm-review-required` veto label is present.
+
+GitHub Actions may observe state, validate guards, post audit evidence, and
+dispatch bounded workflow steps. GitHub Actions must not perform agent coding
+unless the current state explicitly permits that action and the active
+execution-surface policy allows it.
+
 ### 2.11 Language standard
 - All repository-facing content must use **UK English** by default.
 - This applies to:

--- a/ELIS_MultiAgent_Implementation_Plan_v1_9.md
+++ b/ELIS_MultiAgent_Implementation_Plan_v1_9.md
@@ -44,6 +44,27 @@ Before PE work begins, the following must be true:
 - Review artefacts resolve via `docs/reviews/README.md` and `docs/reviews/archive/`.
 - No secret-bearing files are present in the worktree.
 
+### 2.1 Workflow state-machine reference
+
+All PEs in this plan use the canonical workflow states documented in
+`docs/workflow/PE_STATE_MACHINE.md` and mirrored in
+`elis/workflow_state_machine.py`:
+
+`planning`, `implementing`, `gate-1-pending`, `validating`,
+`gate-2-pending`, `merged`, `blocked`, `superseded`.
+
+Future PE handoffs, reviews, registry updates, and GitHub Actions orchestration
+must use these exact state labels. The governing transition guards are:
+
+- Implementer completion: `implementing -> gate-1-pending`
+- Validator authorisation: `gate-1-pending -> validating`
+- Review completion: `validating -> gate-2-pending`
+- Merge approval: `gate-2-pending -> merged`
+
+GitHub Actions may observe guards and dispatch bounded workflow steps; it must
+not perform agent coding unless the current state and execution-surface policy
+permit it.
+
 ---
 
 ## 3. PE Implementation Series

--- a/ELIS_SLR_AI_Platform_Conceptual_Architecture_v1_9.md
+++ b/ELIS_SLR_AI_Platform_Conceptual_Architecture_v1_9.md
@@ -167,6 +167,15 @@ The development workflow is a **state machine**. Each PE must occupy exactly one
 state at a time, and every automation step must be a valid transition between
 states.
 
+Contract sources:
+
+- Human-readable state and guard contract: `docs/workflow/PE_STATE_MACHINE.md`
+- Machine-readable state and guard mirror: `elis/workflow_state_machine.py`
+- Agent operating guidance: `AGENTS.md`
+
+These sources must use the same canonical labels and guard names. If a state or
+guard changes, update all three in the same PE and add targeted validation.
+
 ### Canonical states
 
 | State | Meaning |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,85 +1,225 @@
-# HANDOFF — PE-RUNNER-01
+# HANDOFF — PE-INFRA-SLR-06
 
-**PE:** PE-RUNNER-01  
-**Branch:** fix/pe-runner-01-codex-headless-invocation  
-**Implementer:** Claude Code (infra-impl-claude)  
+**PE:** PE-INFRA-SLR-06  
+**Branch:** feature/pe-infra-slr-06-workflow-state-machine-formalisation  
+**Implementer:** CODEX (`infra-impl-a`)  
 **Date:** 2026-04-24  
-**Base branch:** main
+**Base branch:** main  
+**Implementation commit:** `244787cd2d74a8e907de9c3ffb6f74faadba2725`
 
 ---
 
 ## Summary
 
-Fixes the Codex CLI headless invocation in `scripts/implementer_runner_common.py` so that the Implementer Agent Runner can run Codex non-interactively on a GitHub Actions runner.
+PE-INFRA-SLR-06 formalises the v1.9 PE workflow state machine as a first-class governance contract.
 
-The `codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox <prompt>` invocation (Codex CLI v0.118.0) caused the runner to exit with code 1 and the message `Reading additional input from stdin...`. After completing its initial task, Codex entered an interactive wait-for-continuation loop; with `stdin=subprocess.DEVNULL` providing immediate EOF, Codex reported the error and exited.
+The implementation adds:
 
-The fix removes the prompt from the command-line arguments for Codex and delivers it via stdin instead. When stdin closes (subprocess finishes piping `input=prompt`), Codex processes the task and exits cleanly.
+- a human-readable PE state-machine contract at `docs/workflow/PE_STATE_MACHINE.md`;
+- a machine-readable mirror at `elis/workflow_state_machine.py`;
+- ADR-013 to record the structural workflow decision;
+- AGENTS.md, architecture, and implementation-plan references that use the same canonical state labels and transition guard names;
+- targeted tests proving the state labels and guard language are discoverable and consistent across code and governing docs;
+- validator/current-PE checks reusing the shared state contract instead of duplicating status strings.
 
 ---
 
-## Files changed
+## Files Changed
 
 | File | Change |
 |------|--------|
-| `scripts/implementer_runner_common.py` | `default_cli_command()`: remove `exec` subcommand and positional prompt from Codex args. `run_cli()`: add `_codex_uses_stdin()` helper; pipe prompt via `input=` for Codex default path. |
+| `AGENTS.md` | Adds the canonical workflow state machine, allowed transitions, transition guards, and GitHub Actions boundary. |
+| `ELIS_MultiAgent_Implementation_Plan_v1_9.md` | Adds the v1.9 workflow state-machine reference for future PE workflow language. |
+| `ELIS_SLR_AI_Platform_Conceptual_Architecture_v1_9.md` | Links architecture state-machine authority to the human-readable and machine-readable contracts. |
+| `docs/decisions/ADR-013-workflow-state-machine-contract.md` | Records the state-machine contract decision. |
+| `docs/decisions/README.md` | Adds ADR-013 to the ADR index. |
+| `docs/workflow/PE_STATE_MACHINE.md` | New human-readable canonical PE lifecycle state and guard contract. |
+| `elis/workflow_state_machine.py` | New machine-readable state labels, transitions, guards, and helper functions. |
+| `scripts/check_current_pe.py` | Reuses the shared state-machine constants for active and registry status validation. |
+| `scripts/check_role_registration.py` | Reuses the shared state-machine constants and resolves imports from the active checkout. |
+| `scripts/dispatch_validator_runner.py` | Format-only Black fix required by the full pinned Black gate. |
+| `tests/test_workflow_state_machine.py` | New targeted tests for canonical states, transitions, guard lookup, validator reuse, and governing-doc consistency. |
 
 ---
 
-## Design decisions
+## Design Decisions
 
-- **`exec` subcommand removed**: `codex exec` in v0.118.0 does not exit cleanly in headless mode when stdin is closed. The base `codex` command reads the task from stdin and exits when stdin closes — standard Unix behaviour.
-- **`--skip-git-repo-check` removed**: was only used with `exec`. The base `codex` command handles git repos natively; the runner runs in a checked-out repo so no skip is needed.
-- **`AGENT_RUNNER_TEMPLATE` path unchanged**: when `AGENT_RUNNER_TEMPLATE` is set, `cli_command()` renders the template with `{prompt}` and `{prompt_file}` — the stdin path is not activated (`_codex_uses_stdin()` returns `False`).
-- **Claude path unchanged**: `claude -p <prompt> --dangerously-skip-permissions` is unaffected.
+- **First-class contract:** `docs/workflow/PE_STATE_MACHINE.md` is the human-readable source for agents and PM workflow use; `elis/workflow_state_machine.py` is the machine-readable mirror for tests and scripts.
+- **Shared status constants:** `scripts/check_current_pe.py` and `scripts/check_role_registration.py` now consume the shared state-machine constants so future state changes are not duplicated in validator scripts.
+- **ADR required:** This PE changes cross-cutting PE, agent, and CI governance semantics, so ADR-013 records the decision per `AGENTS.md` ADR rules.
+- **GitHub Actions boundary:** The docs state that GitHub Actions may observe guards and dispatch bounded workflow steps, but must not perform agent coding unless the current state and execution-surface policy permit it.
+- **Format-only gate fix:** `scripts/dispatch_validator_runner.py` was formatted because the full pinned Black gate failed on that existing import layout. No logic changed in that file.
 
 ---
 
-## Acceptance criteria
+## Acceptance Criteria
 
 | AC | Criterion | Result |
 |----|-----------|--------|
-| AC-1 | `run_codex_agent.py` executes without `Reading additional input from stdin` error | PASS — fix removes the positional-prompt invocation that triggered this |
-| AC-2 | Codex receives the full prompt and begins autonomous work | PASS — prompt delivered via stdin; Codex processes it before stdin closes |
-| AC-3 | `implementer-runner.yml` `Run CODEX implementer` step exits without code 1 | PENDING CI — requires live runner run after merge |
-| AC-4 | Claude invocation path unchanged | PASS — `claude` path in `default_cli_command()` unmodified; `_codex_uses_stdin()` returns `False` for claude |
+| AC-1 | The canonical workflow states (`planning`, `implementing`, `gate-1-pending`, `validating`, `gate-2-pending`, `merged`, `blocked`, `superseded`) are documented consistently across architecture and workflow guidance. | PASS — architecture, AGENTS.md, plan v1.9, `docs/workflow/PE_STATE_MACHINE.md`, and tests use the same labels. |
+| AC-2 | Transition guards for implementer completion, validator authorisation, review completion, and merge approval are stated explicitly in the governing docs. | PASS — guard names and required evidence are documented in AGENTS.md and `docs/workflow/PE_STATE_MACHINE.md`, and mirrored in `elis/workflow_state_machine.py`. |
+| AC-3 | GitHub Actions are restricted to observing guards and dispatching bounded workflow steps; they do not perform agent coding unless the state permits it. | PASS — AGENTS.md, the architecture, the plan, and the state-machine contract all state the boundary. |
+| AC-4 | The state-machine language is reflected in the implementation-plan workflow references so future PEs follow the same terms. | PASS — plan v1.9 now has a dedicated workflow state-machine reference section. |
+| AC-5 | A targeted validation check or test proves the state labels/guards are discoverable and consistent. | PASS — `tests/test_workflow_state_machine.py` validates code constants, transitions, guard lookup, script reuse, and governing-doc references. |
 
 ---
 
-## Quality gates
+## Validation Commands
 
+### Tool Versions
+
+```powershell
+C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe -m black --version
+python -m black, 24.8.0 (compiled: no)
+Python (CPython) 3.14.0
+
+C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe -m ruff --version
+ruff 0.6.9
 ```
-python -m black --check scripts/implementer_runner_common.py
-All done! ✨ 🍰 ✨  1 file would be left unchanged.
 
-python -m ruff check scripts/implementer_runner_common.py
-All checks passed!
+### Current PE Validation
 
-python -m pytest tests/ -q
-2 failed, 1014 passed, 17 warnings in 9.99s
-Pre-existing failures: test_verify_claude_auth.py (2 tests) — confirmed present on main before this change.
+```powershell
+C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe scripts/check_current_pe.py
+CURRENT_PE.md OK — release context, roles, registry, and alternation valid.
 ```
 
----
+```powershell
+C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe scripts/check_role_registration.py
+CURRENT_PE.md OK — role registration valid.
+```
 
-## Validation commands for Validator
+```powershell
+C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe scripts/check_agent_scope.py
+Agent scope clean — no secret-pattern files detected in worktree.
+```
 
-```bash
-# 1. Confirm only one file changed
+### Scope Evidence
+
+```powershell
 git diff --name-status origin/main..HEAD
-# Expected: M  scripts/implementer_runner_common.py
-
-# 2. Confirm default_cli_command for codex no longer includes exec or positional prompt
-grep -A 6 "def default_cli_command" scripts/implementer_runner_common.py
-
-# 3. Confirm run_cli pipes prompt via stdin for codex
-grep -A 5 "def _codex_uses_stdin" scripts/implementer_runner_common.py
-
-# 4. Confirm test_verify_claude_auth failures are pre-existing on main
-git stash && python -m pytest tests/test_verify_claude_auth.py -q --tb=no && git stash pop
-# Expected: same 2 failures without this change
-
-# 5. Confirm Claude path unchanged
-grep '"claude"' scripts/implementer_runner_common.py
-# Expected: return ["claude", "-p", prompt, "--dangerously-skip-permissions"]
+M	AGENTS.md
+M	ELIS_MultiAgent_Implementation_Plan_v1_9.md
+M	ELIS_SLR_AI_Platform_Conceptual_Architecture_v1_9.md
+A	docs/decisions/ADR-013-workflow-state-machine-contract.md
+M	docs/decisions/README.md
+A	docs/workflow/PE_STATE_MACHINE.md
+A	elis/workflow_state_machine.py
+M	scripts/check_current_pe.py
+M	scripts/check_role_registration.py
+M	scripts/dispatch_validator_runner.py
+A	tests/test_workflow_state_machine.py
 ```
+
+```powershell
+git diff --stat origin/main..HEAD
+ AGENTS.md                                          |  44 +++++++++
+ ELIS_MultiAgent_Implementation_Plan_v1_9.md        |  21 +++++
+ ...SLR_AI_Platform_Conceptual_Architecture_v1_9.md |   9 ++
+ .../ADR-013-workflow-state-machine-contract.md     |  58 ++++++++++++
+ docs/decisions/README.md                           |   1 +
+ docs/workflow/PE_STATE_MACHINE.md                  |  76 +++++++++++++++
+ elis/workflow_state_machine.py                     | 104 +++++++++++++++++++++
+ scripts/check_current_pe.py                        |  20 +---
+ scripts/check_role_registration.py                 |  23 +++--
+ scripts/dispatch_validator_runner.py               |   4 +-
+ tests/test_workflow_state_machine.py               | 102 ++++++++++++++++++++
+ 11 files changed, 432 insertions(+), 30 deletions(-)
+```
+
+### Formatting
+
+```powershell
+$env:Path='C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts;' + $env:Path; $env:BLACK_CACHE_DIR='C:\Users\carlo\ELIS-SLR-Agent\.tmp\black-cache-pe-infra-slr-06'; python -m black --check --include "\.py$" elis/ tests/ scripts/
+All done! \u2728 \U0001f370 \u2728
+180 files would be left unchanged.
+```
+
+### Ruff
+
+```powershell
+$env:Path='C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts;' + $env:Path; python -m ruff check .
+All checks passed!
+```
+
+### Targeted PE Tests
+
+```powershell
+C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe -m pytest tests/test_workflow_state_machine.py tests/test_check_current_pe.py tests/test_check_role_registration.py --basetemp=C:\Users\carlo\ELIS-SLR-Agent\.tmp\pe-infra-slr-06-targeted -q --tb=short
+.....................                                                    [100%]
+```
+
+### Full Test Suite
+
+```powershell
+C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe -m pytest tests/ --basetemp=C:\Users\carlo\ELIS-SLR-Agent\.tmp\pe-infra-slr-06-full --tb=no -q
+........................................................................ [  7%]
+........................................................................ [ 14%]
+........................................................................ [ 21%]
+........................................................................ [ 28%]
+........................................................................ [ 35%]
+........................................................................ [ 42%]
+........................................................................ [ 49%]
+........................................................................ [ 56%]
+........................................................................ [ 63%]
+........................................................................ [ 70%]
+........................................................................ [ 77%]
+........................................................................ [ 84%]
+........................................................................ [ 91%]
+...................................................................FF... [ 98%]
+..............                                                           [100%]
+============================== warnings summary ===============================
+tests/test_elis_cli.py::test_screen_emits_manifest
+tests/test_elis_cli.py::test_screen_dry_run_does_not_emit_manifest
+tests/test_pipeline_merge.py::test_merge_output_validates_and_is_screen_compatible
+tests/test_pipeline_screen.py::TestScreenMain::test_dry_run
+tests/test_pipeline_screen.py::TestScreenMain::test_write_output
+  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-infra-slr-06\elis\pipeline\screen.py:276: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+    else g.get("year_to", dt.datetime.utcnow().year)
+
+tests/test_elis_cli.py::test_screen_emits_manifest
+tests/test_elis_cli.py::test_screen_dry_run_does_not_emit_manifest
+tests/test_pipeline_merge.py::test_merge_output_validates_and_is_screen_compatible
+tests/test_pipeline_screen.py::TestScreenMain::test_dry_run
+tests/test_pipeline_screen.py::TestScreenMain::test_write_output
+  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-infra-slr-06\elis\pipeline\screen.py:30: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+    return dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+tests/test_pipeline_search.py::TestBuildRunInputs::test_defaults
+tests/test_pipeline_search.py::TestSearchMain::test_dry_run_with_minimal_config
+tests/test_pipeline_search.py::TestSearchMain::test_dry_run_topic_with_name_not_id
+  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-infra-slr-06\elis\pipeline\search.py:154: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+    year_to = int(g.get("year_to", dt.datetime.utcnow().year))
+
+tests/test_pipeline_search.py::TestSearchMain::test_dry_run_with_minimal_config
+tests/test_pipeline_search.py::TestSearchMain::test_dry_run_topic_with_name_not_id
+  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-infra-slr-06\elis\pipeline\search.py:405: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+    y1 = int(config.get("global", {}).get("year_to", dt.datetime.utcnow().year))
+
+tests/test_pipeline_search.py::TestSearchMain::test_dry_run_with_minimal_config
+tests/test_pipeline_search.py::TestSearchMain::test_dry_run_topic_with_name_not_id
+  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-infra-slr-06\elis\pipeline\search.py:43: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+    return dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ===========================
+FAILED tests/test_verify_claude_auth.py::test_fails_when_credentials_file_missing
+FAILED tests/test_verify_claude_auth.py::test_fails_when_credentials_file_lacks_oauth_key
+```
+
+The full-suite failures are not in PE-INFRA-SLR-06 scope. This branch does not modify `tests/test_verify_claude_auth.py` or Claude-auth verification logic:
+
+```powershell
+git diff --name-status -- tests/test_verify_claude_auth.py scripts/verify_claude_auth.py elis/verify_claude_auth.py
+```
+
+(no output)
+
+---
+
+## Notes for Validator
+
+- Validate AC-1 through AC-5 against `ELIS_MultiAgent_Implementation_Plan_v1_9.md` verbatim.
+- Start with `tests/test_workflow_state_machine.py`; it is the PE-specific validation surface.
+- `scripts/dispatch_validator_runner.py` is intentionally format-only to satisfy the full pinned Black gate.
+- The two full-suite failures are unrelated to this PE and should be treated separately from the state-machine work unless CI shows a different result.

--- a/docs/decisions/ADR-013-workflow-state-machine-contract.md
+++ b/docs/decisions/ADR-013-workflow-state-machine-contract.md
@@ -1,0 +1,58 @@
+# ADR-013: Workflow State Machine Contract
+
+**Status:** Accepted
+**Date:** 2026-04-24
+**Deciders:** [PM, CODEX]
+
+## Context
+
+The v1.9 architecture formalises PE lifecycle states, but the same labels and
+guards also need to be discoverable by scripts, validators, and future PEs.
+Without one reusable contract, workflow state can drift between architecture,
+AGENTS.md, implementation plans, and CI/orchestration helpers.
+
+## Decision
+
+PE lifecycle state is governed by a first-class state-machine contract:
+
+- `docs/workflow/PE_STATE_MACHINE.md` is the human-readable state and guard
+  reference.
+- `elis/workflow_state_machine.py` is the machine-readable mirror used by tests
+  and validation scripts.
+- `AGENTS.md`, the v1.9 architecture, and the active implementation plan must
+  use the same canonical labels and guard names.
+
+GitHub Actions may observe the state machine, validate guards, and dispatch
+bounded workflow steps. It must not perform agent coding unless the current
+state and execution-surface policy permit it.
+
+## Consequences
+
+### Positive
+
+- State labels are no longer scattered as undocumented string sets.
+- Transition guards are testable and visible to both agents.
+- Future runner and archive PEs can depend on one lifecycle vocabulary.
+
+### Negative / trade-offs
+
+- Documentation and code must be kept aligned when the state machine changes.
+- State-machine changes now require both documentation and targeted test updates.
+
+## Alternatives considered
+
+### Keep state labels only in `CURRENT_PE.md`
+
+Rejected because `CURRENT_PE.md` is assignment state, not a reusable governance
+contract. It is edited frequently and is not the right place to explain guards.
+
+### Keep state labels only in architecture prose
+
+Rejected because prose alone is not easy for scripts and tests to consume.
+
+## Evidence / references
+
+- `ELIS_SLR_AI_Platform_Conceptual_Architecture_v1_9.md`
+- `ELIS_MultiAgent_Implementation_Plan_v1_9.md`
+- `docs/workflow/PE_STATE_MACHINE.md`
+- `elis/workflow_state_machine.py`

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -116,6 +116,7 @@ An ADR is **not** required for:
 | [ADR-010](ADR-010-gate2-review-trigger.md) | Gate 2 triggered by mapped-bot approval review | Accepted | 2026-04-20 |
 | [ADR-011](ADR-011-github-actions-authority-for-portable-gates.md) | GitHub Actions authority for portable gates | Accepted | 2026-04-22 |
 | [ADR-012](ADR-012-workflow-classification.md) | Workflow classification — CI vs Orchestration | Accepted | 2026-04-22 |
+| [ADR-013](ADR-013-workflow-state-machine-contract.md) | Workflow state machine contract | Accepted | 2026-04-24 |
 
 ---
 

--- a/docs/workflow/PE_STATE_MACHINE.md
+++ b/docs/workflow/PE_STATE_MACHINE.md
@@ -1,0 +1,76 @@
+# PE Workflow State Machine
+
+This document is the human-readable governance contract for PE lifecycle state.
+The machine-readable mirror lives in `elis/workflow_state_machine.py`.
+
+## Canonical States
+
+| State | Meaning |
+|-------|---------|
+| `planning` | PE is defined, but no implementer work has started yet. |
+| `implementing` | Implementer is actively coding on `elis-server`. |
+| `gate-1-pending` | Implementer has finished; `HANDOFF.md` and Status Packet evidence are complete; ready for validator assignment. |
+| `validating` | Validator is actively reviewing on `elis-server`. |
+| `gate-2-pending` | Validator has posted evidence and verdict; awaiting formal approval or merge automation. |
+| `merged` | PR merged; PE complete. |
+| `blocked` | A guard failed, a runner is unavailable, or an external dependency prevents progress. |
+| `superseded` | PE was replaced by a newer governance decision. |
+
+## Allowed Transitions
+
+```text
+planning -> implementing
+implementing -> gate-1-pending
+gate-1-pending -> validating
+gate-1-pending -> blocked
+validating -> gate-2-pending
+gate-2-pending -> merged
+gate-2-pending -> blocked
+any active state -> superseded
+```
+
+## Transition Guards
+
+### Implementer completion
+
+The `implementing -> gate-1-pending` transition requires:
+
+- HANDOFF.md is present and complete.
+- Status Packet sections are complete.
+- Handoff artefacts are committed on the PE branch.
+- The runner observes a matching PE and branch pair.
+
+### Validator authorisation
+
+The `gate-1-pending -> validating` transition requires:
+
+- Explicit PM authorisation is recorded.
+- Validator assignment evidence is present.
+- The PE remains active in `CURRENT_PE.md`.
+
+### Review completion
+
+The `validating -> gate-2-pending` transition requires:
+
+- REVIEW evidence is present.
+- A formal verdict is recorded in the REVIEW file.
+- CI gates are not broken by validator artefacts.
+
+### Merge approval
+
+The `gate-2-pending -> merged` transition requires:
+
+- CI is green.
+- Required review approval is satisfied.
+- No `pm-review-required` veto label is present.
+
+## GitHub Actions Boundary
+
+GitHub Actions may observe state, validate guards, post audit evidence, and
+dispatch bounded workflow steps. It must not perform agent coding unless the
+current state explicitly permits that action and the active execution-surface
+policy allows it.
+
+Portable CI gates remain authoritative for formatting, linting, validation, and
+tests. Agent implementation and validation sessions remain governed by
+`CURRENT_PE.md`, `AGENTS.md`, and this state-machine contract.

--- a/elis/workflow_state_machine.py
+++ b/elis/workflow_state_machine.py
@@ -1,0 +1,104 @@
+"""Canonical PE workflow state machine contract.
+
+This module keeps the state labels and guarded transitions discoverable by
+scripts, tests, and documentation checks. Human-facing governance remains in
+AGENTS.md and the architecture docs; this module is the machine-readable mirror.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+CANONICAL_STATES: tuple[str, ...] = (
+    "planning",
+    "implementing",
+    "gate-1-pending",
+    "validating",
+    "gate-2-pending",
+    "merged",
+    "blocked",
+    "superseded",
+)
+
+ACTIVE_STATES: tuple[str, ...] = (
+    "planning",
+    "implementing",
+    "gate-1-pending",
+    "validating",
+    "gate-2-pending",
+    "blocked",
+)
+
+TERMINAL_STATES: tuple[str, ...] = ("merged", "superseded")
+
+_DIRECT_TRANSITIONS: tuple[tuple[str, str], ...] = (
+    ("planning", "implementing"),
+    ("implementing", "gate-1-pending"),
+    ("gate-1-pending", "validating"),
+    ("gate-1-pending", "blocked"),
+    ("validating", "gate-2-pending"),
+    ("gate-2-pending", "merged"),
+    ("gate-2-pending", "blocked"),
+)
+
+ALLOWED_TRANSITIONS: tuple[tuple[str, str], ...] = (
+    *_DIRECT_TRANSITIONS,
+    *tuple((state, "superseded") for state in ACTIVE_STATES),
+)
+
+IMPLEMENTER_COMPLETION_GUARDS: tuple[str, ...] = (
+    "HANDOFF.md is present and complete",
+    "Status Packet sections are complete",
+    "Handoff artefacts are committed on the PE branch",
+    "The runner observes a matching PE and branch pair",
+)
+
+VALIDATOR_AUTHORISATION_GUARDS: tuple[str, ...] = (
+    "Explicit PM authorisation is recorded",
+    "Validator assignment evidence is present",
+    "The PE remains active in CURRENT_PE.md",
+)
+
+REVIEW_COMPLETION_GUARDS: tuple[str, ...] = (
+    "REVIEW evidence is present",
+    "A formal verdict is recorded in the REVIEW file",
+    "CI gates are not broken by validator artefacts",
+)
+
+MERGE_APPROVAL_GUARDS: tuple[str, ...] = (
+    "CI is green",
+    "Required review approval is satisfied",
+    "No pm-review-required veto label is present",
+)
+
+TRANSITION_GUARDS: dict[tuple[str, str], tuple[str, ...]] = {
+    ("implementing", "gate-1-pending"): IMPLEMENTER_COMPLETION_GUARDS,
+    ("gate-1-pending", "validating"): VALIDATOR_AUTHORISATION_GUARDS,
+    ("validating", "gate-2-pending"): REVIEW_COMPLETION_GUARDS,
+    ("gate-2-pending", "merged"): MERGE_APPROVAL_GUARDS,
+}
+
+
+def is_canonical_state(state: str) -> bool:
+    """Return whether *state* is one of the governed PE state labels."""
+
+    return state in CANONICAL_STATES
+
+
+def can_transition(source: str, target: str) -> bool:
+    """Return whether the state machine permits a source -> target move."""
+
+    return (source, target) in ALLOWED_TRANSITIONS
+
+
+def guards_for(source: str, target: str) -> tuple[str, ...]:
+    """Return the guard evidence required for a source -> target move."""
+
+    return TRANSITION_GUARDS.get((source, target), ())
+
+
+def undocumented_states(states: Iterable[str]) -> tuple[str, ...]:
+    """Return canonical states missing from a discovered state collection."""
+
+    discovered = set(states)
+    return tuple(state for state in CANONICAL_STATES if state not in discovered)

--- a/scripts/check_current_pe.py
+++ b/scripts/check_current_pe.py
@@ -13,24 +13,10 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 engine_from_agent_id = import_module("elis.agent_id").engine_from_agent_id
+workflow_state_machine = import_module("elis.workflow_state_machine")
 
-VALID_ACTIVE_STATUSES = {
-    "planning",
-    "implementing",
-    "gate-1-pending",
-    "validating",
-    "gate-2-pending",
-    "blocked",
-}
-VALID_REGISTRY_STATUSES = {
-    "planning",
-    "implementing",
-    "gate-1-pending",
-    "validating",
-    "gate-2-pending",
-    "merged",
-    "blocked",
-}
+VALID_ACTIVE_STATUSES = set(workflow_state_machine.ACTIVE_STATES)
+VALID_REGISTRY_STATUSES = set(workflow_state_machine.CANONICAL_STATES)
 PE_ID_RE = re.compile(r"^PE(?:-[A-Z0-9]+)+-[0-9]+$")
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 BRANCH_RE = re.compile(r"^(feature/pe-[a-z0-9-]+|chore/[a-z0-9-]+)$")

--- a/scripts/check_role_registration.py
+++ b/scripts/check_role_registration.py
@@ -1,18 +1,17 @@
 import os
 import re
+import sys
+from importlib import import_module
+from pathlib import Path
 
-from elis.agent_id import engine_from_agent_id
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
-VALID_STATUSES = {
-    "planning",
-    "implementing",
-    "gate-1-pending",
-    "validating",
-    "gate-2-pending",
-    "merged",
-    "blocked",
-    "superseded",
-}
+engine_from_agent_id = import_module("elis.agent_id").engine_from_agent_id
+workflow_state_machine = import_module("elis.workflow_state_machine")
+
+VALID_STATUSES = set(workflow_state_machine.CANONICAL_STATES)
 VALID_ROLES = {"Implementer", "Validator"}
 ENGINE_TO_AGENT = {
     "codex": "CODEX",

--- a/scripts/dispatch_validator_runner.py
+++ b/scripts/dispatch_validator_runner.py
@@ -23,7 +23,9 @@ import sys
 from pathlib import Path
 
 from scripts.check_handoff import REQUIRED_SECTIONS as HANDOFF_REQUIRED_SECTIONS
-from scripts.check_status_packet import REQUIRED_SECTIONS as STATUS_PACKET_REQUIRED_SECTIONS
+from scripts.check_status_packet import (
+    REQUIRED_SECTIONS as STATUS_PACKET_REQUIRED_SECTIONS,
+)
 from scripts.implementer_runner_common import (
     CurrentPEContext,
     RunnerError,

--- a/tests/test_workflow_state_machine.py
+++ b/tests/test_workflow_state_machine.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from elis.workflow_state_machine import (
+    ACTIVE_STATES,
+    ALLOWED_TRANSITIONS,
+    CANONICAL_STATES,
+    MERGE_APPROVAL_GUARDS,
+    REVIEW_COMPLETION_GUARDS,
+    TRANSITION_GUARDS,
+    VALIDATOR_AUTHORISATION_GUARDS,
+    can_transition,
+    guards_for,
+)
+from scripts import check_current_pe, check_role_registration
+
+
+def _read(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def test_canonical_states_are_complete_and_ordered() -> None:
+    assert CANONICAL_STATES == (
+        "planning",
+        "implementing",
+        "gate-1-pending",
+        "validating",
+        "gate-2-pending",
+        "merged",
+        "blocked",
+        "superseded",
+    )
+    assert ACTIVE_STATES == (
+        "planning",
+        "implementing",
+        "gate-1-pending",
+        "validating",
+        "gate-2-pending",
+        "blocked",
+    )
+
+
+def test_allowed_transitions_and_guard_lookup_are_discoverable() -> None:
+    expected = {
+        ("planning", "implementing"),
+        ("implementing", "gate-1-pending"),
+        ("gate-1-pending", "validating"),
+        ("gate-1-pending", "blocked"),
+        ("validating", "gate-2-pending"),
+        ("gate-2-pending", "merged"),
+        ("gate-2-pending", "blocked"),
+    }
+    assert expected.issubset(set(ALLOWED_TRANSITIONS))
+    assert all(can_transition(state, "superseded") for state in ACTIVE_STATES)
+    assert not can_transition("planning", "merged")
+    assert guards_for("gate-1-pending", "validating") == (
+        "Explicit PM authorisation is recorded",
+        "Validator assignment evidence is present",
+        "The PE remains active in CURRENT_PE.md",
+    )
+
+
+def test_existing_status_validators_reuse_the_state_machine_contract() -> None:
+    assert check_current_pe.VALID_REGISTRY_STATUSES == set(CANONICAL_STATES)
+    assert check_current_pe.VALID_ACTIVE_STATUSES == set(ACTIVE_STATES)
+    assert check_role_registration.VALID_STATUSES == set(CANONICAL_STATES)
+
+
+def test_governing_docs_expose_states_and_guard_language() -> None:
+    docs = {
+        "architecture": _read("ELIS_SLR_AI_Platform_Conceptual_Architecture_v1_9.md"),
+        "agents": _read("AGENTS.md"),
+        "state_machine": _read("docs/workflow/PE_STATE_MACHINE.md"),
+        "plan": _read("ELIS_MultiAgent_Implementation_Plan_v1_9.md"),
+    }
+
+    for state in CANONICAL_STATES:
+        for name, text in docs.items():
+            assert f"`{state}`" in text, f"{state} missing from {name}"
+
+    guard_text = "\n".join(
+        item for guards in TRANSITION_GUARDS.values() for item in guards
+    )
+    for phrase in (
+        "HANDOFF.md is present and complete",
+        VALIDATOR_AUTHORISATION_GUARDS[0],
+        REVIEW_COMPLETION_GUARDS[1],
+        MERGE_APPROVAL_GUARDS[1],
+    ):
+        assert phrase in guard_text
+        assert phrase in docs["state_machine"]
+
+    for phrase in (
+        "Implementer completion",
+        "Validator authorisation",
+        "Review completion",
+        "Merge approval",
+        "GitHub Actions may observe state, validate guards, post audit evidence",
+    ):
+        assert phrase in docs["agents"]
+        assert phrase in docs["state_machine"]


### PR DESCRIPTION
## Summary
- Formalises the v1.9 PE workflow state machine as a human-readable and machine-readable governance contract.
- Adds ADR-013, `docs/workflow/PE_STATE_MACHINE.md`, and `elis/workflow_state_machine.py`.
- Updates AGENTS.md, architecture, plan v1.9, status validators, and targeted tests.
- `HANDOFF.md` is committed as the final branch commit.

## Test plan
- `python -m black --check --include "\.py$" elis/ tests/ scripts/` — PASS
- `python -m ruff check .` — PASS
- `python -m pytest tests/test_workflow_state_machine.py tests/test_check_current_pe.py tests/test_check_role_registration.py --basetemp=C:\Users\carlo\ELIS-SLR-Agent\.tmp\pe-infra-slr-06-targeted -q --tb=short` — PASS, 21 passed
- `python -m pytest tests/ --basetemp=C:\Users\carlo\ELIS-SLR-Agent\.tmp\pe-infra-slr-06-full --tb=no -q` — 2 known unrelated Claude-auth failures; see HANDOFF for exact output