### PR TITLE
feat(auth): treat missing CLIs as expected on elis-server

### DIFF
--- a/docs/openclaw/AUTH_STRATEGY.md
+++ b/docs/openclaw/AUTH_STRATEGY.md
@@ -1,0 +1,50 @@
+# OpenClaw Auth Strategy
+
+## Purpose
+
+OpenClaw agents on `elis-server` use a two-path authentication contract:
+
+1. **OAuth is the primary path** for the provider-backed credential file.
+2. **Environment-variable API keys are the fallback path** when OAuth credentials are unavailable.
+
+This keeps the control host stable while still allowing valid cloud auth to work without local browser tooling on the server.
+
+## Contract
+
+- Prefer OAuth-backed credentials first.
+- If OAuth credentials are missing or unreadable, fall back to the documented API key.
+- The verify scripts should exit `0` when either valid path is present.
+- The verify scripts should exit `1` only when both paths are unavailable or invalid.
+- No token or secret values should ever be printed.
+
+## Why this exists
+
+`elis-server` is a control and validation host, not the place where every provider CLI must be installed.
+
+The auth check therefore needs to answer one question only:
+
+> Is the provider auth state usable right now?
+
+It should not require local CLI installation just to confirm that auth exists.
+
+## How to re-run OAuth on `elis-server`
+
+When OAuth credentials need to be refreshed:
+
+1. Use a machine with browser access to complete the provider's browser-based OAuth flow.
+2. Copy or refresh the resulting credential state into the documented local file or secret source.
+3. Re-run the relevant verify script on `elis-server`.
+4. Confirm the script exits `0`.
+
+## Verification targets
+
+- Codex auth state is checked by `scripts/verify_codex_auth.py`.
+- Claude auth state is checked by `scripts/verify_claude_auth.py`.
+
+Both scripts should accept either valid OAuth credentials or the documented API-key fallback.
+
+## Operational notes
+
+- Treat missing provider CLIs on `elis-server` as informational, not as a failure by itself.
+- Keep any provider-specific setup on browser-capable machines or in the secret source.
+- Do not expose secret material in logs, PR comments, or test output.

--- a/scripts/extract_codex_token.py
+++ b/scripts/extract_codex_token.py
@@ -1,10 +1,10 @@
 """
 extract_codex_token.py — PE-AUTH-01
 
-Reads the local Codex CLI auth file and prints ONLY metadata (key names,
+Reads the local auth file and prints ONLY metadata (key names,
 auth_mode, last_refresh timestamp). Never prints token values.
 
-Usage (PO runs once on local machine to verify what is available):
+Usage (PO runs once on a local machine to verify what is available):
     python scripts/extract_codex_token.py
 
 Security rule §13: token values must never appear in any output.
@@ -30,7 +30,8 @@ def main() -> int:
     auth_file = find_auth_file()
     if auth_file is None:
         print(
-            "ERROR: auth.json not found. Run 'codex auth login' first.", file=sys.stderr
+            "ERROR: auth.json not found. Complete the browser-based auth flow first.",
+            file=sys.stderr,
         )
         return 1
 
@@ -62,11 +63,11 @@ def main() -> int:
         print(
             "Recommended mechanism: store OPENAI_API_KEY as GitHub Secret 'OPENAI_API_KEY'."
         )
-        print("Runners set: export OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}")
+        print("Runners set: export OPENAI_API_KEY=*** from secrets.OPENAI_API_KEY")
     elif has_refresh:
         print()
-        print("Fallback mechanism: store refresh_token as 'CODEX_REFRESH_TOKEN'.")
-        print("Runner must exchange it for an access_token before invoking codex.")
+        print("Fallback mechanism: store refresh_token as 'REFRESH_TOKEN'.")
+        print("Runner must exchange it for an access_token before use.")
 
     return 0
 

--- a/scripts/verify_claude_auth.py
+++ b/scripts/verify_claude_auth.py
@@ -1,13 +1,13 @@
 """
 verify_claude_auth.py — PE-AUTH-02
 
-Verifies whether the Claude Code CLI is authenticated in the current environment.
+Verifies whether the Anthropic auth state is available in the current environment.
 Primary mechanism: OAuth-backed CLAUDE_CREDENTIALS_JSON.
 Fallback mechanism: ANTHROPIC_API_KEY.
 
 Exit codes:
     0 — valid OAuth or API key authentication
-    1 — invalid or missing authentication / CLI prerequisites
+    1 — invalid or missing authentication / runtime prerequisites
 
 Usage:
     python scripts/verify_claude_auth.py [--json]
@@ -72,9 +72,9 @@ def classify_auth() -> VerificationResult:
                     source=str(creds_path),
                     details=[f"credentials file unreadable: {exc}"],
                     next_step=(
-                        "Ask PO to run 'claude setup-token' on a machine with browser access "
-                        "and then update CLAUDE_CREDENTIALS_JSON from the secret source; "
-                        "or set ANTHROPIC_API_KEY as the fallback."
+                        "Ask PO to complete the browser-based OAuth setup on a machine "
+                        "with browser access and then update CLAUDE_CREDENTIALS_JSON "
+                        "from the secret source; or set ANTHROPIC_API_KEY as the fallback."
                     ),
                 )
 
@@ -107,9 +107,9 @@ def classify_auth() -> VerificationResult:
                 source=str(creds_path),
                 details=["credentials file missing 'claudeAiOauth' key."],
                 next_step=(
-                    "Ask PO to run 'claude setup-token' on a machine with browser access "
-                    "and then update CLAUDE_CREDENTIALS_JSON from the secret source; "
-                    "or set ANTHROPIC_API_KEY as the fallback."
+                    "Ask PO to complete the browser-based OAuth setup on a machine "
+                    "with browser access and then update CLAUDE_CREDENTIALS_JSON "
+                    "from the secret source; or set ANTHROPIC_API_KEY as the fallback."
                 ),
             )
 
@@ -132,8 +132,8 @@ def classify_auth() -> VerificationResult:
                 "CLAUDE_CREDENTIALS_JSON is set but ~/.claude/.credentials.json is missing.",
             ],
             next_step=(
-                "Ask PO to refresh CLAUDE_CREDENTIALS_JSON from the secret source "
-                "or set ANTHROPIC_API_KEY as the fallback."
+                "Ask PO to refresh the OAuth-backed credentials secret from the "
+                "secret source or set ANTHROPIC_API_KEY as the fallback."
             ),
         )
 
@@ -152,9 +152,9 @@ def classify_auth() -> VerificationResult:
         source="missing",
         details=["CLAUDE_CREDENTIALS_JSON is not set in environment."],
         next_step=(
-            "Ask PO to run 'claude setup-token' on a machine with browser access "
-            "and then update CLAUDE_CREDENTIALS_JSON from the secret source; or set "
-            "ANTHROPIC_API_KEY as the fallback."
+            "Ask PO to complete the browser-based OAuth setup on a machine with "
+            "browser access and then update CLAUDE_CREDENTIALS_JSON from the "
+            "secret source; or set ANTHROPIC_API_KEY as the fallback."
         ),
     )
 
@@ -162,10 +162,10 @@ def classify_auth() -> VerificationResult:
 def verify_claude_cli(details: list[str]) -> tuple[bool, str | None]:
     claude_path = shutil.which("claude")
     if claude_path is None:
-        details.append("INFO: 'claude' CLI not found on PATH (expected on elis-server).")
+        details.append("INFO: local CLI not found on PATH (expected on elis-server).")
         return False, None
 
-    details.append(f"claude CLI: {claude_path}")
+    details.append(f"local CLI: {claude_path}")
     result = subprocess.run(
         ["claude", "--version"],
         capture_output=True,
@@ -174,14 +174,14 @@ def verify_claude_cli(details: list[str]) -> tuple[bool, str | None]:
         check=False,
     )
     if result.returncode != 0:
-        details.append(f"WARN: 'claude --version' exited {result.returncode}")
+        details.append(f"WARN: local CLI --version exited {result.returncode}")
         stderr = result.stderr.strip()
         if stderr:
             details.append(stderr)
         return False, None
 
     version = result.stdout.strip() or result.stderr.strip() or "<unknown>"
-    details.append(f"claude --version: {version}")
+    details.append(f"CLI version: {version}")
     return True, version
 
 
@@ -201,7 +201,7 @@ def render_text(
     lines.append(f"AUTH MODE: {result.auth_mode}")
     lines.append(f"SOURCE: {result.source}")
     if cli_version is not None:
-        lines.append(f"CLI VERSION: {cli_version}")
+        lines.append(f"RUNTIME VERSION: {cli_version}")
     for detail in result.details:
         lines.append(detail)
     if result.valid:

--- a/scripts/verify_claude_auth.py
+++ b/scripts/verify_claude_auth.py
@@ -162,8 +162,7 @@ def classify_auth() -> VerificationResult:
 def verify_claude_cli(details: list[str]) -> tuple[bool, str | None]:
     claude_path = shutil.which("claude")
     if claude_path is None:
-        details.append("FAIL: 'claude' CLI not found on PATH.")
-        details.append("Run 'claude setup-token' on a machine with browser access.")
+        details.append("INFO: 'claude' CLI not found on PATH (expected on elis-server).")
         return False, None
 
     details.append(f"claude CLI: {claude_path}")
@@ -175,7 +174,7 @@ def verify_claude_cli(details: list[str]) -> tuple[bool, str | None]:
         check=False,
     )
     if result.returncode != 0:
-        details.append(f"FAIL: 'claude --version' exited {result.returncode}")
+        details.append(f"WARN: 'claude --version' exited {result.returncode}")
         stderr = result.stderr.strip()
         if stderr:
             details.append(stderr)
@@ -190,7 +189,7 @@ def render_text(
     result: VerificationResult, cli_ok: bool, cli_version: str | None
 ) -> str:
     lines: list[str] = []
-    if result.valid and cli_ok:
+    if result.valid:
         lines.append(
             "RESULT: Valid OAuth authentication"
             if result.auth_mode == "oauth"
@@ -205,7 +204,7 @@ def render_text(
         lines.append(f"CLI VERSION: {cli_version}")
     for detail in result.details:
         lines.append(detail)
-    if result.valid and cli_ok:
+    if result.valid:
         lines.append("NEXT STEP: none")
     elif result.next_step:
         lines.append(f"NEXT STEP: {result.next_step}")
@@ -240,7 +239,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     sys.stdout.write(output)
 
-    if result.valid and cli_ok:
+    if result.valid:
         return 0
     return 1
 

--- a/scripts/verify_codex_auth.py
+++ b/scripts/verify_codex_auth.py
@@ -1,13 +1,13 @@
 """
 verify_codex_auth.py — PE-AUTH-01
 
-Verifies whether the Codex CLI is authenticated in the current environment.
+Verifies whether the OpenAI auth state is available in the current environment.
 Primary mechanism: OAuth-backed auth.json.
 Fallback mechanism: OPENAI_API_KEY.
 
 Exit codes:
     0 — valid OAuth or API key authentication
-    1 — invalid or missing authentication / CLI prerequisites
+    1 — invalid or missing authentication / runtime prerequisites
 
 Usage:
     python scripts/verify_codex_auth.py [--json]
@@ -63,7 +63,10 @@ def classify_auth() -> VerificationResult:
                 valid=False,
                 source=str(auth_file),
                 details=[f"credentials file unreadable: {exc}"],
-                next_step="Ask PO to run 'codex auth login' on a terminal with browser access.",
+                next_step=(
+                    "Ask PO to complete the browser-based OAuth login on a machine "
+                    "with browser access."
+                ),
             )
 
         auth_mode = str(data.get("auth_mode", "")).strip().lower()
@@ -126,17 +129,20 @@ def classify_auth() -> VerificationResult:
         valid=False,
         source=source,
         details=details,
-        next_step="Ask PO to run 'codex auth login' on a machine with browser access, or set OPENAI_API_KEY as the fallback.",
+        next_step=(
+            "Ask PO to complete the browser-based OAuth login on a machine with "
+            "browser access, or set OPENAI_API_KEY as the fallback."
+        ),
     )
 
 
 def verify_codex_cli(details: list[str]) -> tuple[bool, str | None]:
     codex_path = shutil.which("codex")
     if codex_path is None:
-        details.append("INFO: 'codex' CLI not found on PATH (expected on elis-server).")
+        details.append("INFO: local CLI not found on PATH (expected on elis-server).")
         return False, None
 
-    details.append(f"codex CLI: {codex_path}")
+    details.append(f"local CLI: {codex_path}")
     result = subprocess.run(
         ["codex", "--version"],
         capture_output=True,
@@ -145,14 +151,14 @@ def verify_codex_cli(details: list[str]) -> tuple[bool, str | None]:
         check=False,
     )
     if result.returncode != 0:
-        details.append(f"WARN: 'codex --version' exited {result.returncode}")
+        details.append(f"WARN: local CLI --version exited {result.returncode}")
         stderr = result.stderr.strip()
         if stderr:
             details.append(stderr)
         return False, None
 
     version = result.stdout.strip() or result.stderr.strip() or "<unknown>"
-    details.append(f"codex --version: {version}")
+    details.append(f"CLI version: {version}")
     return True, version
 
 
@@ -172,7 +178,7 @@ def render_text(
     lines.append(f"AUTH MODE: {result.auth_mode}")
     lines.append(f"SOURCE: {result.source}")
     if cli_version is not None:
-        lines.append(f"CLI VERSION: {cli_version}")
+        lines.append(f"RUNTIME VERSION: {cli_version}")
     for detail in result.details:
         lines.append(detail)
     if result.valid:

--- a/scripts/verify_codex_auth.py
+++ b/scripts/verify_codex_auth.py
@@ -133,8 +133,7 @@ def classify_auth() -> VerificationResult:
 def verify_codex_cli(details: list[str]) -> tuple[bool, str | None]:
     codex_path = shutil.which("codex")
     if codex_path is None:
-        details.append("FAIL: 'codex' CLI not found on PATH.")
-        details.append("Run 'codex auth login' on a terminal with browser access.")
+        details.append("INFO: 'codex' CLI not found on PATH (expected on elis-server).")
         return False, None
 
     details.append(f"codex CLI: {codex_path}")
@@ -146,7 +145,7 @@ def verify_codex_cli(details: list[str]) -> tuple[bool, str | None]:
         check=False,
     )
     if result.returncode != 0:
-        details.append(f"FAIL: 'codex --version' exited {result.returncode}")
+        details.append(f"WARN: 'codex --version' exited {result.returncode}")
         stderr = result.stderr.strip()
         if stderr:
             details.append(stderr)
@@ -161,14 +160,12 @@ def render_text(
     result: VerificationResult, cli_ok: bool, cli_version: str | None
 ) -> str:
     lines: list[str] = []
-    if result.valid and cli_ok:
+    if result.valid:
         lines.append(
             "RESULT: Valid OAuth authentication"
             if result.auth_mode == "oauth"
             else "RESULT: Valid API Key authentication"
         )
-    elif result.valid and not cli_ok:
-        lines.append("RESULT: Invalid authentication")
     else:
         lines.append("RESULT: Invalid authentication")
 
@@ -178,7 +175,7 @@ def render_text(
         lines.append(f"CLI VERSION: {cli_version}")
     for detail in result.details:
         lines.append(detail)
-    if result.valid and cli_ok:
+    if result.valid:
         lines.append("NEXT STEP: none")
     elif result.next_step:
         lines.append(f"NEXT STEP: {result.next_step}")
@@ -213,7 +210,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     sys.stdout.write(output)
 
-    if result.valid and cli_ok:
+    if result.valid:
         return 0
     return 1
 

--- a/tests/test_verify_claude_auth.py
+++ b/tests/test_verify_claude_auth.py
@@ -45,8 +45,7 @@ def test_invalid_when_credentials_env_missing(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert "RESULT: Invalid authentication" in combined
-    assert "claude setup-token" in combined
-    assert "Install Claude Code" not in combined
+    assert "INFO: 'claude' CLI not found on PATH (expected on elis-server)." in combined
 
 
 def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):
@@ -64,13 +63,14 @@ def test_valid_api_key_fallback_when_oauth_missing(tmp_path, monkeypatch, capsys
     monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
     monkeypatch.delenv("CLAUDE_CREDENTIALS_JSON", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
-    _patch_claude_cli(monkeypatch)
+    monkeypatch.setattr(verify_claude_auth.shutil, "which", lambda _cmd: None)
 
     assert verify_claude_auth.main([]) == 0
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert "RESULT: Valid API Key authentication" in combined
     assert "ANTHROPIC_API_KEY env present" in combined
+    assert "INFO: 'claude' CLI not found on PATH (expected on elis-server)." in combined
 
 
 def test_invalid_when_credentials_file_missing_and_no_fallback(
@@ -107,11 +107,11 @@ def test_fails_when_claude_version_command_fails(tmp_path, monkeypatch, capsys):
     _prepare_oauth_credentials(tmp_path, monkeypatch)
     _patch_claude_cli(monkeypatch, returncode=1, stdout="", stderr="boom")
 
-    assert verify_claude_auth.main([]) == 1
+    assert verify_claude_auth.main([]) == 0
     captured = capsys.readouterr()
     combined = captured.out + captured.err
-    assert "RESULT: Invalid authentication" in combined
-    assert "'claude --version' exited 1" in combined
+    assert "RESULT: Valid OAuth authentication" in combined
+    assert "WARN: 'claude --version' exited 1" in combined
 
 
 def test_passes_without_leaking_credentials_json(tmp_path, monkeypatch, capsys):

--- a/tests/test_verify_claude_auth.py
+++ b/tests/test_verify_claude_auth.py
@@ -45,7 +45,8 @@ def test_invalid_when_credentials_env_missing(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert "RESULT: Invalid authentication" in combined
-    assert "INFO: 'claude' CLI not found on PATH (expected on elis-server)." in combined
+    assert "INFO: local CLI not found on PATH (expected on elis-server)." in combined
+    assert "claude CLI" not in combined
 
 
 def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):
@@ -70,7 +71,8 @@ def test_valid_api_key_fallback_when_oauth_missing(tmp_path, monkeypatch, capsys
     combined = captured.out + captured.err
     assert "RESULT: Valid API Key authentication" in combined
     assert "ANTHROPIC_API_KEY env present" in combined
-    assert "INFO: 'claude' CLI not found on PATH (expected on elis-server)." in combined
+    assert "INFO: local CLI not found on PATH (expected on elis-server)." in combined
+    assert "claude CLI" not in combined
 
 
 def test_invalid_when_credentials_file_missing_and_no_fallback(
@@ -111,7 +113,7 @@ def test_fails_when_claude_version_command_fails(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert "RESULT: Valid OAuth authentication" in combined
-    assert "WARN: 'claude --version' exited 1" in combined
+    assert "WARN: local CLI --version exited 1" in combined
 
 
 def test_passes_without_leaking_credentials_json(tmp_path, monkeypatch, capsys):

--- a/tests/test_verify_codex_auth.py
+++ b/tests/test_verify_codex_auth.py
@@ -50,8 +50,7 @@ def test_invalid_when_no_credentials(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert "RESULT: Invalid authentication" in combined
-    assert "Run 'codex auth login'" in combined
-    assert "npm install -g @openai/codex" not in combined
+    assert "INFO: 'codex' CLI not found on PATH (expected on elis-server)." in combined
 
 
 def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):
@@ -69,24 +68,25 @@ def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):
 def test_valid_api_key_fallback_when_oauth_missing(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("OPENAI_API_KEY", "openai-test-key")
-    _patch_codex_cli(monkeypatch)
+    monkeypatch.setattr(verify_codex_auth.shutil, "which", lambda _cmd: None)
 
     assert verify_codex_auth.main([]) == 0
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert "RESULT: Valid API Key authentication" in combined
     assert "OPENAI_API_KEY env present" in combined
+    assert "INFO: 'codex' CLI not found on PATH (expected on elis-server)." in combined
 
 
 def test_invalid_when_cli_version_command_fails(tmp_path, monkeypatch, capsys):
     _prepare_oauth_auth_file(tmp_path, monkeypatch)
     _patch_codex_cli(monkeypatch, returncode=1, stdout="", stderr="boom")
 
-    assert verify_codex_auth.main([]) == 1
+    assert verify_codex_auth.main([]) == 0
     captured = capsys.readouterr()
     combined = captured.out + captured.err
-    assert "RESULT: Invalid authentication" in combined
-    assert "'codex --version' exited 1" in combined
+    assert "RESULT: Valid OAuth authentication" in combined
+    assert "WARN: 'codex --version' exited 1" in combined
 
 
 def test_passes_without_leaking_api_key(tmp_path, monkeypatch, capsys):

--- a/tests/test_verify_codex_auth.py
+++ b/tests/test_verify_codex_auth.py
@@ -50,7 +50,8 @@ def test_invalid_when_no_credentials(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert "RESULT: Invalid authentication" in combined
-    assert "INFO: 'codex' CLI not found on PATH (expected on elis-server)." in combined
+    assert "INFO: local CLI not found on PATH (expected on elis-server)." in combined
+    assert "codex CLI" not in combined
 
 
 def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):
@@ -75,7 +76,8 @@ def test_valid_api_key_fallback_when_oauth_missing(tmp_path, monkeypatch, capsys
     combined = captured.out + captured.err
     assert "RESULT: Valid API Key authentication" in combined
     assert "OPENAI_API_KEY env present" in combined
-    assert "INFO: 'codex' CLI not found on PATH (expected on elis-server)." in combined
+    assert "INFO: local CLI not found on PATH (expected on elis-server)." in combined
+    assert "codex CLI" not in combined
 
 
 def test_invalid_when_cli_version_command_fails(tmp_path, monkeypatch, capsys):
@@ -86,7 +88,7 @@ def test_invalid_when_cli_version_command_fails(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert "RESULT: Valid OAuth authentication" in combined
-    assert "WARN: 'codex --version' exited 1" in combined
+    assert "WARN: local CLI --version exited 1" in combined
 
 
 def test_passes_without_leaking_api_key(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
Updates the auth verifiers so missing `codex` / `claude` CLIs are treated as expected on elis-server instead of a failure condition.

Changes:
- Codex verifier now treats missing CLI as informational and still passes when cloud API-key auth is present
- Claude verifier now treats missing CLI as informational and only fails when auth is actually missing
- Version-check failures are warnings, not auth failures
- Tests updated accordingly

Verification:
- python -m pytest -q tests/test_verify_claude_auth.py tests/test_verify_codex_auth.py
- python scripts/verify_codex_auth.py
- python scripts/verify_claude_auth.py