### PR TITLE
feat(auth): prefer OAuth language in verifiers

### DIFF
--- a/scripts/verify_claude_auth.py
+++ b/scripts/verify_claude_auth.py
@@ -72,8 +72,8 @@ def classify_auth() -> VerificationResult:
                     source=str(creds_path),
                     details=[f"credentials file unreadable: {exc}"],
                     next_step=(
-                        "Ask PO to complete the browser-based OAuth setup on a machine "
-                        "with browser access and then update CLAUDE_CREDENTIALS_JSON "
+                        "Complete the browser-based OAuth setup on a machine with "
+                        "browser access and then update CLAUDE_CREDENTIALS_JSON "
                         "from the secret source; or set ANTHROPIC_API_KEY as the fallback."
                     ),
                 )
@@ -83,6 +83,7 @@ def classify_auth() -> VerificationResult:
                     details.append("ANTHROPIC_API_KEY fallback present: yes")
                 details.append(f"credentials file: {creds_path}")
                 details.append("claudeAiOauth entry present: yes")
+                details.append("PREFERRED PATH: browser-based OAuth authentication.")
                 return VerificationResult(
                     auth_mode="oauth",
                     valid=True,
@@ -98,6 +99,7 @@ def classify_auth() -> VerificationResult:
                     details=[
                         f"credentials file missing claudeAiOauth: {creds_path}",
                         f"ANTHROPIC_API_KEY env present (length={len(api_key)})",
+                        "PREFERRED PATH: browser-based OAuth authentication.",
                     ],
                 )
 
@@ -107,8 +109,8 @@ def classify_auth() -> VerificationResult:
                 source=str(creds_path),
                 details=["credentials file missing 'claudeAiOauth' key."],
                 next_step=(
-                    "Ask PO to complete the browser-based OAuth setup on a machine "
-                    "with browser access and then update CLAUDE_CREDENTIALS_JSON "
+                    "Complete the browser-based OAuth setup on a machine with "
+                    "browser access and then update CLAUDE_CREDENTIALS_JSON "
                     "from the secret source; or set ANTHROPIC_API_KEY as the fallback."
                 ),
             )
@@ -121,6 +123,7 @@ def classify_auth() -> VerificationResult:
                 details=[
                     "OAuth credentials file not found, but fallback API key is present.",
                     f"ANTHROPIC_API_KEY env present (length={len(api_key)})",
+                    "PREFERRED PATH: browser-based OAuth authentication.",
                 ],
             )
 
@@ -132,8 +135,9 @@ def classify_auth() -> VerificationResult:
                 "CLAUDE_CREDENTIALS_JSON is set but ~/.claude/.credentials.json is missing.",
             ],
             next_step=(
-                "Ask PO to refresh the OAuth-backed credentials secret from the "
-                "secret source or set ANTHROPIC_API_KEY as the fallback."
+                "Complete the browser-based OAuth setup on a machine with browser "
+                "access and then refresh the OAuth-backed credentials secret from "
+                "the secret source; or set ANTHROPIC_API_KEY as the fallback."
             ),
         )
 
@@ -143,7 +147,10 @@ def classify_auth() -> VerificationResult:
             auth_mode="api_key",
             valid=True,
             source="env:ANTHROPIC_API_KEY",
-            details=[f"ANTHROPIC_API_KEY env present (length={len(api_key)})"],
+            details=[
+                f"ANTHROPIC_API_KEY env present (length={len(api_key)})",
+                "PREFERRED PATH: browser-based OAuth authentication.",
+            ],
         )
 
     return VerificationResult(
@@ -152,9 +159,9 @@ def classify_auth() -> VerificationResult:
         source="missing",
         details=["CLAUDE_CREDENTIALS_JSON is not set in environment."],
         next_step=(
-            "Ask PO to complete the browser-based OAuth setup on a machine with "
-            "browser access and then update CLAUDE_CREDENTIALS_JSON from the "
-            "secret source; or set ANTHROPIC_API_KEY as the fallback."
+            "Complete the browser-based OAuth setup on a machine with browser "
+            "access and then update CLAUDE_CREDENTIALS_JSON from the secret "
+            "source; or set ANTHROPIC_API_KEY as the fallback."
         ),
     )
 

--- a/scripts/verify_codex_auth.py
+++ b/scripts/verify_codex_auth.py
@@ -64,8 +64,8 @@ def classify_auth() -> VerificationResult:
                 source=str(auth_file),
                 details=[f"credentials file unreadable: {exc}"],
                 next_step=(
-                    "Ask PO to complete the browser-based OAuth login on a machine "
-                    "with browser access."
+                    "Complete the browser-based OAuth login on a machine with "
+                    "browser access."
                 ),
             )
 
@@ -89,6 +89,7 @@ def classify_auth() -> VerificationResult:
                 details.append("OPENAI_API_KEY field present: yes")
             if api_key:
                 details.append("OPENAI_API_KEY env fallback present: yes")
+            details.append("PREFERRED PATH: browser-based OAuth authentication.")
             return VerificationResult(
                 auth_mode="oauth",
                 valid=True,
@@ -104,6 +105,7 @@ def classify_auth() -> VerificationResult:
                 details.append("OPENAI_API_KEY field present: yes")
             if api_key:
                 details.append("OPENAI_API_KEY env fallback present: yes")
+            details.append("PREFERRED PATH: browser-based OAuth authentication.")
             return VerificationResult(
                 auth_mode="api_key",
                 valid=True,
@@ -119,7 +121,10 @@ def classify_auth() -> VerificationResult:
             auth_mode="api_key",
             valid=True,
             source="env:OPENAI_API_KEY",
-            details=[f"OPENAI_API_KEY env present (length={len(api_key)})"],
+            details=[
+                f"OPENAI_API_KEY env present (length={len(api_key)})",
+                "PREFERRED PATH: browser-based OAuth authentication.",
+            ],
         )
     else:
         details.append("auth.json not found")
@@ -130,8 +135,8 @@ def classify_auth() -> VerificationResult:
         source=source,
         details=details,
         next_step=(
-            "Ask PO to complete the browser-based OAuth login on a machine with "
-            "browser access, or set OPENAI_API_KEY as the fallback."
+            "Complete the browser-based OAuth login on a machine with browser "
+            "access, or set OPENAI_API_KEY as the fallback."
         ),
     )
 

--- a/tests/test_verify_claude_auth.py
+++ b/tests/test_verify_claude_auth.py
@@ -47,7 +47,10 @@ def test_invalid_when_credentials_env_missing(tmp_path, monkeypatch, capsys):
     assert "RESULT: Invalid authentication" in combined
     assert "INFO: local CLI not found on PATH (expected on elis-server)." in combined
     assert "claude CLI" not in combined
-    assert "NEXT STEP: Complete the browser-based OAuth setup on a machine with browser access and then update CLAUDE_CREDENTIALS_JSON from the secret source; or set ANTHROPIC_API_KEY as the fallback." in combined
+    assert (
+        "NEXT STEP: Complete the browser-based OAuth setup on a machine with browser access and then update CLAUDE_CREDENTIALS_JSON from the secret source; or set ANTHROPIC_API_KEY as the fallback."
+        in combined
+    )
 
 
 def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):

--- a/tests/test_verify_claude_auth.py
+++ b/tests/test_verify_claude_auth.py
@@ -47,6 +47,7 @@ def test_invalid_when_credentials_env_missing(tmp_path, monkeypatch, capsys):
     assert "RESULT: Invalid authentication" in combined
     assert "INFO: local CLI not found on PATH (expected on elis-server)." in combined
     assert "claude CLI" not in combined
+    assert "NEXT STEP: Complete the browser-based OAuth setup on a machine with browser access and then update CLAUDE_CREDENTIALS_JSON from the secret source; or set ANTHROPIC_API_KEY as the fallback." in combined
 
 
 def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):
@@ -71,6 +72,7 @@ def test_valid_api_key_fallback_when_oauth_missing(tmp_path, monkeypatch, capsys
     combined = captured.out + captured.err
     assert "RESULT: Valid API Key authentication" in combined
     assert "ANTHROPIC_API_KEY env present" in combined
+    assert "PREFERRED PATH: browser-based OAuth authentication." in combined
     assert "INFO: local CLI not found on PATH (expected on elis-server)." in combined
     assert "claude CLI" not in combined
 

--- a/tests/test_verify_codex_auth.py
+++ b/tests/test_verify_codex_auth.py
@@ -52,7 +52,10 @@ def test_invalid_when_no_credentials(tmp_path, monkeypatch, capsys):
     assert "RESULT: Invalid authentication" in combined
     assert "INFO: local CLI not found on PATH (expected on elis-server)." in combined
     assert "codex CLI" not in combined
-    assert "NEXT STEP: Complete the browser-based OAuth login on a machine with browser access, or set OPENAI_API_KEY as the fallback." in combined
+    assert (
+        "NEXT STEP: Complete the browser-based OAuth login on a machine with browser access, or set OPENAI_API_KEY as the fallback."
+        in combined
+    )
 
 
 def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):

--- a/tests/test_verify_codex_auth.py
+++ b/tests/test_verify_codex_auth.py
@@ -52,6 +52,7 @@ def test_invalid_when_no_credentials(tmp_path, monkeypatch, capsys):
     assert "RESULT: Invalid authentication" in combined
     assert "INFO: local CLI not found on PATH (expected on elis-server)." in combined
     assert "codex CLI" not in combined
+    assert "NEXT STEP: Complete the browser-based OAuth login on a machine with browser access, or set OPENAI_API_KEY as the fallback." in combined
 
 
 def test_valid_oauth_authentication(tmp_path, monkeypatch, capsys):
@@ -76,6 +77,7 @@ def test_valid_api_key_fallback_when_oauth_missing(tmp_path, monkeypatch, capsys
     combined = captured.out + captured.err
     assert "RESULT: Valid API Key authentication" in combined
     assert "OPENAI_API_KEY env present" in combined
+    assert "PREFERRED PATH: browser-based OAuth authentication." in combined
     assert "INFO: local CLI not found on PATH (expected on elis-server)." in combined
     assert "codex CLI" not in combined
 


### PR DESCRIPTION
Refines the auth verifier wording so OAuth is clearly the preferred path for both Codex and Claude Code.

Changes:
- user-facing next-step text now says "Complete..." instead of "Ask PO to complete..."
- both verifiers now emit a "PREFERRED PATH: browser-based OAuth authentication." note when API-key fallback is used
- tests updated to assert the new wording

Verification:
- python -m pytest -q tests/test_verify_codex_auth.py tests/test_verify_claude_auth.py
- python scripts/verify_codex_auth.py
- python scripts/verify_claude_auth.py