### PR TITLE
feat: standardize auth verifier output and guidance

### DIFF
--- a/CURRENT_PE.md
+++ b/CURRENT_PE.md
@@ -125,6 +125,7 @@
 | PE-SLR-13       | slr            | prog-impl-a          | prog-val-b         | feature/pe-slr-13-screening-lightweight-support-local-first-validation  | merged          | 2026-04-26   |
 | PE-SLR-14       | slr            | prog-impl-b          | prog-val-a         | feature/pe-slr-14-extraction-synthesis-off-host-contract-validation     | merged          | 2026-04-26   |
 | PE-SLR-15       | slr            | prog-impl-a          | prog-val-b         | feature/pe-slr-15-hybrid-slr-end-to-end-validation-and-housekeeping     | merged          | 2026-04-26   |
+| PE-AGT-00       | agt            | infra-impl-a         | infra-val-b        | feature/pe-agt-00-model-authentication-setup                            | implementing    | 2026-04-26   |
 
 Valid status values:
 - `planning`
@@ -214,6 +215,7 @@ PM housekeeping entries (prefix `PM-CHORE-XX`):
 | PM-CHORE-70  | Closed PE-SLR-15 as merged (PR #380, PASS verdict — Claude Code Validator). ELIS_MultiAgent_Implementation_Plan_v1_9.md complete — all 15 SLR PEs (PE-SLR-01 through PE-SLR-15) and infrastructure prerequisites (PE-INFRA-SLR-06 through PE-INFRA-SLR-08, PE-SLR-11, PE-SLR-12) merged. No active PE. Platform ready. Awaiting PM assignment of next plan. | 2026-04-26 |
 | PM-CHORE-71  | Adopted ELIS_MultiAgent_Implementation_Plan_v2_0.md (release v2.0.1). Opened PE-AGT-00 (Model Authentication Setup) with `infra-impl-a` (CODEX) as Implementer and `infra-val-b` (Claude Code) as Validator per PO directive. Implementer start is gated: PO must run Claude Code and Codex OAuth logins on elis-server and confirm `python scripts/verify_claude_auth.py` and `python scripts/verify_codex_auth.py` both exit 0 before branch work begins. | 2026-04-26 |
 | PE-AGT-00    | infra           | infra-impl-a         | infra-val-b        | feature/pe-agt-00-model-authentication-setup      | implementing    | 2026-04-26   |
+
 
 Alternation rule:
 - For consecutive PEs in the same domain, the implementer engine must alternate (`codex` <-> `claude`).

--- a/scripts/verify_claude_auth.py
+++ b/scripts/verify_claude_auth.py
@@ -1,94 +1,253 @@
 """
 verify_claude_auth.py — PE-AUTH-02
 
-Verifies that the Claude Code CLI is ready for headless runner use via
-CLAUDE_CREDENTIALS_JSON (written to ~/.claude/.credentials.json before
-this script runs).
+Verifies whether the Claude Code CLI is authenticated in the current environment.
+Primary mechanism: OAuth-backed CLAUDE_CREDENTIALS_JSON.
+Fallback mechanism: ANTHROPIC_API_KEY.
 
 Exit codes:
-    0 — claude CLI is available and credentials file is present
-    1 — required environment or CLI preconditions are missing
+    0 — valid OAuth or API key authentication
+    1 — invalid or missing authentication / CLI prerequisites
 
 Usage:
-    python scripts/verify_claude_auth.py
+    python scripts/verify_claude_auth.py [--json]
 
 Security rule §13: never prints credential values.
 """
 
+from __future__ import annotations
+
+import argparse
 import json
 import os
 import pathlib
 import shutil
 import subprocess
 import sys
+from dataclasses import dataclass, asdict
 
 
-def main() -> int:
+@dataclass
+class VerificationResult:
+    auth_mode: str
+    valid: bool
+    source: str
+    details: list[str]
+    next_step: str | None = None
+
+
+def _credentials_file() -> pathlib.Path:
+    return pathlib.Path.home() / ".claude" / ".credentials.json"
+
+
+def classify_auth() -> VerificationResult:
     credentials_json = os.environ.get("CLAUDE_CREDENTIALS_JSON", "")
-    if not credentials_json:
-        print(
-            "FAIL: CLAUDE_CREDENTIALS_JSON is not set in environment.", file=sys.stderr
-        )
-        print(
-            "Set it from the GitHub Secret before invoking this script.",
-            file=sys.stderr,
-        )
-        return 1
-    print(f"OK: CLAUDE_CREDENTIALS_JSON is set (length={len(credentials_json)})")
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    creds_path = _credentials_file()
 
-    creds_path = pathlib.Path.home() / ".claude" / ".credentials.json"
-    if not creds_path.exists():
-        print(
-            f"FAIL: credentials file not found at {creds_path}",
-            file=sys.stderr,
-        )
-        print(
-            "The 'Write Claude credentials file' step must run before this script.",
-            file=sys.stderr,
-        )
-        return 1
-    print(f"OK: credentials file exists at {creds_path}")
+    details: list[str] = []
 
-    try:
-        data = json.loads(creds_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        print(f"FAIL: credentials file is not valid JSON: {exc}", file=sys.stderr)
-        return 1
-
-    if "claudeAiOauth" not in data:
-        print(
-            "FAIL: credentials file missing 'claudeAiOauth' key.",
-            file=sys.stderr,
+    # Primary path: OAuth-backed credentials file injected from the secret.
+    if credentials_json:
+        details.append(
+            f"CLAUDE_CREDENTIALS_JSON env present (length={len(credentials_json)})"
         )
-        return 1
-    print("OK: credentials file contains claudeAiOauth entry")
+        if creds_path.exists():
+            try:
+                data = json.loads(creds_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                if api_key:
+                    return VerificationResult(
+                        auth_mode="api_key",
+                        valid=True,
+                        source="env:ANTHROPIC_API_KEY",
+                        details=[
+                            f"primary OAuth file unreadable: {exc}",
+                            f"ANTHROPIC_API_KEY env present (length={len(api_key)})",
+                        ],
+                    )
+                return VerificationResult(
+                    auth_mode="invalid",
+                    valid=False,
+                    source=str(creds_path),
+                    details=[f"credentials file unreadable: {exc}"],
+                    next_step=(
+                        "Ask PO to run 'claude setup-token' on a machine with browser access "
+                        "(or otherwise refresh Claude Code credentials) and then update "
+                        "CLAUDE_CREDENTIALS_JSON from the secret source; or set "
+                        "ANTHROPIC_API_KEY as the fallback."
+                    ),
+                )
 
+            if "claudeAiOauth" in data:
+                if api_key:
+                    details.append("ANTHROPIC_API_KEY fallback present: yes")
+                details.append(f"credentials file: {creds_path}")
+                details.append("claudeAiOauth entry present: yes")
+                return VerificationResult(
+                    auth_mode="oauth",
+                    valid=True,
+                    source=str(creds_path),
+                    details=details,
+                )
+
+            if api_key:
+                return VerificationResult(
+                    auth_mode="api_key",
+                    valid=True,
+                    source="env:ANTHROPIC_API_KEY",
+                    details=[
+                        f"credentials file missing claudeAiOauth: {creds_path}",
+                        f"ANTHROPIC_API_KEY env present (length={len(api_key)})",
+                    ],
+                )
+
+            return VerificationResult(
+                auth_mode="invalid",
+                valid=False,
+                source=str(creds_path),
+                details=["credentials file missing 'claudeAiOauth' key."],
+                next_step=(
+                    "Ask PO to run 'claude setup-token' on a machine with browser access "
+                    "(or otherwise refresh Claude Code credentials) and then update "
+                    "CLAUDE_CREDENTIALS_JSON from the secret source; or set "
+                    "ANTHROPIC_API_KEY as the fallback."
+                ),
+            )
+
+        if api_key:
+            return VerificationResult(
+                auth_mode="api_key",
+                valid=True,
+                source="env:ANTHROPIC_API_KEY",
+                details=[
+                    "OAuth credentials file not found, but fallback API key is present.",
+                    f"ANTHROPIC_API_KEY env present (length={len(api_key)})",
+                ],
+            )
+
+        return VerificationResult(
+            auth_mode="invalid",
+            valid=False,
+            source=str(creds_path),
+            details=[
+                "CLAUDE_CREDENTIALS_JSON is set but ~/.claude/.credentials.json is missing.",
+            ],
+            next_step=(
+                "Ask PO to refresh CLAUDE_CREDENTIALS_JSON from the secret source "
+                "or set ANTHROPIC_API_KEY as the fallback."
+            ),
+        )
+
+    # Fallback path: API key authentication.
+    if api_key:
+        return VerificationResult(
+            auth_mode="api_key",
+            valid=True,
+            source="env:ANTHROPIC_API_KEY",
+            details=[f"ANTHROPIC_API_KEY env present (length={len(api_key)})"],
+        )
+
+    return VerificationResult(
+        auth_mode="invalid",
+        valid=False,
+        source="missing",
+        details=["CLAUDE_CREDENTIALS_JSON is not set in environment."],
+        next_step=(
+            "Ask PO to run 'claude setup-token' on a machine with browser access "
+            "(or otherwise refresh Claude Code credentials) and then update "
+            "CLAUDE_CREDENTIALS_JSON from the secret source; or set "
+            "ANTHROPIC_API_KEY as the fallback."
+        ),
+    )
+
+
+def verify_claude_cli(details: list[str]) -> tuple[bool, str | None]:
     claude_path = shutil.which("claude")
     if claude_path is None:
-        print("FAIL: 'claude' CLI not found on PATH.", file=sys.stderr)
-        print(
-            "Install Claude Code with the official Anthropic installer before retrying.",
-            file=sys.stderr,
+        details.append("FAIL: 'claude' CLI not found on PATH.")
+        details.append(
+            "Install Claude Code with the official Anthropic installer before retrying."
         )
-        return 1
-    print(f"OK: claude CLI found at {claude_path}")
+        return False, None
 
+    details.append(f"claude CLI: {claude_path}")
     result = subprocess.run(
         ["claude", "--version"],
         capture_output=True,
         text=True,
         timeout=15,
+        check=False,
     )
     if result.returncode != 0:
-        print(f"FAIL: 'claude --version' exited {result.returncode}", file=sys.stderr)
-        print(result.stderr, file=sys.stderr)
-        return 1
+        details.append(f"FAIL: 'claude --version' exited {result.returncode}")
+        stderr = result.stderr.strip()
+        if stderr:
+            details.append(stderr)
+        return False, None
 
-    version = result.stdout.strip() or result.stderr.strip()
-    print(f"OK: claude --version -> {version}")
-    print()
-    print("claude auth verification PASS")
-    return 0
+    version = result.stdout.strip() or result.stderr.strip() or "<unknown>"
+    details.append(f"claude --version: {version}")
+    return True, version
+
+
+def render_text(
+    result: VerificationResult, cli_ok: bool, cli_version: str | None
+) -> str:
+    lines: list[str] = []
+    if result.valid and cli_ok:
+        lines.append(
+            "RESULT: Valid OAuth authentication"
+            if result.auth_mode == "oauth"
+            else "RESULT: Valid API Key authentication"
+        )
+    else:
+        lines.append("RESULT: Invalid authentication")
+
+    lines.append(f"AUTH MODE: {result.auth_mode}")
+    lines.append(f"SOURCE: {result.source}")
+    if cli_version is not None:
+        lines.append(f"CLI VERSION: {cli_version}")
+    for detail in result.details:
+        lines.append(detail)
+    if result.valid and cli_ok:
+        lines.append("NEXT STEP: none")
+    elif result.next_step:
+        lines.append(f"NEXT STEP: {result.next_step}")
+    return "\n".join(lines) + "\n"
+
+
+def render_json(
+    result: VerificationResult, cli_ok: bool, cli_version: str | None
+) -> str:
+    payload = asdict(result)
+    payload["cli_ok"] = cli_ok
+    payload["cli_version"] = cli_version
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify Claude authentication state.")
+    parser.add_argument(
+        "--json", action="store_true", help="Print JSON instead of text output."
+    )
+    args = parser.parse_args(argv)
+
+    result = classify_auth()
+    cli_details: list[str] = []
+    cli_ok, cli_version = verify_claude_cli(cli_details)
+    result.details = cli_details + result.details
+
+    output = (
+        render_json(result, cli_ok, cli_version)
+        if args.json
+        else render_text(result, cli_ok, cli_version)
+    )
+    sys.stdout.write(output)
+
+    if result.valid and cli_ok:
+        return 0
+    return 1
 
 
 if __name__ == "__main__":

--- a/scripts/verify_codex_auth.py
+++ b/scripts/verify_codex_auth.py
@@ -1,62 +1,221 @@
 """
 verify_codex_auth.py — PE-AUTH-01
 
-Verifies that the Codex CLI is authenticated in the current environment.
-Intended for use in GitHub Actions runners after OPENAI_API_KEY is injected.
+Verifies whether the Codex CLI is authenticated in the current environment.
+Primary mechanism: OAuth-backed auth.json.
+Fallback mechanism: OPENAI_API_KEY.
 
 Exit codes:
-    0 — codex is available and authenticated
-    1 — codex CLI not found or not authenticated
+    0 — valid OAuth or API key authentication
+    1 — invalid or missing authentication / CLI prerequisites
 
 Usage:
-    python scripts/verify_codex_auth.py
+    python scripts/verify_codex_auth.py [--json]
 
 Security rule §13: never prints token values.
 """
 
+from __future__ import annotations
+
+import argparse
+import json
 import os
+import pathlib
 import shutil
 import subprocess
 import sys
+from dataclasses import dataclass, asdict
 
 
-def main() -> int:
-    # Check OPENAI_API_KEY is set (existence only — never print value)
+@dataclass
+class VerificationResult:
+    auth_mode: str
+    valid: bool
+    source: str
+    details: list[str]
+    next_step: str | None = None
+
+
+def find_auth_file() -> pathlib.Path | None:
+    candidates = [
+        pathlib.Path.home() / ".codex" / "auth.json",
+        pathlib.Path.home() / ".config" / "openai" / "auth.json",
+    ]
+    for path in candidates:
+        if path.exists():
+            return path
+    return None
+
+
+def classify_auth() -> VerificationResult:
+    auth_file = find_auth_file()
     api_key = os.environ.get("OPENAI_API_KEY", "")
-    if not api_key:
-        print("FAIL: OPENAI_API_KEY is not set in environment.", file=sys.stderr)
-        print(
-            "Set it from the GitHub Secret before invoking this script.",
-            file=sys.stderr,
-        )
-        return 1
-    print(f"OK: OPENAI_API_KEY is set (length={len(api_key)})")
 
-    # Check codex CLI is on PATH
+    details: list[str] = []
+    source = "missing"
+
+    if auth_file is not None:
+        try:
+            data = json.loads(auth_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            return VerificationResult(
+                auth_mode="invalid",
+                valid=False,
+                source=str(auth_file),
+                details=[f"credentials file unreadable: {exc}"],
+                next_step="Ask PO to re-run 'codex auth login' on a terminal with browser access.",
+            )
+
+        auth_mode = str(data.get("auth_mode", "")).strip().lower()
+        tokens = data.get("tokens")
+        has_refresh_token = isinstance(tokens, dict) and bool(
+            tokens.get("refresh_token")
+        )
+        has_access_token = isinstance(tokens, dict) and bool(tokens.get("access_token"))
+        has_top_level_api_key = bool(data.get("OPENAI_API_KEY"))
+
+        if auth_mode in {"chatgpt", "oauth"} or has_refresh_token or has_access_token:
+            details.append(f"auth.json location: {auth_file}")
+            if auth_mode:
+                details.append(f"auth_mode: {auth_mode}")
+            if has_refresh_token:
+                details.append("refresh_token present: yes")
+            if has_access_token:
+                details.append("access_token present: yes")
+            if has_top_level_api_key:
+                details.append("OPENAI_API_KEY field present: yes")
+            if api_key:
+                details.append("OPENAI_API_KEY env fallback present: yes")
+            return VerificationResult(
+                auth_mode="oauth",
+                valid=True,
+                source=str(auth_file),
+                details=details,
+            )
+
+        if auth_mode in {"apikey", "api_key"} or has_top_level_api_key or api_key:
+            details.append(f"auth.json location: {auth_file}")
+            if auth_mode:
+                details.append(f"auth_mode: {auth_mode}")
+            if has_top_level_api_key:
+                details.append("OPENAI_API_KEY field present: yes")
+            if api_key:
+                details.append("OPENAI_API_KEY env fallback present: yes")
+            return VerificationResult(
+                auth_mode="api_key",
+                valid=True,
+                source=str(auth_file) if auth_file else "env:OPENAI_API_KEY",
+                details=details,
+            )
+
+        details.append(f"auth.json location: {auth_file}")
+        details.append("No supported auth markers found in auth.json")
+        source = str(auth_file)
+    elif api_key:
+        return VerificationResult(
+            auth_mode="api_key",
+            valid=True,
+            source="env:OPENAI_API_KEY",
+            details=[f"OPENAI_API_KEY env present (length={len(api_key)})"],
+        )
+    else:
+        details.append("auth.json not found")
+
+    return VerificationResult(
+        auth_mode="invalid",
+        valid=False,
+        source=source,
+        details=details,
+        next_step="Ask PO to run 'codex auth login' on a machine with browser access, or set OPENAI_API_KEY as the fallback.",
+    )
+
+
+def verify_codex_cli(details: list[str]) -> tuple[bool, str | None]:
     codex_path = shutil.which("codex")
     if codex_path is None:
-        print("FAIL: 'codex' CLI not found on PATH.", file=sys.stderr)
-        print("Install with: npm install -g @openai/codex", file=sys.stderr)
-        return 1
-    print(f"OK: codex CLI found at {codex_path}")
+        details.append("FAIL: 'codex' CLI not found on PATH.")
+        details.append("Install with: npm install -g @openai/codex")
+        return False, None
 
-    # Run codex --version as a smoke-test (no auth required, confirms binary works)
+    details.append(f"codex CLI: {codex_path}")
     result = subprocess.run(
         ["codex", "--version"],
         capture_output=True,
         text=True,
         timeout=15,
+        check=False,
     )
     if result.returncode != 0:
-        print(f"FAIL: 'codex --version' exited {result.returncode}", file=sys.stderr)
-        print(result.stderr, file=sys.stderr)
-        return 1
-    version = result.stdout.strip() or result.stderr.strip()
-    print(f"OK: codex --version → {version}")
+        details.append(f"FAIL: 'codex --version' exited {result.returncode}")
+        stderr = result.stderr.strip()
+        if stderr:
+            details.append(stderr)
+        return False, None
 
-    print()
-    print("codex auth verification PASS")
-    return 0
+    version = result.stdout.strip() or result.stderr.strip() or "<unknown>"
+    details.append(f"codex --version: {version}")
+    return True, version
+
+
+def render_text(
+    result: VerificationResult, cli_ok: bool, cli_version: str | None
+) -> str:
+    lines: list[str] = []
+    if result.valid and cli_ok:
+        lines.append(
+            "RESULT: Valid OAuth authentication"
+            if result.auth_mode == "oauth"
+            else "RESULT: Valid API Key authentication"
+        )
+    elif result.valid and not cli_ok:
+        lines.append("RESULT: Invalid authentication")
+    else:
+        lines.append("RESULT: Invalid authentication")
+
+    lines.append(f"AUTH MODE: {result.auth_mode}")
+    lines.append(f"SOURCE: {result.source}")
+    if cli_version is not None:
+        lines.append(f"CLI VERSION: {cli_version}")
+    for detail in result.details:
+        lines.append(detail)
+    if result.valid and cli_ok:
+        lines.append("NEXT STEP: none")
+    elif result.next_step:
+        lines.append(f"NEXT STEP: {result.next_step}")
+    return "\n".join(lines) + "\n"
+
+
+def render_json(
+    result: VerificationResult, cli_ok: bool, cli_version: str | None
+) -> str:
+    payload = asdict(result)
+    payload["cli_ok"] = cli_ok
+    payload["cli_version"] = cli_version
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify Codex authentication state.")
+    parser.add_argument(
+        "--json", action="store_true", help="Print JSON instead of text output."
+    )
+    args = parser.parse_args(argv)
+
+    result = classify_auth()
+    cli_details: list[str] = []
+    cli_ok, cli_version = verify_codex_cli(cli_details)
+    result.details = cli_details + result.details
+
+    output = (
+        render_json(result, cli_ok, cli_version)
+        if args.json
+        else render_text(result, cli_ok, cli_version)
+    )
+    sys.stdout.write(output)
+
+    if result.valid and cli_ok:
+        return 0
+    return 1
 
 
 if __name__ == "__main__":

--- a/tests/test_verify_claude_auth.py
+++ b/tests/test_verify_claude_auth.py
@@ -6,7 +6,7 @@ import subprocess
 from scripts import verify_claude_auth
 
 
-def _write_credentials_file(tmp_path, monkeypatch, payload=None):
+def _prepare_oauth_credentials(tmp_path, monkeypatch, payload=None):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("CLAUDE_CREDENTIALS_JSON", '{"present": true}')
     creds_dir = tmp_path / ".claude"
@@ -17,65 +17,67 @@ def _write_credentials_file(tmp_path, monkeypatch, payload=None):
     return creds_path
 
 
-def test_fails_when_credentials_env_missing(monkeypatch, capsys):
-    monkeypatch.delenv("CLAUDE_CREDENTIALS_JSON", raising=False)
-
-    assert verify_claude_auth.main() == 1
-    captured = capsys.readouterr()
-    assert "CLAUDE_CREDENTIALS_JSON is not set" in captured.err
-
-
-def test_fails_when_credentials_file_missing(tmp_path, monkeypatch, capsys):
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("CLAUDE_CREDENTIALS_JSON", '{"present": true}')
-
-    assert verify_claude_auth.main() == 1
-    captured = capsys.readouterr()
-    assert "credentials file not found" in captured.err
-
-
-def test_fails_when_credentials_file_lacks_oauth_key(tmp_path, monkeypatch, capsys):
-    _write_credentials_file(tmp_path, monkeypatch, payload={"unexpected": True})
-
-    assert verify_claude_auth.main() == 1
-    captured = capsys.readouterr()
-    assert "missing 'claudeAiOauth' key" in captured.err
-
-
-def test_fails_when_claude_missing(tmp_path, monkeypatch, capsys):
-    _write_credentials_file(tmp_path, monkeypatch)
-    monkeypatch.setattr(verify_claude_auth.shutil, "which", lambda _cmd: None)
-
-    assert verify_claude_auth.main() == 1
-    captured = capsys.readouterr()
-    assert "'claude' CLI not found on PATH." in captured.err
-
-
-def test_fails_when_claude_version_command_fails(tmp_path, monkeypatch, capsys):
-    _write_credentials_file(tmp_path, monkeypatch)
+def _patch_claude_cli(monkeypatch, returncode=0, stdout="1.2.3", stderr=""):
     monkeypatch.setattr(
-        verify_claude_auth.shutil, "which", lambda _cmd: "/usr/local/bin/claude"
+        verify_claude_auth.shutil,
+        "which",
+        lambda _cmd: "/usr/local/bin/claude",
     )
     monkeypatch.setattr(
         verify_claude_auth.subprocess,
         "run",
         lambda *_args, **_kwargs: subprocess.CompletedProcess(
             args=["claude", "--version"],
-            returncode=1,
-            stdout="",
-            stderr="boom",
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
         ),
     )
 
-    assert verify_claude_auth.main() == 1
+
+def test_invalid_when_credentials_env_missing(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_JSON", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(verify_claude_auth.shutil, "which", lambda _cmd: None)
+
+    assert verify_claude_auth.main([]) == 1
     captured = capsys.readouterr()
-    assert "'claude --version' exited 1" in captured.err
+    combined = captured.out + captured.err
+    assert "RESULT: Invalid authentication" in combined
+    assert "claude setup-token" in combined
 
 
-def test_passes_without_leaking_credentials_json(tmp_path, monkeypatch, capsys):
-    credentials_json = '{"accessToken":"sk-ant-st-secret-value"}'
-    _write_credentials_file(tmp_path, monkeypatch)
-    monkeypatch.setenv("CLAUDE_CREDENTIALS_JSON", credentials_json)
+def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):
+    _prepare_oauth_credentials(tmp_path, monkeypatch)
+    _patch_claude_cli(monkeypatch)
+
+    assert verify_claude_auth.main([]) == 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "RESULT: Valid OAuth authentication" in combined
+    assert "claudeAiOauth entry present: yes" in combined
+
+
+def test_valid_api_key_fallback_when_oauth_missing(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_JSON", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _patch_claude_cli(monkeypatch)
+
+    assert verify_claude_auth.main([]) == 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "RESULT: Valid API Key authentication" in combined
+    assert "ANTHROPIC_API_KEY env present" in combined
+
+
+def test_invalid_when_credentials_file_missing_and_no_fallback(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_CREDENTIALS_JSON", '{"present": true}')
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.setattr(
         verify_claude_auth.shutil, "which", lambda _cmd: "/usr/local/bin/claude"
     )
@@ -90,9 +92,36 @@ def test_passes_without_leaking_credentials_json(tmp_path, monkeypatch, capsys):
         ),
     )
 
-    assert verify_claude_auth.main() == 0
+    assert verify_claude_auth.main([]) == 1
     captured = capsys.readouterr()
     combined = captured.out + captured.err
-    assert "claude auth verification PASS" in combined
+    assert "RESULT: Invalid authentication" in combined
+    assert (
+        "CLAUDE_CREDENTIALS_JSON is set but ~/.claude/.credentials.json is missing."
+        in combined
+    )
+
+
+def test_fails_when_claude_version_command_fails(tmp_path, monkeypatch, capsys):
+    _prepare_oauth_credentials(tmp_path, monkeypatch)
+    _patch_claude_cli(monkeypatch, returncode=1, stdout="", stderr="boom")
+
+    assert verify_claude_auth.main([]) == 1
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "RESULT: Invalid authentication" in combined
+    assert "'claude --version' exited 1" in combined
+
+
+def test_passes_without_leaking_credentials_json(tmp_path, monkeypatch, capsys):
+    credentials_json = '{"accessToken":"sk-ant...alue"}'
+    _prepare_oauth_credentials(tmp_path, monkeypatch)
+    monkeypatch.setenv("CLAUDE_CREDENTIALS_JSON", credentials_json)
+    _patch_claude_cli(monkeypatch)
+
+    assert verify_claude_auth.main([]) == 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "RESULT: Valid OAuth authentication" in combined
     assert "length=" in combined
     assert credentials_json not in combined

--- a/tests/test_verify_codex_auth.py
+++ b/tests/test_verify_codex_auth.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+from scripts import verify_codex_auth
+
+
+def _prepare_oauth_auth_file(tmp_path, monkeypatch, payload=None):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    auth_dir = tmp_path / ".codex"
+    auth_dir.mkdir()
+    auth_path = auth_dir / "auth.json"
+    data = (
+        payload
+        if payload is not None
+        else {
+            "auth_mode": "chatgpt",
+            "tokens": {"refresh_token": "refresh-x", "access_token": "access-x"},
+        }
+    )
+    auth_path.write_text(json.dumps(data), encoding="utf-8")
+    return auth_path
+
+
+def _patch_codex_cli(monkeypatch, returncode=0, stdout="0.0.0", stderr=""):
+    monkeypatch.setattr(
+        verify_codex_auth.shutil,
+        "which",
+        lambda _cmd: "/usr/local/bin/codex",
+    )
+    monkeypatch.setattr(
+        verify_codex_auth.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["codex", "--version"],
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+        ),
+    )
+
+
+def test_invalid_when_no_credentials(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(verify_codex_auth.shutil, "which", lambda _cmd: None)
+
+    assert verify_codex_auth.main([]) == 1
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "RESULT: Invalid authentication" in combined
+    assert "auth.json not found" in combined
+
+
+def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):
+    _prepare_oauth_auth_file(tmp_path, monkeypatch)
+    _patch_codex_cli(monkeypatch)
+
+    assert verify_codex_auth.main([]) == 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "RESULT: Valid OAuth authentication" in combined
+    assert "auth_mode: chatgpt" in combined
+    assert "refresh_token present: yes" in combined
+
+
+def test_valid_api_key_fallback_when_oauth_missing(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-test-key")
+    _patch_codex_cli(monkeypatch)
+
+    assert verify_codex_auth.main([]) == 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "RESULT: Valid API Key authentication" in combined
+    assert "OPENAI_API_KEY env present" in combined
+
+
+def test_invalid_when_cli_version_command_fails(tmp_path, monkeypatch, capsys):
+    _prepare_oauth_auth_file(tmp_path, monkeypatch)
+    _patch_codex_cli(monkeypatch, returncode=1, stdout="", stderr="boom")
+
+    assert verify_codex_auth.main([]) == 1
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "RESULT: Invalid authentication" in combined
+    assert "'codex --version' exited 1" in combined
+
+
+def test_passes_without_leaking_api_key(tmp_path, monkeypatch, capsys):
+    api_key = "sk-openai-secret-value"
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", api_key)
+    _patch_codex_cli(monkeypatch)
+
+    assert verify_codex_auth.main([]) == 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "RESULT: Valid API Key authentication" in combined
+    assert "length=" in combined
+    assert api_key not in combined


### PR DESCRIPTION
## Summary\n- Normalize auth verifier outputs to Valid OAuth / Valid API Key / Invalid authentication\n- Add next-step guidance for Codex and Claude when OAuth is missing\n- Add coverage for both verifiers and the new Claude guidance\n\n## Verification\n- python -m pytest -q tests/test_verify_claude_auth.py tests/test_verify_codex_auth.py\n- python -m black --check scripts/verify_claude_auth.py scripts/verify_codex_auth.py tests/test_verify_claude_auth.py tests/test_verify_codex_auth.py\n- python -m ruff check scripts/verify_claude_auth.py scripts/verify_codex_auth.py tests/test_verify_claude_auth.py tests/test_verify_codex_auth.py