### PR TITLE
feat(auth): prefer OAuth login guidance

### DIFF
--- a/scripts/verify_claude_auth.py
+++ b/scripts/verify_claude_auth.py
@@ -73,9 +73,8 @@ def classify_auth() -> VerificationResult:
                     details=[f"credentials file unreadable: {exc}"],
                     next_step=(
                         "Ask PO to run 'claude setup-token' on a machine with browser access "
-                        "(or otherwise refresh Claude Code credentials) and then update "
-                        "CLAUDE_CREDENTIALS_JSON from the secret source; or set "
-                        "ANTHROPIC_API_KEY as the fallback."
+                        "and then update CLAUDE_CREDENTIALS_JSON from the secret source; "
+                        "or set ANTHROPIC_API_KEY as the fallback."
                     ),
                 )
 
@@ -109,9 +108,8 @@ def classify_auth() -> VerificationResult:
                 details=["credentials file missing 'claudeAiOauth' key."],
                 next_step=(
                     "Ask PO to run 'claude setup-token' on a machine with browser access "
-                    "(or otherwise refresh Claude Code credentials) and then update "
-                    "CLAUDE_CREDENTIALS_JSON from the secret source; or set "
-                    "ANTHROPIC_API_KEY as the fallback."
+                    "and then update CLAUDE_CREDENTIALS_JSON from the secret source; "
+                    "or set ANTHROPIC_API_KEY as the fallback."
                 ),
             )
 
@@ -155,8 +153,7 @@ def classify_auth() -> VerificationResult:
         details=["CLAUDE_CREDENTIALS_JSON is not set in environment."],
         next_step=(
             "Ask PO to run 'claude setup-token' on a machine with browser access "
-            "(or otherwise refresh Claude Code credentials) and then update "
-            "CLAUDE_CREDENTIALS_JSON from the secret source; or set "
+            "and then update CLAUDE_CREDENTIALS_JSON from the secret source; or set "
             "ANTHROPIC_API_KEY as the fallback."
         ),
     )
@@ -166,9 +163,7 @@ def verify_claude_cli(details: list[str]) -> tuple[bool, str | None]:
     claude_path = shutil.which("claude")
     if claude_path is None:
         details.append("FAIL: 'claude' CLI not found on PATH.")
-        details.append(
-            "Install Claude Code with the official Anthropic installer before retrying."
-        )
+        details.append("Run 'claude setup-token' on a machine with browser access.")
         return False, None
 
     details.append(f"claude CLI: {claude_path}")

--- a/scripts/verify_codex_auth.py
+++ b/scripts/verify_codex_auth.py
@@ -63,7 +63,7 @@ def classify_auth() -> VerificationResult:
                 valid=False,
                 source=str(auth_file),
                 details=[f"credentials file unreadable: {exc}"],
-                next_step="Ask PO to re-run 'codex auth login' on a terminal with browser access.",
+                next_step="Ask PO to run 'codex auth login' on a terminal with browser access.",
             )
 
         auth_mode = str(data.get("auth_mode", "")).strip().lower()
@@ -134,7 +134,7 @@ def verify_codex_cli(details: list[str]) -> tuple[bool, str | None]:
     codex_path = shutil.which("codex")
     if codex_path is None:
         details.append("FAIL: 'codex' CLI not found on PATH.")
-        details.append("Install with: npm install -g @openai/codex")
+        details.append("Run 'codex auth login' on a terminal with browser access.")
         return False, None
 
     details.append(f"codex CLI: {codex_path}")

--- a/tests/test_verify_claude_auth.py
+++ b/tests/test_verify_claude_auth.py
@@ -46,6 +46,7 @@ def test_invalid_when_credentials_env_missing(tmp_path, monkeypatch, capsys):
     combined = captured.out + captured.err
     assert "RESULT: Invalid authentication" in combined
     assert "claude setup-token" in combined
+    assert "Install Claude Code" not in combined
 
 
 def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):

--- a/tests/test_verify_codex_auth.py
+++ b/tests/test_verify_codex_auth.py
@@ -50,7 +50,8 @@ def test_invalid_when_no_credentials(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert "RESULT: Invalid authentication" in combined
-    assert "auth.json not found" in combined
+    assert "Run 'codex auth login'" in combined
+    assert "npm install -g @openai/codex" not in combined
 
 
 def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
Updates the auth verifiers to point operators at OAuth login flows instead of installer commands.

Changes:
- Claude verifier now asks for `claude setup-token` on a machine with browser access
- Codex verifier now asks for `codex auth login` on a terminal with browser access
- Tests updated to assert the installer strings are absent

Verification:
- python -m pytest -q tests/test_verify_claude_auth.py tests/test_verify_codex_auth.py
- python -m py_compile scripts/verify_claude_auth.py scripts/verify_codex_auth.py