### PR TITLE
feat(pe-slr-11): confirm local-first implementer runner

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,49 +1,41 @@
-# HANDOFF - PE-INFRA-SLR-08
+# HANDOFF - PE-SLR-11
 
-**PE:** PE-INFRA-SLR-08  
-**Branch:** feature/pe-infra-slr-08-control-plane-workflow-wiring  
-**PR:** #374 - https://github.com/rochasamurai/ELIS-Multi-AI-Agent-Platform/pull/374  
-**Implementer:** CODEX (`infra-impl-a`)  
+**PE:** PE-SLR-11  
+**Branch:** feature/pe-slr-11-implementer-runner-local-first-confirmation  
+**Implementer:** CODEX  
 **Date:** 2026-04-25  
 **Base branch:** main  
-**Implementation commits:**  
-- `15498d8df25351e5d14478fc629c74505fce4dbc`
-- `2a01fa299c6e82f04cd47829867c3df8f175a995`
+**Implementation commit:** `3b5f51db6d763c607d4df0035769e1f4d0e6cb97`
 
 ---
 
 ## Summary
 
-PE-INFRA-SLR-08 wires the GitHub Actions control plane to the v1.9 workflow
-state machine and local-first execution boundary.
+PE-SLR-11 confirms and hardens the implementer-runner local-first contract.
 
 The implementation:
 
-- adds dispatch helper constants/functions to `elis/workflow_state_machine.py`;
-- validates parsed `CURRENT_PE.md` statuses against canonical workflow states;
-- updates implementer and validator dispatch scripts to use state-machine helpers
-  instead of duplicating raw string checks;
-- keeps validator dispatch blocked until implementer-complete evidence exists:
-  `HANDOFF.md`, complete Status Packet sections, and a branch matching the active
-  PE branch;
-- allows the control plane to observe `implementing -> gate-1-pending` from
-  complete implementer evidence before dispatching through
-  `gate-1-pending -> validating`;
-- replaces brittle provider-substring validator mention logic in
-  `auto-assign-validator.yml` with `scripts/resolve_validator_handle.py`;
-- adds `scripts/check_control_plane_wiring.py` to prove development-agent coding
-  entrypoints stay on the self-hosted `elis-server` runner and CI workflows stay
-  bounded to gates;
-- documents the control-plane boundary in `AGENTS.md`,
-  `docs/workflow/PE_STATE_MACHINE.md`, and ADR-014; and
-- adds focused tests for the wiring, dispatch helpers, Gate 1 state guard, and
-  evidence-backed validator dispatch path.
+- adds `scripts/check_implementer_runner_local_first.py`, a PE-specific contract
+  check proving that the implementer runner:
+  - runs on `[self-hosted, elis-server]`;
+  - exposes the governed `workflow_dispatch` inputs;
+  - invokes both implementer entrypoints with `--pe-id`, `--plan`, `--branch`,
+    and `--base-branch`;
+  - emits the PM started webhook; and
+  - reads `CURRENT_PE.md` and the active plan before building the agent prompt;
+- tightens `scripts/implementer_runner_common.py` so PR creation/readying is
+  reserved for the runner, not the agent prompt;
+- adds `ensure_handoff_ready_for_pr()` so the runner refuses PR operations unless
+  the working tree is clean and `HANDOFF.md` is part of the last commit;
+- moves the PR-create guard before `create_draft_pr()` in `run_implementer()`,
+  ensuring `HANDOFF.md` is committed before any PR is opened;
+- updates the implementer prompt to include the active plan acceptance criteria
+  explicitly and to tell the agent not to open or ready the PR itself; and
+- adds focused tests covering the local-first check, prompt contract, handoff
+  guard, and PR-operation ordering.
 
-After the first push, live `validator-dispatch` correctly exposed one remaining
-gap: it required `CURRENT_PE.md` to already say `gate-1-pending`, even when the
-PR branch had complete implementer evidence. Commit `2a01fa2` fixes that gap by
-making the evidence-backed transition explicit in the state-machine helper and
-the dispatcher tests.
+No PR was opened before this HANDOFF commit. That ordering is intentional for
+PE-SLR-11 AC-3.
 
 ---
 
@@ -51,42 +43,28 @@ the dispatcher tests.
 
 | File | Change |
 |------|--------|
-| `.github/workflows/auto-assign-validator.yml` | Use the model-agnostic validator handle resolver instead of inline provider substring parsing. |
-| `AGENTS.md` | Document GitHub Actions as control plane, not the development-agent coding substrate, including the evidence-backed Gate 1 observation. |
-| `docs/decisions/ADR-014-control-plane-workflow-wiring.md` | New ADR for the control-plane workflow boundary and evidence-backed dispatch behaviour. |
-| `docs/decisions/README.md` | Add ADR-014 to the ADR index. |
-| `docs/workflow/PE_STATE_MACHINE.md` | Add the control-plane wiring section, evidence-backed dispatch rule, and validation command. |
-| `elis/workflow_state_machine.py` | Add dispatch state constants, strict dispatch helpers, and an evidence-backed validator dispatch helper. |
-| `scripts/check_control_plane_wiring.py` | New repository check for local-first agent runners and bounded CI workflows. |
-| `scripts/dispatch_implementer_runner.py` | Use the canonical implementer dispatch helper. |
-| `scripts/dispatch_validator_runner.py` | Verify HANDOFF/Status Packet sections before allowing validator dispatch through canonical evidence-backed helpers. |
-| `scripts/implementer_runner_common.py` | Reject non-canonical `CURRENT_PE.md` registry statuses during parse. |
-| `scripts/pm_gate_evaluator.py` | Align Gate 1 assignment decisions with evidence-backed validator dispatch. |
-| `tests/test_control_plane_workflow_wiring.py` | New focused control-plane wiring tests. |
-| `tests/test_dispatch_validator_runner.py` | Cover complete-evidence dispatch from `implementing` and rejection from non-ready states. |
-| `tests/test_pm_gate_evaluator.py` | Cover Gate 1 pass from complete `implementing` evidence and rejection from `planning`. |
-| `tests/test_workflow_state_machine.py` | Cover strict and evidence-backed dispatch helpers plus control-plane documentation language. |
+| `scripts/check_implementer_runner_local_first.py` | New local verification check for the implementer-runner contract. |
+| `scripts/implementer_runner_common.py` | Tighten implementer prompt, add handoff-before-PR guard, and enforce guard before PR creation. |
+| `tests/test_implementer_runner_common.py` | Add prompt, handoff guard, and PR operation ordering tests. |
+| `tests/test_implementer_runner_local_first.py` | Add focused tests for the new local-first contract check. |
+| `HANDOFF.md` | Replace previous PE handoff with PE-SLR-11 handoff and Status Packet. |
 
 ---
 
 ## Design Decisions
 
-- **State-machine helpers live in `elis/workflow_state_machine.py`:** dispatch
-  eligibility is part of the lifecycle contract, so the implementer and
-  validator dispatch scripts now consume the canonical mirror rather than
-  hardcoding state strings locally.
-- **Strict and evidence-backed validator dispatch are separate helpers:** strict
-  dispatch still follows `gate-1-pending -> validating`; the live control plane
-  may use the evidence-backed helper only after HANDOFF and Status Packet checks
-  have passed.
-- **Workflow boundary check is conservative:** only the implementer and validator
-  runner workflows may invoke development-agent coding entrypoints, and they
-  must run on the self-hosted `elis-server` surface.
-- **CI remains credential-free:** the new check rejects bot/App credentials in
-  CI workflows so portable gates stay reproducible and merge-authoritative.
-- **Validator mention resolution is model-agnostic:** `auto-assign-validator.yml`
-  now delegates to the existing resolver, which handles role-slot IDs such as
-  `infra-val-a` / `infra-val-b` correctly.
+- **Runner owns PR operations:** the agent prompt now explicitly tells the
+  implementer agent not to open, refresh, or ready the PR. The runner performs
+  PR operations only after checking the handoff contract.
+- **AC-3 takes precedence over draft-PR habit:** this PE specifically confirms
+  that `HANDOFF.md` is committed before the PR is opened. The PR is therefore
+  intentionally opened only after this handoff commit.
+- **Local verification is executable:** `check_implementer_runner_local_first.py`
+  checks the live repository workflow and runner code instead of relying only on
+  prose.
+- **The check reads real Step 0 context:** the local-first check parses
+  `CURRENT_PE.md`, loads the active plan, extracts the active PE criteria, and
+  builds the prompt before reporting PASS.
 
 ---
 
@@ -94,11 +72,11 @@ the dispatcher tests.
 
 | AC | Criterion | Result |
 |----|-----------|--------|
-| AC-1 | Implementer and validator dispatch paths are aligned with the state machine and local-first execution surface. | PASS - dispatch scripts use canonical state-machine helpers; runner workflows stay on `[self-hosted, elis-server]`; focused tests cover implementer dispatch, strict validator dispatch, and evidence-backed validator dispatch. |
-| AC-2 | Workflow files do not attempt to perform GitHub-hosted agent coding where `elis-server` is the intended execution surface. | PASS - `scripts/check_control_plane_wiring.py` and tests fail if Codex/Claude development-agent entrypoints appear outside local runner workflows or on `ubuntu-latest`. |
-| AC-3 | Portable gates remain bounded to CI/test duties: formatting, linting, validation, and tests. | PASS - the control-plane check verifies CI workflows avoid bot/App credentials and agent coding entrypoints while retaining portable gate commands. |
-| AC-4 | Validator dispatch is blocked until implementer-complete evidence exists. | PASS - `dispatch_validator_runner.py` verifies HANDOFF and Status Packet sections before dispatch, rejects `planning`, and permits `implementing` only after complete evidence is present. |
-| AC-5 | The workflow/documentation pair describes GitHub Actions as control plane, not the coding substrate. | PASS - `AGENTS.md`, `docs/workflow/PE_STATE_MACHINE.md`, and ADR-014 all state the control-plane boundary; tests assert the governing language is present. |
+| AC-1 | Implementer runner launches from the governed workflow and starts a local session on `elis-server`. | PASS - the new check verifies `.github/workflows/implementer-runner.yml` runs on `[self-hosted, elis-server]`, has governed dispatch inputs, invokes the implementer entrypoints, and emits the PM started webhook. |
+| AC-2 | The implementer session reads `CURRENT_PE.md` and the active plan before changing files. | PASS - `run_implementer()` parses `CURRENT_PE.md` and `build_prompt()` extracts active-plan criteria before `run_cli()` invokes the agent; tests and the local-first check cover this path. |
+| AC-3 | `HANDOFF.md` is committed before the PR is opened. | PASS - `ensure_handoff_ready_for_pr()` now runs before `create_draft_pr()`, and no PE-SLR-11 PR existed before this HANDOFF commit. |
+| AC-4 | The feature branch stays scope-safe and contains only PE-intended changes. | PASS - committed scope contains only runner contract code, focused tests, and `HANDOFF.md`. |
+| AC-5 | Local verification proves the runner invocation path is stable. | PASS - `check_implementer_runner_local_first.py`, control-plane wiring check, Black, Ruff, and 25 focused pytest tests pass locally. |
 
 ---
 
@@ -122,12 +100,24 @@ git diff --name-status -- tests/test_verify_claude_auth.py scripts/verify_claude
 
 (no output)
 
+### PE-Specific Local-First Checks
+
+```powershell
+& 'C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe' scripts/check_control_plane_wiring.py
+Control-plane wiring OK — agent coding is local-first and CI is bounded.
+```
+
+```powershell
+& 'C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe' scripts/check_implementer_runner_local_first.py
+Implementer runner local-first contract OK - PE-SLR-11 reads CURRENT_PE.md and ELIS_MultiAgent_Implementation_Plan_v1_9.md before agent run.
+```
+
 ### Formatting
 
 ```powershell
 $env:BLACK_CACHE_DIR = (Join-Path (Get-Location) '.black-cache-pe'); & 'C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe' -m black --check --include '\.py$' elis scripts tests; $code = $LASTEXITCODE; if (Test-Path .black-cache-pe) { Remove-Item -LiteralPath (Resolve-Path .black-cache-pe).Path -Recurse -Force }; exit $code
 All done! \u2728 \U0001f370 \u2728
-184 files would be left unchanged.
+186 files would be left unchanged.
 ```
 
 ### Ruff
@@ -137,21 +127,14 @@ All done! \u2728 \U0001f370 \u2728
 All checks passed!
 ```
 
-### Control-Plane Wiring Check
-
-```powershell
-& 'C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe' scripts/check_control_plane_wiring.py
-Control-plane wiring OK — agent coding is local-first and CI is bounded.
-```
-
 ### PE-Specific Tests
 
 ```powershell
-& 'C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe' -m pytest tests/test_control_plane_workflow_wiring.py tests/test_workflow_state_machine.py tests/test_dispatch_implementer_runner.py tests/test_dispatch_validator_runner.py tests/test_pm_gate_evaluator.py -q -p no:cacheprovider
-..............................                                           [100%]
+& 'C:\Users\carlo\ELIS-SLR-Agent\.venv\Scripts\python.exe' -m pytest tests/test_implementer_runner_common.py tests/test_implementer_runner_local_first.py tests/test_dispatch_implementer_runner.py tests/test_control_plane_workflow_wiring.py -q -p no:cacheprovider
+.........................                                                [100%]
 ```
 
-PE-specific tests: PASS - 30/30 passed.
+PE-specific tests: PASS - 25/25 passed.
 
 ### Full Test Suite
 
@@ -163,15 +146,15 @@ PE-specific tests: PASS - 30/30 passed.
 ........................................................................ [ 27%]
 ........................................................................ [ 34%]
 ........................................................................ [ 41%]
-........................................................................ [ 48%]
-........................................................................ [ 55%]
-........................................................................ [ 62%]
+........................................................................ [ 47%]
+........................................................................ [ 54%]
+........................................................................ [ 61%]
 ........................................................................ [ 68%]
 ........................................................................ [ 75%]
 ........................................................................ [ 82%]
 ........................................................................ [ 89%]
-........................................................................ [ 96%]
-................FF..................                                     [100%]
+........................................................................ [ 95%]
+.......................FF..................                              [100%]
 ================================== FAILURES ===================================
 __________________ test_fails_when_credentials_file_missing ___________________
 tests\test_verify_claude_auth.py:32: in test_fails_when_credentials_file_missing
@@ -217,7 +200,7 @@ tests/test_elis_cli.py::test_screen_dry_run_does_not_emit_manifest
 tests/test_pipeline_merge.py::test_merge_output_validates_and_is_screen_compatible
 tests/test_pipeline_screen.py::TestScreenMain::test_dry_run
 tests/test_pipeline_screen.py::TestScreenMain::test_write_output
-  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-infra-slr-08\elis\pipeline\screen.py:276: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-slr-11\elis\pipeline\screen.py:276: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
     else g.get("year_to", dt.datetime.utcnow().year)
 
 tests/test_elis_cli.py::test_screen_emits_manifest
@@ -225,23 +208,23 @@ tests/test_elis_cli.py::test_screen_dry_run_does_not_emit_manifest
 tests/test_pipeline_merge.py::test_merge_output_validates_and_is_screen_compatible
 tests/test_pipeline_screen.py::TestScreenMain::test_dry_run
 tests/test_pipeline_screen.py::TestScreenMain::test_write_output
-  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-infra-slr-08\elis\pipeline\screen.py:30: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-slr-11\elis\pipeline\screen.py:30: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
     return dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
 
 tests/test_pipeline_search.py::TestBuildRunInputs::test_defaults
 tests/test_pipeline_search.py::TestSearchMain::test_dry_run_with_minimal_config
 tests/test_pipeline_search.py::TestSearchMain::test_dry_run_topic_with_name_not_id
-  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-infra-slr-08\elis\pipeline\search.py:154: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-slr-11\elis\pipeline\search.py:154: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
     year_to = int(g.get("year_to", dt.datetime.utcnow().year))
 
 tests/test_pipeline_search.py::TestSearchMain::test_dry_run_with_minimal_config
 tests/test_pipeline_search.py::TestSearchMain::test_dry_run_topic_with_name_not_id
-  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-infra-slr-08\elis\pipeline\search.py:405: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-slr-11\elis\pipeline\search.py:405: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
     y1 = int(config.get("global", {}).get("year_to", dt.datetime.utcnow().year))
 
 tests/test_pipeline_search.py::TestSearchMain::test_dry_run_with_minimal_config
 tests/test_pipeline_search.py::TestSearchMain::test_dry_run_topic_with_name_not_id
-  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-infra-slr-08\elis\pipeline\search.py:43: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+  C:\Users\carlo\ELIS-SLR-Agent\.worktrees\pe-slr-11\elis\pipeline\search.py:43: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
     return dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
 
 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
@@ -250,21 +233,20 @@ FAILED tests/test_verify_claude_auth.py::test_fails_when_credentials_file_missin
 FAILED tests/test_verify_claude_auth.py::test_fails_when_credentials_file_lacks_oauth_key
 ```
 
-The full-suite failures are outside PE-INFRA-SLR-08 scope. This branch does not
-modify `tests/test_verify_claude_auth.py` or `scripts/verify_claude_auth.py`, as
-shown by the empty diff command above.
+The full-suite failures are outside PE-SLR-11 scope. This branch does not modify
+`tests/test_verify_claude_auth.py` or `scripts/verify_claude_auth.py`, as shown
+by the empty diff command above.
 
-### PR Evidence
-
-```powershell
-gh pr list --state open --base main
-374	feat(pe-infra-slr-08): control-plane workflow wiring	feature/pe-infra-slr-08-control-plane-workflow-wiring	OPEN	2026-04-25T04:02:59Z
-```
+### PR Pre-Open Evidence
 
 ```powershell
-gh pr view 374 --json number,state,url,headRefName,baseRefName,title,isDraft,mergeStateStatus,reviewDecision
-{"baseRefName":"main","headRefName":"feature/pe-infra-slr-08-control-plane-workflow-wiring","isDraft":false,"mergeStateStatus":"CLEAN","number":374,"reviewDecision":"","state":"OPEN","title":"feat(pe-infra-slr-08): control-plane workflow wiring","url":"https://github.com/rochasamurai/ELIS-Multi-AI-Agent-Platform/pull/374"}
+gh pr list --state open --base main --head feature/pe-slr-11-implementer-runner-local-first-confirmation
 ```
+
+(no output)
+
+This confirms no PE-SLR-11 PR existed before `HANDOFF.md` was written and
+committed for this PE.
 
 ---
 
@@ -274,9 +256,7 @@ gh pr view 374 --json number,state,url,headRefName,baseRefName,title,isDraft,mer
 
 ```powershell
 git status -sb
-## feature/pe-infra-slr-08-control-plane-workflow-wiring...origin/feature/pe-infra-slr-08-control-plane-workflow-wiring [ahead 1]
-warning: unable to access 'C:\Users\carlo/.config/git/ignore': Permission denied
-warning: unable to access 'C:\Users\carlo/.config/git/ignore': Permission denied
+## feature/pe-slr-11-implementer-runner-local-first-confirmation...origin/main [ahead 1]
 
 git diff --name-status
 
@@ -289,96 +269,75 @@ git diff --stat
 git fetch --all --prune
 
 git branch --show-current
-feature/pe-infra-slr-08-control-plane-workflow-wiring
+feature/pe-slr-11-implementer-runner-local-first-confirmation
 
 git rev-parse HEAD
-2a01fa299c6e82f04cd47829867c3df8f175a995
+3b5f51db6d763c607d4df0035769e1f4d0e6cb97
 
 git log -5 --oneline --decorate
-2a01fa2 (HEAD -> feature/pe-infra-slr-08-control-plane-workflow-wiring) fix(pe-infra-slr-08): allow evidence-backed validator dispatch
-255d87e (origin/feature/pe-infra-slr-08-control-plane-workflow-wiring) docs(pe-infra-slr-08): add implementation handoff
-15498d8 feat(pe-infra-slr-08): wire control-plane workflow guards
-2bbdcea (origin/main, origin/HEAD, main) chore(pm): PM-CHORE-64 — close PE-INFRA-SLR-07, open PE-INFRA-SLR-08
-ce06c48 Merge pull request #373 from rochasamurai/feature/pe-infra-slr-07-review-archive-migration
+3b5f51d (HEAD -> feature/pe-slr-11-implementer-runner-local-first-confirmation) feat(pe-slr-11): confirm local-first implementer runner
+bfd5263 (origin/main, origin/HEAD, main) chore(pm): PM-CHORE-65 — close PE-INFRA-SLR-08, open PE-SLR-11
+0336ffb Merge pull request #374 from rochasamurai/feature/pe-infra-slr-08-control-plane-workflow-wiring
+2c80c49 (feature/pe-infra-slr-08-control-plane-workflow-wiring) test(pe-infra-slr-08): add validator review evidence
+b3e94e5 docs(pe-infra-slr-08): refresh handoff after dispatch fix
 ```
 
 ### 6.3 Scope evidence
 
 ```powershell
 git diff --name-status origin/main..HEAD
-M	.github/workflows/auto-assign-validator.yml
-M	AGENTS.md
-M	HANDOFF.md
-A	docs/decisions/ADR-014-control-plane-workflow-wiring.md
-M	docs/decisions/README.md
-M	docs/workflow/PE_STATE_MACHINE.md
-M	elis/workflow_state_machine.py
-A	scripts/check_control_plane_wiring.py
-M	scripts/dispatch_implementer_runner.py
-M	scripts/dispatch_validator_runner.py
+A	scripts/check_implementer_runner_local_first.py
 M	scripts/implementer_runner_common.py
-M	scripts/pm_gate_evaluator.py
-A	tests/test_control_plane_workflow_wiring.py
-M	tests/test_dispatch_validator_runner.py
-M	tests/test_pm_gate_evaluator.py
-M	tests/test_workflow_state_machine.py
+M	tests/test_implementer_runner_common.py
+A	tests/test_implementer_runner_local_first.py
 ```
 
 ```powershell
 git diff --stat origin/main..HEAD
- .github/workflows/auto-assign-validator.yml        |  30 +-
- AGENTS.md                                          |   9 +
- HANDOFF.md                                         | 372 +++++++++++++++------
- .../ADR-014-control-plane-workflow-wiring.md       |  83 +++++
- docs/decisions/README.md                           |   1 +
- docs/workflow/PE_STATE_MACHINE.md                  |  28 ++
- elis/workflow_state_machine.py                     |  49 +++
- scripts/check_control_plane_wiring.py              | 140 ++++++++
- scripts/dispatch_implementer_runner.py             |   3 +-
- scripts/dispatch_validator_runner.py               |  32 +-
- scripts/implementer_runner_common.py               |   5 +
- scripts/pm_gate_evaluator.py                       |  11 +-
- tests/test_control_plane_workflow_wiring.py        |  73 ++++
- tests/test_dispatch_validator_runner.py            |  26 +-
- tests/test_pm_gate_evaluator.py                    |  34 ++
- tests/test_workflow_state_machine.py               |  19 ++
- 16 files changed, 770 insertions(+), 145 deletions(-)
+ scripts/check_implementer_runner_local_first.py | 234 ++++++++++++++++++++++++
+ scripts/implementer_runner_common.py            |  31 +++-
+ tests/test_implementer_runner_common.py         |  77 ++++++++
+ tests/test_implementer_runner_local_first.py    | 107 +++++++++++
+ 4 files changed, 440 insertions(+), 9 deletions(-)
 ```
 
 ### 6.4 Quality gates
 
 ```text
-black: PASS - 184 files would be left unchanged.
-ruff: PASS - All checks passed!
-Control-plane wiring check: PASS.
-PE-specific tests: PASS - 30/30 passed.
-pytest full suite: FAIL local preflight - 2 unrelated Windows/Claude-auth failures in tests/test_verify_claude_auth.py; all other tests reached completion.
-GitHub Actions CI: authoritative portable gate evidence remains on PR #374 after push.
+black: PASS - 186 files would be left unchanged.
+ruff: PASS - All checks passed.
+check_current_pe.py: PASS.
+check_agent_scope.py: PASS.
+check_control_plane_wiring.py: PASS.
+check_implementer_runner_local_first.py: PASS.
+PE-specific tests: PASS - 25/25 passed.
+pytest full suite: FAIL local preflight - 2 unrelated Windows/Claude-auth failures in tests/test_verify_claude_auth.py.
+GitHub Actions CI: authoritative portable gate evidence will be collected on PR after this HANDOFF commit is pushed.
 ```
 
 ### 6.5 PR evidence
 
-```text
-PR: #374
-State: OPEN
-Draft: false
-Base: main
-Head: feature/pe-infra-slr-08-control-plane-workflow-wiring
-Merge state: CLEAN
-URL: https://github.com/rochasamurai/ELIS-Multi-AI-Agent-Platform/pull/374
+```powershell
+gh pr list --state open --base main --head feature/pe-slr-11-implementer-runner-local-first-confirmation
 ```
+
+(no output)
+
+PR intentionally not opened before HANDOFF commit to satisfy PE-SLR-11 AC-3.
 
 ---
 
 ## Notes for Validator
 
-- Validate PE-INFRA-SLR-08 AC-1 through AC-5 verbatim against
+- Validate PE-SLR-11 AC-1 through AC-5 verbatim against
   `ELIS_MultiAgent_Implementation_Plan_v1_9.md`.
-- Start with `scripts/check_control_plane_wiring.py` and
-  `tests/test_control_plane_workflow_wiring.py`; they are the PE-specific
-  enforcement surface for AC-1 through AC-5.
-- Re-run `tests/test_dispatch_validator_runner.py` because it now covers the
-  live Gate 1 failure mode discovered after the first push.
-- The local full-suite failure is pre-existing/host-specific and isolated from
-  this PE by the empty diff for `tests/test_verify_claude_auth.py` and
+- Start with `scripts/check_implementer_runner_local_first.py`; it is the
+  PE-specific proof for AC-1, AC-2, AC-3, and AC-5.
+- Re-run the focused tests:
+  `tests/test_implementer_runner_common.py`,
+  `tests/test_implementer_runner_local_first.py`,
+  `tests/test_dispatch_implementer_runner.py`, and
+  `tests/test_control_plane_workflow_wiring.py`.
+- The local full-suite failure is host-specific and isolated from this PE by the
+  empty diff for `tests/test_verify_claude_auth.py` and
   `scripts/verify_claude_auth.py`.

--- a/docs/reviews/archive/REVIEW_PE_SLR_11.md
+++ b/docs/reviews/archive/REVIEW_PE_SLR_11.md
@@ -1,0 +1,145 @@
+# REVIEW_PE_SLR_11.md
+
+**PE:** PE-SLR-11  
+**Validator:** Claude Code (`prog-val-b`)  
+**PR:** #376  
+**Branch:** feature/pe-slr-11-implementer-runner-local-first-confirmation  
+**Date:** 2026-04-25  
+**Plan:** ELIS_MultiAgent_Implementation_Plan_v1_9.md
+
+---
+
+### Verdict
+
+PASS
+
+---
+
+### Gate results
+
+```
+black --check:                          186 files would be left unchanged. PASS
+ruff check:                             All checks passed! PASS
+check_control_plane_wiring.py:          Control-plane wiring OK — agent coding is local-first and CI is bounded. PASS
+check_implementer_runner_local_first.py: Implementer runner local-first contract OK — PE-SLR-11 reads CURRENT_PE.md and ELIS_MultiAgent_Implementation_Plan_v1_9.md before agent run. PASS
+pytest (PE-specific):                   25 passed. PASS
+pytest (full suite):                    1049 passed, 2 failed (pre-existing test_verify_claude_auth.py — not in scope). PASS
+CI checks (PR #376):                    All pass (current-pe-check, quality, tests, validate, gate-1, openclaw-*, review-evidence-check, secrets-scope-check). PASS
+```
+
+---
+
+### Scope
+
+```
+git diff --name-status origin/main..HEAD
+M  HANDOFF.md
+A  scripts/check_implementer_runner_local_first.py
+M  scripts/implementer_runner_common.py
+M  tests/test_implementer_runner_common.py
+A  tests/test_implementer_runner_local_first.py
+```
+
+All 5 changed files are within PE-SLR-11 scope. `HANDOFF.md` is the expected implementer deliverable.
+
+---
+
+### Required fixes
+
+None.
+
+---
+
+### Evidence
+
+**AC-1 — Implementer runner launches from governed workflow and starts local session on elis-server.**
+
+`check_implementer_runner_local_first.py` parses `.github/workflows/implementer-runner.yml` and confirms:
+- `runs-on: [self-hosted, elis-server]` — no `ubuntu-latest`;
+- governed `workflow_dispatch` inputs present: `pe_id`, `branch`, `engine`, `plan_file`, `base_branch`;
+- both implementer entrypoints invoked: `python scripts/run_codex_agent.py` and `python scripts/run_claude_agent.py`;
+- required agent arguments passed: `--pe-id`, `--plan`, `--branch`, `--base-branch`;
+- PM started webhook emitted with `"stage": "started"`.
+
+```
+python scripts/check_implementer_runner_local_first.py
+Implementer runner local-first contract OK — PE-SLR-11 reads CURRENT_PE.md and ELIS_MultiAgent_Implementation_Plan_v1_9.md before agent run.
+```
+
+**AC-2 — Implementer session reads CURRENT_PE.md and active plan before changing files.**
+
+`implementer_runner_common.py` diff confirms `run_implementer()` calls `parse_current_pe(current_pe_path)` and then `build_prompt()` with `plan_path` before `run_cli()`. The prompt now includes:
+
+```python
+"=== ACTIVE PLAN ACCEPTANCE CRITERIA ===\n"
+f"{criteria_block}\n\n"
+"=== CURRENT_PE.md ===\n"
+```
+
+`check_implementer_runner_local_first.py` verifies both section markers are present in the built prompt using the live `CURRENT_PE.md` and plan, and confirms `acceptance_criteria_for_pe()` returns a non-empty criteria block for PE-SLR-11.
+
+The prompt also now explicitly says `"Do not open, refresh, or ready the PR yourself."`, reserving all PR operations for the runner (confirmed absent from old prompt in the diff).
+
+**AC-3 — HANDOFF.md is committed before the PR is opened.**
+
+Commit timestamps:
+- `f37131f docs(pe-slr-11): add implementer handoff` — authored `2026-04-25T16:22:02Z`
+- PR #376 created — `2026-04-25T16:25:44Z`
+
+HANDOFF.md commit precedes PR creation by 3 minutes 42 seconds. ✓
+
+`ensure_handoff_ready_for_pr()` is now called in `run_implementer()` before `create_draft_pr()`:
+
+```python
+ensure_handoff_ready_for_pr()
+create_draft_pr(inputs.branch, inputs.base_branch, inputs.pe_id)
+mark_pr_ready(inputs.branch, inputs.base_branch)
+```
+
+Guard raises `RunnerError` if the working tree is dirty or if `HANDOFF.md` is not the last committed file. The old post-`create_draft_pr` dirty-tree check was replaced by this pre-PR guard.
+
+PE-specific tests assert the ordering:
+```python
+assert events == ["run_cli", "handoff_guard", "create_pr", "ready_pr"]
+```
+
+**AC-4 — Feature branch stays scope-safe and contains only PE-intended changes.**
+
+```
+git diff --name-status origin/main..HEAD
+M  HANDOFF.md
+A  scripts/check_implementer_runner_local_first.py
+M  scripts/implementer_runner_common.py
+M  tests/test_implementer_runner_common.py
+A  tests/test_implementer_runner_local_first.py
+```
+
+Empty diff for unrelated files confirmed:
+```
+git diff --name-status -- tests/test_verify_claude_auth.py scripts/verify_claude_auth.py
+(no output)
+```
+
+**AC-5 — Local verification proves the runner invocation path is stable.**
+
+PE-specific tests (25/25):
+
+```
+pytest tests/test_implementer_runner_common.py tests/test_implementer_runner_local_first.py \
+       tests/test_dispatch_implementer_runner.py tests/test_control_plane_workflow_wiring.py -q -p no:cacheprovider
+.........................                                                [100%]
+25 passed
+```
+
+Full suite: 1049 passed, 2 failed (pre-existing `test_verify_claude_auth.py` — Windows subprocess path issue, confirmed out of scope by empty diff above).
+
+All CI checks on PR #376 pass: `current-pe-check`, `quality` (×3), `tests` (×3), `validate`, `gate-1`, `openclaw-config-sync-check`, `openclaw-doctor-check`, `openclaw-health-check`, `openclaw-security-check`, `review-evidence-check`, `secrets-scope-check`.
+
+**Pre-existing failures (not in scope):**
+
+```
+git diff --name-status -- tests/test_verify_claude_auth.py scripts/verify_claude_auth.py
+(no output)
+```
+
+The 2 failures in `test_verify_claude_auth.py` pre-date this PE and are caused by a Windows path issue in the subprocess invocation of the `claude` CLI — unrelated to PE-SLR-11 scope.

--- a/scripts/check_implementer_runner_local_first.py
+++ b/scripts/check_implementer_runner_local_first.py
@@ -1,0 +1,234 @@
+"""Validate the implementer runner local-first contract.
+
+PE-SLR-11 uses this check to prove that the governed implementer runner starts
+on the self-hosted ``elis-server`` execution surface, reads ``CURRENT_PE.md`` and
+the active plan before invoking the agent, and keeps PR operations behind the
+handoff guard.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import yaml  # noqa: E402
+
+from elis.workflow_state_machine import (  # noqa: E402
+    LOCAL_AGENT_EXECUTION_SURFACE,
+    implementer_dispatch_allowed,
+)
+from scripts.implementer_runner_common import (  # noqa: E402
+    RunnerError,
+    acceptance_criteria_for_pe,
+    build_prompt,
+    parse_current_pe,
+)
+
+WORKFLOW_PATH = Path(".github/workflows/implementer-runner.yml")
+RUNNER_SCRIPT = Path("scripts/implementer_runner_common.py")
+
+REQUIRED_WORKFLOW_INPUTS = {
+    "pe_id",
+    "branch",
+    "engine",
+    "plan_file",
+    "base_branch",
+}
+
+REQUIRED_AGENT_ENTRYPOINTS = {
+    "codex": "python scripts/run_codex_agent.py",
+    "claude": "python scripts/run_claude_agent.py",
+}
+
+REQUIRED_AGENT_ARGS = {
+    "--pe-id",
+    "--plan",
+    "--branch",
+    "--base-branch",
+}
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _normalise_runs_on(value: object) -> set[str]:
+    if isinstance(value, str):
+        return {value}
+    if isinstance(value, list):
+        return {str(item) for item in value}
+    return set()
+
+
+def _workflow_payload(workflow_path: Path) -> dict[str, object]:
+    payload = yaml.load(_read(workflow_path), Loader=yaml.BaseLoader)
+    if not isinstance(payload, dict):
+        raise RunnerError(f"{workflow_path} did not parse as a YAML mapping.")
+    return payload
+
+
+def validate_implementer_runner_local_first(
+    *,
+    repo_root: Path,
+    current_pe_path: Path,
+    plan_path: Path,
+) -> list[str]:
+    """Return validation errors for the implementer runner contract."""
+
+    errors: list[str] = []
+    workflow_path = repo_root / WORKFLOW_PATH
+    runner_path = repo_root / RUNNER_SCRIPT
+
+    if not workflow_path.exists():
+        return [f"{WORKFLOW_PATH.as_posix()} is missing."]
+    if not runner_path.exists():
+        return [f"{RUNNER_SCRIPT.as_posix()} is missing."]
+
+    workflow_text = _read(workflow_path)
+    runner_text = _read(runner_path)
+    try:
+        workflow = _workflow_payload(workflow_path)
+    except RunnerError as exc:
+        return [str(exc)]
+
+    jobs = workflow.get("jobs", {})
+    if not isinstance(jobs, dict):
+        return [f"{WORKFLOW_PATH.as_posix()} has no jobs mapping."]
+    job = jobs.get("run-implementer", {})
+    if not isinstance(job, dict):
+        return [f"{WORKFLOW_PATH.as_posix()} has no run-implementer job."]
+
+    runs_on = _normalise_runs_on(job.get("runs-on"))
+    if "self-hosted" not in runs_on or LOCAL_AGENT_EXECUTION_SURFACE not in runs_on:
+        errors.append(
+            "Implementer runner must run on [self-hosted, "
+            f"{LOCAL_AGENT_EXECUTION_SURFACE}]."
+        )
+    if "ubuntu-latest" in runs_on:
+        errors.append("Implementer runner must not use ubuntu-latest.")
+
+    dispatch = workflow.get("on", {}).get("workflow_dispatch", {})
+    inputs = dispatch.get("inputs", {}) if isinstance(dispatch, dict) else {}
+    if not isinstance(inputs, dict):
+        inputs = {}
+    missing_inputs = REQUIRED_WORKFLOW_INPUTS - set(inputs)
+    if missing_inputs:
+        errors.append(
+            "Implementer runner workflow_dispatch is missing inputs: "
+            + ", ".join(sorted(missing_inputs))
+        )
+
+    for engine, entrypoint in REQUIRED_AGENT_ENTRYPOINTS.items():
+        if entrypoint not in workflow_text:
+            errors.append(f"Implementer runner does not invoke {engine}: {entrypoint}.")
+    for argument in REQUIRED_AGENT_ARGS:
+        if argument not in workflow_text:
+            errors.append(f"Implementer runner does not pass {argument}.")
+
+    if "Notify PM Agent webhook — PE started" not in workflow_text:
+        errors.append("Implementer runner does not emit the PE-started webhook.")
+    if '"stage": "started"' not in workflow_text:
+        errors.append("Implementer runner webhook payload lacks stage=started.")
+
+    for required_call in (
+        "parse_current_pe(current_pe_path)",
+        "acceptance_criteria_for_pe(plan_path, pe_id)",
+        "ensure_handoff_ready_for_pr()",
+        "create_draft_pr(inputs.branch, inputs.base_branch, inputs.pe_id)",
+        "mark_pr_ready(inputs.branch, inputs.base_branch)",
+    ):
+        if required_call not in runner_text:
+            errors.append(f"Runner code is missing guard/call: {required_call}.")
+
+    handoff_guard_index = runner_text.find("ensure_handoff_ready_for_pr()")
+    pr_create_index = runner_text.find(
+        "create_draft_pr(inputs.branch, inputs.base_branch, inputs.pe_id)"
+    )
+    ready_index = runner_text.find("mark_pr_ready(inputs.branch, inputs.base_branch)")
+    if not (0 <= handoff_guard_index < pr_create_index < ready_index):
+        errors.append("Runner must check HANDOFF.md before PR create/ready operations.")
+
+    try:
+        context = parse_current_pe(current_pe_path)
+        criteria = acceptance_criteria_for_pe(plan_path, context.pe_id)
+        prompt = build_prompt(
+            engine=context.implementer_engine,
+            repo_root=repo_root,
+            current_pe_path=current_pe_path,
+            plan_path=plan_path,
+            pe_id=context.pe_id,
+        )
+    except (OSError, RunnerError) as exc:
+        errors.append(str(exc))
+    else:
+        if not implementer_dispatch_allowed(context.status):
+            errors.append(
+                f"Active PE status is {context.status!r}; implementer dispatch "
+                "requires an implementing PE."
+            )
+        if not criteria:
+            errors.append(f"No acceptance criteria found for {context.pe_id}.")
+        if "=== CURRENT_PE.md ===" not in prompt:
+            errors.append("Runner prompt does not include CURRENT_PE.md context.")
+        if "=== ACTIVE PLAN ACCEPTANCE CRITERIA ===" not in prompt:
+            errors.append("Runner prompt does not include active plan criteria.")
+        if "Do not open, refresh, or ready the PR yourself." not in prompt:
+            errors.append(
+                "Runner prompt does not reserve PR operations for the runner."
+            )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate implementer runner local-first contract."
+    )
+    parser.add_argument("--repo-root", default=".", help="Repository root path.")
+    parser.add_argument(
+        "--current-pe", default="CURRENT_PE.md", help="Path to CURRENT_PE.md."
+    )
+    parser.add_argument(
+        "--plan",
+        default=None,
+        help="Path to the active plan. Defaults to CURRENT_PE.md Plan file.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    current_pe_path = (repo_root / args.current_pe).resolve()
+    try:
+        context = parse_current_pe(current_pe_path)
+    except (OSError, RunnerError) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+    plan_path = (
+        Path(args.plan).resolve()
+        if args.plan
+        else (repo_root / context.plan_file).resolve()
+    )
+
+    errors = validate_implementer_runner_local_first(
+        repo_root=repo_root,
+        current_pe_path=current_pe_path,
+        plan_path=plan_path,
+    )
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+
+    print(
+        "Implementer runner local-first contract OK - "
+        f"{context.pe_id} reads CURRENT_PE.md and {plan_path.name} before agent run."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/implementer_runner_common.py
+++ b/scripts/implementer_runner_common.py
@@ -167,11 +167,14 @@ def build_prompt(
         f"You are the ELIS {engine.upper()} Implementer runner for {pe_id}.\n\n"
         "Follow AGENTS.md Section 5.1 autonomously.\n"
         "Implement only the active PE acceptance criteria, keep scope minimal,\n"
-        "open or refresh the draft PR, run quality gates, update the namespaced\n"
-        "handoff file in handoffs/, regenerate the root HANDOFF.md with\n"
-        "`python scripts/copy_handoff.py`, and only convert the PR to ready when\n"
-        "HANDOFF.md is the last commit.\n\n"
-        "Acceptance criteria:\n"
+        "run quality gates, update the namespaced handoff file in handoffs/,\n"
+        "regenerate the root HANDOFF.md with `python scripts/copy_handoff.py`,\n"
+        "and commit all changes with HANDOFF.md as the last commit.\n"
+        "Do not open, refresh, or ready the PR yourself. The runner opens or\n"
+        "readies the PR only after it verifies a clean tree and HANDOFF.md as\n"
+        "the last commit.\n\n"
+        f"Active plan: {plan_path.name}\n\n"
+        "=== ACTIVE PLAN ACCEPTANCE CRITERIA ===\n"
         f"{criteria_block}\n\n"
         "Canonical context files follow.\n\n"
         "=== AGENTS.md ===\n"
@@ -269,6 +272,19 @@ def working_tree_clean() -> bool:
     if result.returncode != 0:
         raise RunnerError(result.stderr.strip() or "git status failed.")
     return not result.stdout.strip()
+
+
+def ensure_handoff_ready_for_pr() -> None:
+    """Refuse PR operations until the runner handoff contract is satisfied."""
+
+    if not working_tree_clean():
+        raise RunnerError(
+            "Working tree is dirty after agent run; refusing to open or ready PR."
+        )
+    if not last_commit_touches("HANDOFF.md"):
+        raise RunnerError(
+            "HANDOFF.md is not part of the last commit; refusing to open or ready PR."
+        )
 
 
 def pr_number(branch: str, base_branch: str) -> str | None:
@@ -502,11 +518,8 @@ def run_implementer(argv: list[str], *, engine: str) -> int:
             timeout_seconds=inputs.timeout_seconds,
         )
 
+        ensure_handoff_ready_for_pr()
         create_draft_pr(inputs.branch, inputs.base_branch, inputs.pe_id)
-        if not working_tree_clean():
-            raise RunnerError(
-                "Working tree is dirty after agent run; refusing to continue."
-            )
         mark_pr_ready(inputs.branch, inputs.base_branch)
         print(f"{engine} implementer runner PASS for {inputs.pe_id}")
         return 0

--- a/tests/test_implementer_runner_common.py
+++ b/tests/test_implementer_runner_common.py
@@ -101,7 +101,10 @@ def test_build_prompt_contains_acceptance_criteria(tmp_path):
 
     assert "You are the ELIS CODEX Implementer runner for PE-AUTO-04." in prompt
     assert "AGENTS BODY" in prompt
+    assert "=== ACTIVE PLAN ACCEPTANCE CRITERIA ===" in prompt
     assert "PR opened by the correct account" in prompt
+    assert "Do not open, refresh, or ready the PR yourself." in prompt
+    assert "open or refresh the draft PR" not in prompt
 
 
 def test_budget_guard_fails_when_commit_limit_exceeded():
@@ -161,6 +164,80 @@ def test_last_commit_touches_returns_false(monkeypatch):
     )
 
     assert common.last_commit_touches("HANDOFF.md") is False
+
+
+def test_handoff_pr_guard_requires_clean_tree(monkeypatch):
+    monkeypatch.setattr(common, "working_tree_clean", lambda: False)
+    monkeypatch.setattr(common, "last_commit_touches", lambda _path: True)
+
+    with pytest.raises(common.RunnerError, match="Working tree is dirty"):
+        common.ensure_handoff_ready_for_pr()
+
+
+def test_handoff_pr_guard_requires_handoff_in_last_commit(monkeypatch):
+    monkeypatch.setattr(common, "working_tree_clean", lambda: True)
+    monkeypatch.setattr(common, "last_commit_touches", lambda _path: False)
+
+    with pytest.raises(common.RunnerError, match="HANDOFF.md is not part"):
+        common.ensure_handoff_ready_for_pr()
+
+
+def test_handoff_pr_guard_accepts_clean_tree_and_handoff_last(monkeypatch):
+    monkeypatch.setattr(common, "working_tree_clean", lambda: True)
+    monkeypatch.setattr(common, "last_commit_touches", lambda _path: True)
+
+    common.ensure_handoff_ready_for_pr()
+
+
+def test_run_implementer_checks_handoff_before_pr_operations(monkeypatch):
+    events: list[str] = []
+    inputs = common.RunnerInputs(
+        pe_id="PE-AUTO-04",
+        branch="feature/pe-auto-04-impl-runner",
+        base_branch="main",
+        plan_file="ELIS_2Agent_Automation_Plan_v2_0.md",
+        engine="codex",
+        max_commits=20,
+        timeout_seconds=300,
+    )
+    context = common.CurrentPEContext(
+        pe_id="PE-AUTO-04",
+        branch="feature/pe-auto-04-impl-runner",
+        base_branch="main",
+        plan_file="ELIS_2Agent_Automation_Plan_v2_0.md",
+        plan_location="repo root",
+        status="implementing",
+        implementer_agent="infra-impl-codex",
+        validator_agent="infra-val-claude",
+        implementer_engine="codex",
+        validator_engine="claude",
+    )
+
+    monkeypatch.setattr(common, "parse_runner_inputs", lambda _argv, _engine: inputs)
+    monkeypatch.setattr(common, "parse_current_pe", lambda _path: context)
+    monkeypatch.setattr(common, "ensure_expected_login", lambda _engine: None)
+    monkeypatch.setattr(common, "branch_commit_count", lambda _base: 0)
+    monkeypatch.setattr(common, "build_prompt", lambda **_kwargs: "prompt")
+
+    def fake_run_cli(*_args, **_kwargs):
+        events.append("run_cli")
+
+    def fake_handoff_guard():
+        events.append("handoff_guard")
+
+    def fake_create_pr(*_args):
+        events.append("create_pr")
+
+    def fake_ready(*_args):
+        events.append("ready_pr")
+
+    monkeypatch.setattr(common, "run_cli", fake_run_cli)
+    monkeypatch.setattr(common, "ensure_handoff_ready_for_pr", fake_handoff_guard)
+    monkeypatch.setattr(common, "create_draft_pr", fake_create_pr)
+    monkeypatch.setattr(common, "mark_pr_ready", fake_ready)
+
+    assert common.run_implementer(["runner"], engine="codex") == 0
+    assert events == ["run_cli", "handoff_guard", "create_pr", "ready_pr"]
 
 
 def test_runner_started_at_uses_epoch_env(monkeypatch):

--- a/tests/test_implementer_runner_local_first.py
+++ b/tests/test_implementer_runner_local_first.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_implementer_runner_local_first import (
+    validate_implementer_runner_local_first,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+CURRENT_PE_BODY = """\
+## Release context
+
+| Field          | Value                       |
+|----------------|-----------------------------|
+| Release        | ELIS SLR Agent              |
+| Base branch    | main                        |
+| Plan file      | ELIS_MultiAgent_Implementation_Plan_v1_9.md |
+| Plan location  | repo root                   |
+
+## Current PE
+
+| Field   | Value |
+|---------|-------|
+| PE      | PE-SLR-11 |
+| Branch  | feature/pe-slr-11-implementer-runner-local-first-confirmation |
+
+## Agent roles
+
+| Agent       | Role        |
+|-------------|-------------|
+| CODEX       | Implementer |
+| Claude Code | Validator   |
+
+## Active PE Registry
+
+| PE-ID     | Domain | Implementer-agentId | Validator-agentId | Branch | Status | Last-updated |
+|-----------|--------|---------------------|-------------------|--------|--------|--------------|
+| PE-SLR-11 | slr    | infra-impl-codex    | infra-val-claude  | feature/pe-slr-11-implementer-runner-local-first-confirmation | implementing | 2026-04-25 |
+"""
+
+PLAN_BODY = """\
+### PE-SLR-11 · Implementer Runner Local-First Confirmation
+
+**Acceptance Criteria**
+
+| AC | Criterion |
+|----|-----------|
+| AC-1 | Implementer runner launches from the governed workflow and starts a local session on `elis-server`. |
+| AC-2 | The implementer session reads `CURRENT_PE.md` and the active plan before changing files. |
+| AC-3 | `HANDOFF.md` is committed before the PR is opened. |
+| AC-4 | The feature branch stays scope-safe and contains only PE-intended changes. |
+| AC-5 | Local verification proves the runner invocation path is stable. |
+
+---
+"""
+
+
+def test_implementer_runner_local_first_check_passes_with_active_context(tmp_path):
+    current_pe = tmp_path / "CURRENT_PE.md"
+    plan = tmp_path / "ELIS_MultiAgent_Implementation_Plan_v1_9.md"
+    current_pe.write_text(CURRENT_PE_BODY, encoding="utf-8")
+    plan.write_text(PLAN_BODY, encoding="utf-8")
+
+    assert (
+        validate_implementer_runner_local_first(
+            repo_root=REPO_ROOT,
+            current_pe_path=current_pe,
+            plan_path=plan,
+        )
+        == []
+    )
+
+
+def test_implementer_runner_check_reports_missing_plan_section(tmp_path):
+    current_pe = tmp_path / "CURRENT_PE.md"
+    plan = tmp_path / "ELIS_MultiAgent_Implementation_Plan_v1_9.md"
+    current_pe.write_text(CURRENT_PE_BODY, encoding="utf-8")
+    plan.write_text("# Wrong plan\n", encoding="utf-8")
+
+    errors = validate_implementer_runner_local_first(
+        repo_root=REPO_ROOT,
+        current_pe_path=current_pe,
+        plan_path=plan,
+    )
+
+    assert any("Could not find plan section for PE-SLR-11" in error for error in errors)
+
+
+def test_implementer_runner_check_requires_implementing_state(tmp_path):
+    current_pe = tmp_path / "CURRENT_PE.md"
+    plan = tmp_path / "ELIS_MultiAgent_Implementation_Plan_v1_9.md"
+    current_pe.write_text(
+        CURRENT_PE_BODY.replace("implementing", "gate-1-pending"),
+        encoding="utf-8",
+    )
+    plan.write_text(PLAN_BODY, encoding="utf-8")
+
+    errors = validate_implementer_runner_local_first(
+        repo_root=REPO_ROOT,
+        current_pe_path=current_pe,
+        plan_path=plan,
+    )
+
+    assert any(
+        "implementer dispatch requires an implementing PE" in error for error in errors
+    )


### PR DESCRIPTION
## Summary
- Confirm the implementer runner remains local-first on `[self-hosted, elis-server]` and reads `CURRENT_PE.md` plus the active plan before agent invocation.
- Reserve PR creation/readying for the runner and enforce a clean tree plus `HANDOFF.md` as the last commit before PR operations.
- Add `scripts/check_implementer_runner_local_first.py` and focused regression tests for PE-SLR-11.

## Test plan
- python scripts/check_current_pe.py
- python scripts/check_agent_scope.py
- python scripts/check_control_plane_wiring.py
- python scripts/check_implementer_runner_local_first.py
- python -m black --check --include "\.py$" elis scripts tests
- python -m ruff check elis scripts tests
- python -m pytest tests/test_implementer_runner_common.py tests/test_implementer_runner_local_first.py tests/test_dispatch_implementer_runner.py tests/test_control_plane_workflow_wiring.py -q -p no:cacheprovider
- python -m pytest tests -q --tb=short -p no:cacheprovider (local preflight: 2 unrelated Windows/Claude-auth failures)

## Handoff
- HANDOFF.md is committed as the final branch commit before PR creation (`f37131f`).