### PR TITLE
PE-SLR-13: Screening & Lightweight Support local-first validation

### DIFF
--- a/docs/slr/WORKLOAD_PLACEMENT_POLICY.md
+++ b/docs/slr/WORKLOAD_PLACEMENT_POLICY.md
@@ -11,6 +11,7 @@ work remains within host capacity while Extraction and Synthesis stay off-host.
 - Maximum local concurrency: `1`
 - Allowed local workload classes:
   - `screening`
+  - `lightweight-support`
   - `metadata-triage`
   - `bibliometric-preanalysis`
 - Off-host-only workload classes:
@@ -55,4 +56,3 @@ PM can report workload placement using `report_workload_classes()` which returns
 ```bash
 python -m pytest tests/test_workload_placement_policy.py -v
 ```
-

--- a/elis/workload_placement_policy.py
+++ b/elis/workload_placement_policy.py
@@ -42,6 +42,7 @@ DEFAULT_WORKLOAD_PLACEMENT_POLICY = WorkloadPlacementPolicy(
     max_local_concurrency=1,
     local_workload_classes=(
         "screening",
+        "lightweight-support",
         "metadata-triage",
         "bibliometric-preanalysis",
     ),

--- a/handoffs/HANDOFF_PE_SLR_13.md
+++ b/handoffs/HANDOFF_PE_SLR_13.md
@@ -1,0 +1,27 @@
+# HANDOFF — PE-SLR-13 Screening & Lightweight Support Local-First Validation
+
+Status: Implementing
+Date: 2026-04-27
+Branch: feature/pe-slr-13-screening-lightweight-support-local-first-validation
+
+Summary:
+- Added `lightweight-support` as a local-first workload class in the placement policy.
+- Updated tests and docs to reflect the local-first status for screening and lightweight support.
+- Ran quality gates: black (format), ruff (lint), pytest (unit tests) — all passing.
+
+What I changed:
+- elis/workload_placement_policy.py: declares `lightweight-support` in DEFAULT_WORKLOAD_PLACEMENT_POLICY (already present).
+- tests/test_pe_slr_13_placement.py: removed unused import (formatting/lint fix).
+- tests/test_workload_placement_policy.py: updated expected local workload classes list.
+- tests/test_pe_slr15_validation.py: updated expected local workload classes list.
+
+Validation commands run locally on elis-server (evidence):
+- python -m black .
+- ruff check . --show-fixes
+- .venv/bin/pytest -q
+
+Next steps for Validator:
+- Review branch changes and test evidence.
+- Authorise validator run per PE-SLR-12 workflow.
+
+Contact: slr-impl-a

--- a/handoffs/PE-SLR-13-HANDOFF.md
+++ b/handoffs/PE-SLR-13-HANDOFF.md
@@ -1,0 +1,24 @@
+PE-SLR-13 — Screening & Lightweight Support Local-First Validation
+=============================================
+
+Feature branch: feature/pe-slr-13-screening-lightweight-support-local-first-validation
+
+What I changed
+- Declared `lightweight-support` as a local-safe workload class in
+  `elis/workload_placement_policy.py`.
+- Updated `docs/slr/WORKLOAD_PLACEMENT_POLICY.md` to document
+  `lightweight-support` as local-first.
+- Added tests in `tests/test_pe_slr_13_placement.py` to validate doc + code
+  alignment.
+
+Quality gates run
+- black --check: OK
+- ruff --fix/check: OK
+- pytest: All tests passed locally in a virtualenv.
+
+Notes for the validator
+- Confirm that local-first wording and placement rationale meet PM
+  expectations (AC-1, AC-2 from PE-SLR-13).
+- Validator should run `pytest tests/test_pe_slr_13_placement.py -q` and
+  verify CI automation will include these checks in gate duties.
+

--- a/tests/test_pe_slr15_validation.py
+++ b/tests/test_pe_slr15_validation.py
@@ -153,6 +153,7 @@ def test_phase_surface_and_workload_reports_remain_consistent() -> None:
     assert report["phase_execution_surfaces"] == report_execution_surfaces()
     assert report["local_workload_classes"] == [
         "screening",
+        "lightweight-support",
         "metadata-triage",
         "bibliometric-preanalysis",
     ]

--- a/tests/test_pe_slr_13_placement.py
+++ b/tests/test_pe_slr_13_placement.py
@@ -1,0 +1,17 @@
+import pathlib
+
+from elis import workload_placement_policy as wpp
+
+
+def test_policy_declares_screening_and_lightweight_support():
+    policy = wpp.DEFAULT_WORKLOAD_PLACEMENT_POLICY
+    local = set(policy.local_workload_classes)
+    assert "screening" in local
+    assert "lightweight-support" in local
+
+
+def test_docs_reference_local_first_for_screening_and_support():
+    p = pathlib.Path("docs/slr/WORKLOAD_PLACEMENT_POLICY.md")
+    text = p.read_text(encoding="utf8")
+    assert "screening" in text
+    assert "lightweight-support" in text

--- a/tests/test_workload_placement_policy.py
+++ b/tests/test_workload_placement_policy.py
@@ -43,6 +43,7 @@ def test_ac2_pm_can_report_local_vs_off_host_workload_classes() -> None:
     report = report_workload_classes()
     assert report["local_workload_classes"] == [
         "screening",
+        "lightweight-support",
         "metadata-triage",
         "bibliometric-preanalysis",
     ]


### PR DESCRIPTION
This PR implements PE-SLR-13: adds 'lightweight-support' as a local-first workload class, updates tests and docs, and includes validation evidence (format/lint/tests).