### PR TITLE
Rewrite OpenClaw agent settings for first-version model set

### DIFF
--- a/ELIS_MultiAgent_Implementation_Plan_v2_0.md
+++ b/ELIS_MultiAgent_Implementation_Plan_v2_0.md
@@ -59,7 +59,7 @@ All 19 registered agents are reviewed. The plan is complete when every agent has
 || Domain | infra |
 || Implementer | `infra-impl-a` |
 || Validator | `infra-val-b` |
-|| Agents covered | All Codex agents (`openai/gpt-5.1-codex`); all Claude Code agents (`anthropic/claude-*`) |
+|| Agents covered | All Codex agents (`openai/gpt-5.1-codex`); all non-CODEX agents in the active roster |
 || Depends On | — |
 || Status | Planned |
 

--- a/docs/openclaw/AGENT_CATALOGUE.md
+++ b/docs/openclaw/AGENT_CATALOGUE.md
@@ -19,27 +19,40 @@ deployment run is executed.
 
 ## 2. Source-Controlled Runtime Target (19 agents)
 
-| ID | Domain | Role | Model | Workspace |
-|---|---|---|---|---|
-| `pm` | PM | Orchestrator | `openai/gpt-5-mini` | `/home/samurai/openclaw/workspace-pm` |
-| `prog-impl-codex` | Programs | Implementer | `openai/gpt-5.1-codex` | `/home/samurai/openclaw/workspace-prog-impl` |
-| `prog-impl-claude` | Programs | Implementer | `anthropic/claude-sonnet-4-6` | `/home/samurai/openclaw/workspace-prog-impl` |
-| `prog-val-codex` | Programs | Validator | `openai/gpt-5.1-codex` | `/home/samurai/openclaw/workspace-prog-val` |
-| `prog-val-claude` | Programs | Validator | `anthropic/claude-sonnet-4-6` | `/home/samurai/openclaw/workspace-prog-val` |
-| `infra-impl-codex` | Infrastructure | Implementer | `openai/gpt-5.1-codex` | `/home/samurai/openclaw/workspace-infra-impl` |
-| `infra-impl-claude` | Infrastructure | Implementer | `anthropic/claude-sonnet-4-6` | `/home/samurai/openclaw/workspace-infra-impl` |
-| `infra-val-codex` | Infrastructure | Validator | `openai/gpt-5.1-codex` | `/home/samurai/openclaw/workspace-infra-val` |
-| `infra-val-claude` | Infrastructure | Validator | `anthropic/claude-sonnet-4-6` | `/home/samurai/openclaw/workspace-infra-val` |
-| `harvest-impl-codex` | Harvest | Implementer | `openai/gpt-5.1-codex` | `/home/samurai/openclaw/workspace-slr-harvest` |
-| `harvest-val-claude` | Harvest | Validator | `anthropic/claude-sonnet-4-6` | `/home/samurai/openclaw/workspace-slr-harvest` |
-| `screen-impl-claude` | Screen | Implementer | `anthropic/claude-opus-4-6` | `/home/samurai/openclaw/workspace-slr-screen` |
-| `screen-val-codex` | Screen | Validator | `openai/gpt-5.1-codex` | `/home/samurai/openclaw/workspace-slr-screen` |
-| `extract-impl-codex` | Extraction | Implementer | `openai/gpt-5.1-codex` | `/home/samurai/openclaw/workspace-slr-extract` |
-| `extract-val-claude` | Extraction | Validator | `anthropic/claude-opus-4-6` | `/home/samurai/openclaw/workspace-slr-extract` |
-| `synth-impl-claude` | Synthesis | Implementer | `anthropic/claude-opus-4-6` | `/home/samurai/openclaw/workspace-slr-synth` |
-| `synth-val-codex` | Synthesis | Validator | `openai/gpt-5.1-codex` | `/home/samurai/openclaw/workspace-slr-synth` |
-| `prisma-impl-claude` | PRISMA | Implementer | `anthropic/claude-sonnet-4-6` | `/home/samurai/openclaw/workspace-slr-prisma` |
-| `prisma-val-codex` | PRISMA | Validator | `openai/gpt-5.1-codex` | `/home/samurai/openclaw/workspace-slr-prisma` |
+### PM
+- `pm` — Orchestrator — `openai/gpt-5-mini` — `/home/samurai/openclaw/workspace-pm`
+
+### Prog
+- `prog-impl-a` — Implementer — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-prog-impl`
+- `prog-impl-b` — Implementer — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-prog-impl`
+- `prog-val-a` — Validator — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-prog-val`
+- `prog-val-b` — Validator — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-prog-val`
+
+### Infra
+- `infra-impl-a` — Implementer — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-infra-impl`
+- `infra-impl-b` — Implementer — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-infra-impl`
+- `infra-val-a` — Validator — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-infra-val`
+- `infra-val-b` — Validator — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-infra-val`
+
+### SLR — Harvest
+- `harvest-impl-a` — Implementer — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-slr-harvest`
+- `harvest-val-b` — Validator — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-slr-harvest`
+
+### SLR — Screen
+- `screen-impl-b` — Implementer — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-slr-screen`
+- `screen-val-a` — Validator — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-slr-screen`
+
+### SLR — Extract
+- `extract-impl-a` — Implementer — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-slr-extract`
+- `extract-val-b` — Validator — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-slr-extract`
+
+### SLR — Synth
+- `synth-impl-b` — Implementer — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-slr-synth`
+- `synth-val-a` — Validator — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-slr-synth`
+
+### SLR — Prisma
+- `prisma-impl-b` — Implementer — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-slr-prisma`
+- `prisma-val-a` — Validator — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-slr-prisma`
 
 Notes:
 

--- a/docs/openclaw/AGENT_CATALOGUE.md
+++ b/docs/openclaw/AGENT_CATALOGUE.md
@@ -20,43 +20,43 @@ deployment run is executed.
 ## 2. Source-Controlled Runtime Target (19 agents)
 
 ### PM
-- `pm` — Orchestrator — `openai/gpt-5-mini` — `/home/samurai/openclaw/workspace-pm`
+- `pm` — Orchestrator — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-pm`
 
 ### Prog
-- `prog-impl-a` — Implementer — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-prog-impl`
-- `prog-impl-b` — Implementer — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-prog-impl`
+- `prog-impl-a` — Implementer — `qwen/qwen3-coder-flash` — `/home/samurai/openclaw/workspace-prog-impl`
+- `prog-impl-b` — Implementer — `deepseek/deepseek-v4-flash` — `/home/samurai/openclaw/workspace-prog-impl`
 - `prog-val-a` — Validator — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-prog-val`
-- `prog-val-b` — Validator — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-prog-val`
+- `prog-val-b` — Validator — `z-ai/glm-5.1` — `/home/samurai/openclaw/workspace-prog-val`
 
 ### Infra
-- `infra-impl-a` — Implementer — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-infra-impl`
-- `infra-impl-b` — Implementer — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-infra-impl`
+- `infra-impl-a` — Implementer — `qwen/qwen3-coder-flash` — `/home/samurai/openclaw/workspace-infra-impl`
+- `infra-impl-b` — Implementer — `deepseek/deepseek-v4-flash` — `/home/samurai/openclaw/workspace-infra-impl`
 - `infra-val-a` — Validator — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-infra-val`
-- `infra-val-b` — Validator — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-infra-val`
+- `infra-val-b` — Validator — `z-ai/glm-5.1` — `/home/samurai/openclaw/workspace-infra-val`
 
 ### SLR — Harvest
-- `harvest-impl-a` — Implementer — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-slr-harvest`
-- `harvest-val-b` — Validator — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-slr-harvest`
+- `harvest-impl-a` — Implementer — `qwen/qwen3-coder-flash` — `/home/samurai/openclaw/workspace-slr-harvest`
+- `harvest-val-b` — Validator — `z-ai/glm-5.1` — `/home/samurai/openclaw/workspace-slr-harvest`
 
 ### SLR — Screen
-- `screen-impl-b` — Implementer — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-slr-screen`
+- `screen-impl-b` — Implementer — `deepseek/deepseek-v4-flash` — `/home/samurai/openclaw/workspace-slr-screen`
 - `screen-val-a` — Validator — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-slr-screen`
 
 ### SLR — Extract
-- `extract-impl-a` — Implementer — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-slr-extract`
-- `extract-val-b` — Validator — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-slr-extract`
+- `extract-impl-a` — Implementer — `qwen/qwen3-coder-flash` — `/home/samurai/openclaw/workspace-slr-extract`
+- `extract-val-b` — Validator — `z-ai/glm-5.1` — `/home/samurai/openclaw/workspace-slr-extract`
 
 ### SLR — Synth
-- `synth-impl-b` — Implementer — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-slr-synth`
+- `synth-impl-b` — Implementer — `deepseek/deepseek-v4-flash` — `/home/samurai/openclaw/workspace-slr-synth`
 - `synth-val-a` — Validator — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-slr-synth`
 
 ### SLR — Prisma
-- `prisma-impl-b` — Implementer — `openrouter/xiaomi/mimo-v2.5-pro` — `/home/samurai/openclaw/workspace-slr-prisma`
+- `prisma-impl-b` — Implementer — `deepseek/deepseek-v4-flash` — `/home/samurai/openclaw/workspace-slr-prisma`
 - `prisma-val-a` — Validator — `deepseek/deepseek-v4-pro` — `/home/samurai/openclaw/workspace-slr-prisma`
 
 Notes:
 
-- PM remains in contingency mode on `openai/gpt-5-mini`.
+- PM remains in contingency mode on `deepseek/deepseek-v4-pro`.
 - Generic `workspace-slr-impl` / `workspace-slr-val` are removed from the source-controlled runtime.
 - Production runtime remains native `systemd`, not Docker.
 

--- a/docs/openclaw/CODEX_AGENT_SETUP.md
+++ b/docs/openclaw/CODEX_AGENT_SETUP.md
@@ -22,16 +22,16 @@ PM coordinates and records decisions.
 The first-version configuration uses these model roles:
 
 ```txt
-PM:           deepseek/deepseek-v4-pro
-Fallback:     deepseek/deepseek-v3.2
+PM:           openrouter/deepseek/deepseek-v4-pro
+Fallback:     openrouter/deepseek/deepseek-v3.2
 
-Implementers: qwen/qwen3-coder-flash
-              deepseek/deepseek-v4-flash
+Implementers: openrouter/qwen/qwen3-coder-flash
+              openrouter/deepseek/deepseek-v4-flash
 
-Validators:   deepseek/deepseek-v4-pro
-              z-ai/glm-5.1
+Validators:   openrouter/deepseek/deepseek-v4-pro
+              openrouter/z-ai/glm-5.1
 
-Escalation:   xiaomi/mimo-v2.5-pro
+Escalation:   openrouter/xiaomi/mimo-v2.5-pro
 ```
 
 This structure is functional and has three advantages:
@@ -48,8 +48,8 @@ This structure is functional and has three advantages:
 
 ```txt
 pm
-Primary:  deepseek/deepseek-v4-pro
-Fallback: deepseek/deepseek-v3.2
+Primary:  openrouter/deepseek/deepseek-v4-pro
+Fallback: openrouter/deepseek/deepseek-v3.2
 ```
 
 **Role:** coordination, task assignment, handoff review, validator routing, release governance, escalation decisions.
@@ -61,8 +61,8 @@ Fallback: deepseek/deepseek-v3.2
 ### 2.2 Implementer Agents
 
 ```txt
-impl-a: qwen/qwen3-coder-flash
-impl-b: deepseek/deepseek-v4-flash
+impl-a: openrouter/qwen/qwen3-coder-flash
+impl-b: openrouter/deepseek/deepseek-v4-flash
 ```
 
 **Role:** repository edits, workflow changes, implementation tasks, coding repairs, documentation updates, test additions.
@@ -74,8 +74,8 @@ impl-b: deepseek/deepseek-v4-flash
 ### 2.3 Validator Agents
 
 ```txt
-val-a: deepseek/deepseek-v4-pro
-val-b: z-ai/glm-5.1
+val-a: openrouter/deepseek/deepseek-v4-pro
+val-b: openrouter/z-ai/glm-5.1
 ```
 
 **Role:** independent review, technical validation, deterministic behaviour checks, schema/manifest review, CI review, release-gate review.
@@ -87,7 +87,7 @@ val-b: z-ai/glm-5.1
 ### 2.4 Escalation Agent
 
 ```txt
-escalation-reviewer: xiaomi/mimo-v2.5-pro
+escalation-reviewer: openrouter/xiaomi/mimo-v2.5-pro
 ```
 
 **Role:** arbitration, conflict resolution, high-risk review, repeated failure review, PM-requested independent judgement.
@@ -118,8 +118,8 @@ Therefore, MiMo-V2.5-Pro should be configured as a named escalation agent, not m
 ### 4.1 PM
 
 ```txt
-pm — deepseek/deepseek-v4-pro
-fallback — deepseek/deepseek-v3.2
+pm — openrouter/deepseek/deepseek-v4-pro
+fallback — openrouter/deepseek/deepseek-v3.2
 escalates to — escalation-reviewer
 ```
 
@@ -128,11 +128,11 @@ escalates to — escalation-reviewer
 ### 4.2 Prog — Programs
 
 ```txt
-prog-impl-a — qwen/qwen3-coder-flash
-prog-impl-b — deepseek/deepseek-v4-flash
+prog-impl-a — openrouter/qwen/qwen3-coder-flash
+prog-impl-b — openrouter/deepseek/deepseek-v4-flash
 
-prog-val-a  — deepseek/deepseek-v4-pro
-prog-val-b  — z-ai/glm-5.1
+prog-val-a  — openrouter/deepseek/deepseek-v4-pro
+prog-val-b  — openrouter/z-ai/glm-5.1
 ```
 
 ---
@@ -140,11 +140,11 @@ prog-val-b  — z-ai/glm-5.1
 ### 4.3 Infra — Infrastructure
 
 ```txt
-infra-impl-a — qwen/qwen3-coder-flash
-infra-impl-b — deepseek/deepseek-v4-flash
+infra-impl-a — openrouter/qwen/qwen3-coder-flash
+infra-impl-b — openrouter/deepseek/deepseek-v4-flash
 
-infra-val-a  — deepseek/deepseek-v4-pro
-infra-val-b  — z-ai/glm-5.1
+infra-val-a  — openrouter/deepseek/deepseek-v4-pro
+infra-val-b  — openrouter/z-ai/glm-5.1
 ```
 
 ---
@@ -152,11 +152,11 @@ infra-val-b  — z-ai/glm-5.1
 ### 4.4 SLR — Harvest
 
 ```txt
-harvest-impl-a — deepseek/deepseek-v4-flash
-harvest-impl-b — qwen/qwen3-coder-flash
+harvest-impl-a — openrouter/deepseek/deepseek-v4-flash
+harvest-impl-b — openrouter/qwen/qwen3-coder-flash
 
-harvest-val-a  — deepseek/deepseek-v4-pro
-harvest-val-b  — z-ai/glm-5.1
+harvest-val-a  — openrouter/deepseek/deepseek-v4-pro
+harvest-val-b  — openrouter/z-ai/glm-5.1
 ```
 
 ---
@@ -164,11 +164,11 @@ harvest-val-b  — z-ai/glm-5.1
 ### 4.5 SLR — Screen
 
 ```txt
-screen-impl-a — deepseek/deepseek-v4-flash
-screen-impl-b — qwen/qwen3-coder-flash
+screen-impl-a — openrouter/deepseek/deepseek-v4-flash
+screen-impl-b — openrouter/qwen/qwen3-coder-flash
 
-screen-val-a  — deepseek/deepseek-v4-pro
-screen-val-b  — z-ai/glm-5.1
+screen-val-a  — openrouter/deepseek/deepseek-v4-pro
+screen-val-b  — openrouter/z-ai/glm-5.1
 ```
 
 ---
@@ -176,11 +176,11 @@ screen-val-b  — z-ai/glm-5.1
 ### 4.6 SLR — Extract
 
 ```txt
-extract-impl-a — qwen/qwen3-coder-flash
-extract-impl-b — deepseek/deepseek-v4-flash
+extract-impl-a — openrouter/qwen/qwen3-coder-flash
+extract-impl-b — openrouter/deepseek/deepseek-v4-flash
 
-extract-val-a  — deepseek/deepseek-v4-pro
-extract-val-b  — z-ai/glm-5.1
+extract-val-a  — openrouter/deepseek/deepseek-v4-pro
+extract-val-b  — openrouter/z-ai/glm-5.1
 ```
 
 ---
@@ -188,11 +188,11 @@ extract-val-b  — z-ai/glm-5.1
 ### 4.7 SLR — Synth
 
 ```txt
-synth-impl-a — deepseek/deepseek-v4-flash
-synth-impl-b — qwen/qwen3-coder-flash
+synth-impl-a — openrouter/deepseek/deepseek-v4-flash
+synth-impl-b — openrouter/qwen/qwen3-coder-flash
 
-synth-val-a  — deepseek/deepseek-v4-pro
-synth-val-b  — z-ai/glm-5.1
+synth-val-a  — openrouter/deepseek/deepseek-v4-pro
+synth-val-b  — openrouter/z-ai/glm-5.1
 ```
 
 ---
@@ -200,11 +200,11 @@ synth-val-b  — z-ai/glm-5.1
 ### 4.8 SLR — Prisma
 
 ```txt
-prisma-impl-a — deepseek/deepseek-v4-flash
-prisma-impl-b — qwen/qwen3-coder-flash
+prisma-impl-a — openrouter/deepseek/deepseek-v4-flash
+prisma-impl-b — openrouter/qwen/qwen3-coder-flash
 
-prisma-val-a  — deepseek/deepseek-v4-pro
-prisma-val-b  — z-ai/glm-5.1
+prisma-val-a  — openrouter/deepseek/deepseek-v4-pro
+prisma-val-b  — openrouter/z-ai/glm-5.1
 ```
 
 ---
@@ -212,7 +212,7 @@ prisma-val-b  — z-ai/glm-5.1
 ### 4.9 Escalation
 
 ```txt
-escalation-reviewer — xiaomi/mimo-v2.5-pro
+escalation-reviewer — openrouter/xiaomi/mimo-v2.5-pro
 ```
 
 ---
@@ -229,33 +229,33 @@ Use this as the conceptual model policy in `openclaw.json` or the equivalent Ope
   "agents": {
     "defaults": {
       "model": {
-        "primary": "deepseek/deepseek-v4-pro",
+        "primary": "openrouter/deepseek/deepseek-v4-pro",
         "fallbacks": [
-          "deepseek/deepseek-v3.2"
+          "openrouter/deepseek/deepseek-v3.2"
         ]
       },
       "models": {
-        "deepseek/deepseek-v4-pro": {
+        "openrouter/deepseek/deepseek-v4-pro": {
           "alias": "deepseek-v4-pro",
           "purpose": "PM coordination, high-quality validation, long-context reasoning"
         },
-        "deepseek/deepseek-v3.2": {
+        "openrouter/deepseek/deepseek-v3.2": {
           "alias": "deepseek-v3.2",
           "purpose": "PM fallback and lower-cost reasoning fallback"
         },
-        "deepseek/deepseek-v4-flash": {
+        "openrouter/deepseek/deepseek-v4-flash": {
           "alias": "deepseek-v4-flash",
           "purpose": "low-cost implementation, routine coding, SLR pipeline edits"
         },
-        "qwen/qwen3-coder-flash": {
+        "openrouter/qwen/qwen3-coder-flash": {
           "alias": "qwen3-coder-flash",
           "purpose": "coding-specialist implementation agent"
         },
-        "z-ai/glm-5.1": {
+        "openrouter/z-ai/glm-5.1": {
           "alias": "glm-5.1",
           "purpose": "independent validation, long-horizon code review, engineering-grade review"
         },
-        "xiaomi/mimo-v2.5-pro": {
+        "openrouter/xiaomi/mimo-v2.5-pro": {
           "alias": "mimo-v2.5-pro",
           "purpose": "escalation, arbitration, conflict resolution, high-risk review"
         }
@@ -277,9 +277,9 @@ This is a logical registry for agent assignment. The exact schema may need adjus
     "pm": {
       "role": "project-manager",
       "model": {
-        "primary": "deepseek/deepseek-v4-pro",
+        "primary": "openrouter/deepseek/deepseek-v4-pro",
         "fallbacks": [
-          "deepseek/deepseek-v3.2"
+          "openrouter/deepseek/deepseek-v3.2"
         ]
       },
       "can_call": [
@@ -317,126 +317,126 @@ This is a logical registry for agent assignment. The exact schema may need adjus
 
     "prog-impl-a": {
       "role": "programs-implementer",
-      "model": "qwen/qwen3-coder-flash"
+      "model": "openrouter/qwen/qwen3-coder-flash"
     },
     "prog-impl-b": {
       "role": "programs-implementer",
-      "model": "deepseek/deepseek-v4-flash"
+      "model": "openrouter/deepseek/deepseek-v4-flash"
     },
     "prog-val-a": {
       "role": "programs-validator",
-      "model": "deepseek/deepseek-v4-pro"
+      "model": "openrouter/deepseek/deepseek-v4-pro"
     },
     "prog-val-b": {
       "role": "programs-validator",
-      "model": "z-ai/glm-5.1"
+      "model": "openrouter/z-ai/glm-5.1"
     },
 
     "infra-impl-a": {
       "role": "infrastructure-implementer",
-      "model": "qwen/qwen3-coder-flash"
+      "model": "openrouter/qwen/qwen3-coder-flash"
     },
     "infra-impl-b": {
       "role": "infrastructure-implementer",
-      "model": "deepseek/deepseek-v4-flash"
+      "model": "openrouter/deepseek/deepseek-v4-flash"
     },
     "infra-val-a": {
       "role": "infrastructure-validator",
-      "model": "deepseek/deepseek-v4-pro"
+      "model": "openrouter/deepseek/deepseek-v4-pro"
     },
     "infra-val-b": {
       "role": "infrastructure-validator",
-      "model": "z-ai/glm-5.1"
+      "model": "openrouter/z-ai/glm-5.1"
     },
 
     "harvest-impl-a": {
       "role": "slr-harvest-implementer",
-      "model": "deepseek/deepseek-v4-flash"
+      "model": "openrouter/deepseek/deepseek-v4-flash"
     },
     "harvest-impl-b": {
       "role": "slr-harvest-implementer",
-      "model": "qwen/qwen3-coder-flash"
+      "model": "openrouter/qwen/qwen3-coder-flash"
     },
     "harvest-val-a": {
       "role": "slr-harvest-validator",
-      "model": "deepseek/deepseek-v4-pro"
+      "model": "openrouter/deepseek/deepseek-v4-pro"
     },
     "harvest-val-b": {
       "role": "slr-harvest-validator",
-      "model": "z-ai/glm-5.1"
+      "model": "openrouter/z-ai/glm-5.1"
     },
 
     "screen-impl-a": {
       "role": "slr-screen-implementer",
-      "model": "deepseek/deepseek-v4-flash"
+      "model": "openrouter/deepseek/deepseek-v4-flash"
     },
     "screen-impl-b": {
       "role": "slr-screen-implementer",
-      "model": "qwen/qwen3-coder-flash"
+      "model": "openrouter/qwen/qwen3-coder-flash"
     },
     "screen-val-a": {
       "role": "slr-screen-validator",
-      "model": "deepseek/deepseek-v4-pro"
+      "model": "openrouter/deepseek/deepseek-v4-pro"
     },
     "screen-val-b": {
       "role": "slr-screen-validator",
-      "model": "z-ai/glm-5.1"
+      "model": "openrouter/z-ai/glm-5.1"
     },
 
     "extract-impl-a": {
       "role": "slr-extract-implementer",
-      "model": "qwen/qwen3-coder-flash"
+      "model": "openrouter/qwen/qwen3-coder-flash"
     },
     "extract-impl-b": {
       "role": "slr-extract-implementer",
-      "model": "deepseek/deepseek-v4-flash"
+      "model": "openrouter/deepseek/deepseek-v4-flash"
     },
     "extract-val-a": {
       "role": "slr-extract-validator",
-      "model": "deepseek/deepseek-v4-pro"
+      "model": "openrouter/deepseek/deepseek-v4-pro"
     },
     "extract-val-b": {
       "role": "slr-extract-validator",
-      "model": "z-ai/glm-5.1"
+      "model": "openrouter/z-ai/glm-5.1"
     },
 
     "synth-impl-a": {
       "role": "slr-synthesis-implementer",
-      "model": "deepseek/deepseek-v4-flash"
+      "model": "openrouter/deepseek/deepseek-v4-flash"
     },
     "synth-impl-b": {
       "role": "slr-synthesis-implementer",
-      "model": "qwen/qwen3-coder-flash"
+      "model": "openrouter/qwen/qwen3-coder-flash"
     },
     "synth-val-a": {
       "role": "slr-synthesis-validator",
-      "model": "deepseek/deepseek-v4-pro"
+      "model": "openrouter/deepseek/deepseek-v4-pro"
     },
     "synth-val-b": {
       "role": "slr-synthesis-validator",
-      "model": "z-ai/glm-5.1"
+      "model": "openrouter/z-ai/glm-5.1"
     },
 
     "prisma-impl-a": {
       "role": "slr-prisma-implementer",
-      "model": "deepseek/deepseek-v4-flash"
+      "model": "openrouter/deepseek/deepseek-v4-flash"
     },
     "prisma-impl-b": {
       "role": "slr-prisma-implementer",
-      "model": "qwen/qwen3-coder-flash"
+      "model": "openrouter/qwen/qwen3-coder-flash"
     },
     "prisma-val-a": {
       "role": "slr-prisma-validator",
-      "model": "deepseek/deepseek-v4-pro"
+      "model": "openrouter/deepseek/deepseek-v4-pro"
     },
     "prisma-val-b": {
       "role": "slr-prisma-validator",
-      "model": "z-ai/glm-5.1"
+      "model": "openrouter/z-ai/glm-5.1"
     },
 
     "escalation-reviewer": {
       "role": "escalation-arbitrator",
-      "model": "xiaomi/mimo-v2.5-pro",
+      "model": "openrouter/xiaomi/mimo-v2.5-pro",
       "mode": "read-only-review",
       "called_by": [
         "pm"
@@ -612,19 +612,19 @@ The escalation reviewer should return `NEEDS HUMAN DECISION` when:
 
 ```txt
 PM
-- deepseek/deepseek-v4-pro
-- fallback: deepseek/deepseek-v3.2
+- openrouter/deepseek/deepseek-v4-pro
+- fallback: openrouter/deepseek/deepseek-v3.2
 
 Implementers
-- qwen/qwen3-coder-flash
-- deepseek/deepseek-v4-flash
+- openrouter/qwen/qwen3-coder-flash
+- openrouter/deepseek/deepseek-v4-flash
 
 Validators
-- deepseek/deepseek-v4-pro
-- z-ai/glm-5.1
+- openrouter/deepseek/deepseek-v4-pro
+- openrouter/z-ai/glm-5.1
 
 Escalation
-- xiaomi/mimo-v2.5-pro
+- openrouter/xiaomi/mimo-v2.5-pro
 ```
 
 ---

--- a/docs/openclaw/CODEX_AGENT_SETUP.md
+++ b/docs/openclaw/CODEX_AGENT_SETUP.md
@@ -1,116 +1,698 @@
-# CODEX Agent Setup — PE-OC-18 Runbook
+# OpenClaw Agent Settings
 
-> **Prerequisite:** PE-OC-17 complete (OpenClaw running, Telegram paired).
+**Document purpose:** Define the ELIS OpenClaw multi-agent model policy, including PM coordination, implementer/validator separation, and a named escalation path.
 
-## Model Tier Policy
-
-| Role | Model | Fallback |
-|---|---|---|
-| PM Agent (orchestration) | `openai/gpt-5.1-codex` | — |
-| CODEX agents (`*-impl-codex`, `*-val-codex`) | `openai/gpt-5.1-codex` | — |
-| Claude coding agents (`*-impl-claude`, `*-val-claude`) | `anthropic/claude-sonnet-4-6` | `anthropic/claude-opus-4-6` |
-
-**Rationale:** `openai/gpt-5.1-codex` drives all CODEX roles and PM orchestration.
-`anthropic/claude-sonnet-4-6` is the primary for Claude coding/validation; Opus is its fallback only.
+**Scope:** PM agent, programme agents, infrastructure agents, SLR agents, validator agents, implementer agents, and escalation/arbitration workflow.
 
 ---
 
-## Step 1 — Store API Keys on Host
+## 1. Executive Summary
 
-Both keys must be present in `~/.openclaw/.env` before starting the container:
+The recommended ELIS/OpenClaw setup should separate routine implementation, independent validation, PM coordination, and high-risk arbitration.
 
-```bash
-# On Windows (PowerShell) — append to existing file
-Add-Content -Path "$env:USERPROFILE\.openclaw\.env" -Value 'OPENAI_API_KEY=<your-openai-key>'
-Add-Content -Path "$env:USERPROFILE\.openclaw\.env" -Value 'ANTHROPIC_API_KEY=<your-anthropic-key>'
+Core principle:
+
+```txt
+Cheap / fast models implement.
+Stronger / independent models validate.
+MiMo arbitrates only when necessary.
+PM coordinates and records decisions.
 ```
 
-Verify both keys are present:
+The first-version configuration uses these model roles:
 
-```bash
-docker exec openclaw sh -c 'grep -E "OPENAI_API_KEY|ANTHROPIC_API_KEY" /home/node/.openclaw/.env | cut -d= -f1'
-# Expected output:
-# OPENAI_API_KEY
-# ANTHROPIC_API_KEY
+```txt
+PM:           openrouter/deepseek/deepseek-v4-pro
+Fallback:     openrouter/deepseek/deepseek-v3.2
+
+Implementers: openrouter/qwen/qwen3-coder-flash
+              openrouter/deepseek/deepseek-v4-flash
+
+Validators:   openrouter/deepseek/deepseek-v4-pro
+              openrouter/z-ai/glm-5.1
+
+Escalation:   openrouter/xiaomi/mimo-v2.5-pro
 ```
 
-> /!\ Never commit `.env`. Keys live on the host only.
+This structure is functional and has three advantages:
+
+1. **Lower routine cost** by using Flash/Coder models for implementation.
+2. **Better role separation** between implementation and validation.
+3. **Clear escalation path** by reserving MiMo for arbitration.
 
 ---
 
-## Step 2 — Restart Container to Apply Env Changes
+## 2. Recommended Model Roles
 
-```bash
-docker compose down
-docker compose up -d
-docker compose ps
+### 2.1 PM Agent
+
+```txt
+pm
+Primary:  openrouter/deepseek/deepseek-v4-pro
+Fallback: openrouter/deepseek/deepseek-v3.2
 ```
 
-Verify both keys are visible inside the container:
+**Role:** coordination, task assignment, handoff review, validator routing, release governance, escalation decisions.
 
-```bash
-docker exec openclaw sh -c 'echo "OPENAI: ${OPENAI_API_KEY:0:8}... ANTHROPIC: ${ANTHROPIC_API_KEY:0:8}..."'
+**Rationale:** DeepSeek V4 Pro is appropriate for PM coordination because it supports long-context reasoning, code-aware planning, and multi-step agent workflow supervision. DeepSeek V3.2 is the lower-cost fallback for continuity.
+
+---
+
+### 2.2 Implementer Agents
+
+```txt
+impl-a: openrouter/qwen/qwen3-coder-flash
+impl-b: openrouter/deepseek/deepseek-v4-flash
+```
+
+**Role:** repository edits, workflow changes, implementation tasks, coding repairs, documentation updates, test additions.
+
+**Rationale:** implementers should be cost-efficient and coding-oriented. Qwen3 Coder Flash is the coding-specialist agent. DeepSeek V4 Flash is the fast general implementation model.
+
+---
+
+### 2.3 Validator Agents
+
+```txt
+val-a: openrouter/deepseek/deepseek-v4-pro
+val-b: openrouter/z-ai/glm-5.1
+```
+
+**Role:** independent review, technical validation, deterministic behaviour checks, schema/manifest review, CI review, release-gate review.
+
+**Rationale:** validators should not simply mirror implementers. DeepSeek V4 Pro provides strong reasoning and long-context review. GLM-5.1 provides independent model-family diversity and stronger cross-checking.
+
+---
+
+### 2.4 Escalation Agent
+
+```txt
+escalation-reviewer: openrouter/xiaomi/mimo-v2.5-pro
+```
+
+**Role:** arbitration, conflict resolution, high-risk review, repeated failure review, PM-requested independent judgement.
+
+**Rationale:** MiMo-V2.5-Pro should not be used as an ordinary fallback for every PM request. It should be reserved for situations where the cost of a mistake exceeds the cost of using a stronger arbitration model.
+
+---
+
+## 3. Fallback vs Escalation
+
+Fallback and escalation are different mechanisms.
+
+| Mechanism | Trigger | Purpose | Example |
+|---|---|---|---|
+| Fallback | Primary model error, outage, rate limit, context failure | Keep the agent running | PM primary model fails, so PM uses DeepSeek V3.2 |
+| Escalation | Disagreement, uncertainty, failed validation, high-risk change | Improve decision quality | Validator A says PASS, Validator B says FAIL, so PM calls MiMo |
+
+**Fallback is technical continuity.**
+
+**Escalation is governance arbitration.**
+
+Therefore, MiMo-V2.5-Pro should be configured as a named escalation agent, not merely as a fallback model.
+
+---
+
+## 4. Complete Agent Matrix
+
+### 4.1 PM
+
+```txt
+pm — openrouter/deepseek/deepseek-v4-pro
+fallback — openrouter/deepseek/deepseek-v3.2
+escalates to — escalation-reviewer
 ```
 
 ---
 
-## Step 3 — Verify Agent Registration
+### 4.2 Prog — Programs
 
-```bash
-docker exec openclaw node /app/openclaw.mjs agents list
-```
+```txt
+prog-impl-a — openrouter/qwen/qwen3-coder-flash
+prog-impl-b — openrouter/deepseek/deepseek-v4-flash
 
-Expected output includes all registered agents:
-
-```
-* main (default)
-  Model: openai/gpt-5.1-codex
-* pm
-  Workspace: workspace-pm
-  Model: openai/gpt-5.1-codex
-* prog-impl-codex
-  Workspace: workspace-prog-impl
-  Model: openai/gpt-5.1-codex
-* prog-impl-claude
-  Workspace: workspace-prog-impl
-  Model: anthropic/claude-sonnet-4-6
-* prog-val-codex
-  Workspace: workspace-prog-val
-  Model: openai/gpt-5.1-codex
-* prog-val-claude
-  Workspace: workspace-prog-val
-  Model: anthropic/claude-sonnet-4-6
+prog-val-a  — openrouter/deepseek/deepseek-v4-pro
+prog-val-b  — openrouter/z-ai/glm-5.1
 ```
 
 ---
 
-## Step 4 — Run Doctor Check
+### 4.3 Infra — Infrastructure
 
-```bash
-python scripts/check_openclaw_doctor.py
-```
+```txt
+infra-impl-a — openrouter/qwen/qwen3-coder-flash
+infra-impl-b — openrouter/deepseek/deepseek-v4-flash
 
-Expected: `OK: openclaw doctor configuration meets expected policies` (exit 0).
-
----
-
-## Step 5 — Verify PM Agent Still Responds via Telegram
-
-Send `status` from the PO Telegram account. The PM Agent (now running on `openai/gpt-5.1-codex`) should respond with the Active PE Registry summary.
-
-If no response within 30 seconds:
-
-```bash
-docker compose logs openclaw --tail=50
+infra-val-a  — openrouter/deepseek/deepseek-v4-pro
+infra-val-b  — openrouter/z-ai/glm-5.1
 ```
 
 ---
 
-## Troubleshooting
+### 4.4 SLR — Harvest
 
-| Symptom | Action |
-|---|---|
-| Agent list missing `prog-*` entries | Confirm `openclaw/openclaw.json` was synced: `bash scripts/deploy_openclaw_workspaces.sh` |
-| PM Agent no longer responds after model change | Check `OPENAI_API_KEY` is valid: `docker exec openclaw sh -c 'echo $OPENAI_API_KEY \| cut -c1-8'` |
-| Claude agent auth failure | Confirm `ANTHROPIC_API_KEY` in container env: `docker exec openclaw sh -c 'echo $ANTHROPIC_API_KEY \| cut -c1-8'` |
-| `openclaw doctor` fails | Verify all agents have `exec.ask: true` and `skills.hub.autoInstall: false` in `openclaw.json` |
+```txt
+harvest-impl-a — openrouter/deepseek/deepseek-v4-flash
+harvest-impl-b — openrouter/qwen/qwen3-coder-flash
+
+harvest-val-a  — openrouter/deepseek/deepseek-v4-pro
+harvest-val-b  — openrouter/z-ai/glm-5.1
+```
+
+---
+
+### 4.5 SLR — Screen
+
+```txt
+screen-impl-a — openrouter/deepseek/deepseek-v4-flash
+screen-impl-b — openrouter/qwen/qwen3-coder-flash
+
+screen-val-a  — openrouter/deepseek/deepseek-v4-pro
+screen-val-b  — openrouter/z-ai/glm-5.1
+```
+
+---
+
+### 4.6 SLR — Extract
+
+```txt
+extract-impl-a — openrouter/qwen/qwen3-coder-flash
+extract-impl-b — openrouter/deepseek/deepseek-v4-flash
+
+extract-val-a  — openrouter/deepseek/deepseek-v4-pro
+extract-val-b  — openrouter/z-ai/glm-5.1
+```
+
+---
+
+### 4.7 SLR — Synth
+
+```txt
+synth-impl-a — openrouter/deepseek/deepseek-v4-flash
+synth-impl-b — openrouter/qwen/qwen3-coder-flash
+
+synth-val-a  — openrouter/deepseek/deepseek-v4-pro
+synth-val-b  — openrouter/z-ai/glm-5.1
+```
+
+---
+
+### 4.8 SLR — Prisma
+
+```txt
+prisma-impl-a — openrouter/deepseek/deepseek-v4-flash
+prisma-impl-b — openrouter/qwen/qwen3-coder-flash
+
+prisma-val-a  — openrouter/deepseek/deepseek-v4-pro
+prisma-val-b  — openrouter/z-ai/glm-5.1
+```
+
+---
+
+### 4.9 Escalation
+
+```txt
+escalation-reviewer — openrouter/xiaomi/mimo-v2.5-pro
+```
+
+---
+
+## 5. OpenClaw Model Allow-List
+
+Use this as the conceptual model policy in `openclaw.json` or the equivalent OpenClaw settings file.
+
+```json
+{
+  "env": {
+    "OPENROUTER_API_KEY": "sk-or-..."
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "openrouter/deepseek/deepseek-v4-pro",
+        "fallbacks": [
+          "openrouter/deepseek/deepseek-v3.2"
+        ]
+      },
+      "models": {
+        "openrouter/deepseek/deepseek-v4-pro": {
+          "alias": "deepseek-v4-pro",
+          "purpose": "PM coordination, high-quality validation, long-context reasoning"
+        },
+        "openrouter/deepseek/deepseek-v3.2": {
+          "alias": "deepseek-v3.2",
+          "purpose": "PM fallback and lower-cost reasoning fallback"
+        },
+        "openrouter/deepseek/deepseek-v4-flash": {
+          "alias": "deepseek-v4-flash",
+          "purpose": "low-cost implementation, routine coding, SLR pipeline edits"
+        },
+        "openrouter/qwen/qwen3-coder-flash": {
+          "alias": "qwen3-coder-flash",
+          "purpose": "coding-specialist implementation agent"
+        },
+        "openrouter/z-ai/glm-5.1": {
+          "alias": "glm-5.1",
+          "purpose": "independent validation, long-horizon code review, engineering-grade review"
+        },
+        "openrouter/xiaomi/mimo-v2.5-pro": {
+          "alias": "mimo-v2.5-pro",
+          "purpose": "escalation, arbitration, conflict resolution, high-risk review"
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## 6. Logical Agent Registry
+
+This is a logical registry for agent assignment. The exact schema may need adjustment depending on the OpenClaw version installed on the ELIS server.
+
+```json
+{
+  "agents": {
+    "pm": {
+      "role": "project-manager",
+      "model": {
+        "primary": "openrouter/deepseek/deepseek-v4-pro",
+        "fallbacks": [
+          "openrouter/deepseek/deepseek-v3.2"
+        ]
+      },
+      "can_call": [
+        "prog-impl-a",
+        "prog-impl-b",
+        "prog-val-a",
+        "prog-val-b",
+        "infra-impl-a",
+        "infra-impl-b",
+        "infra-val-a",
+        "infra-val-b",
+        "harvest-impl-a",
+        "harvest-impl-b",
+        "harvest-val-a",
+        "harvest-val-b",
+        "screen-impl-a",
+        "screen-impl-b",
+        "screen-val-a",
+        "screen-val-b",
+        "extract-impl-a",
+        "extract-impl-b",
+        "extract-val-a",
+        "extract-val-b",
+        "synth-impl-a",
+        "synth-impl-b",
+        "synth-val-a",
+        "synth-val-b",
+        "prisma-impl-a",
+        "prisma-impl-b",
+        "prisma-val-a",
+        "prisma-val-b",
+        "escalation-reviewer"
+      ]
+    },
+
+    "prog-impl-a": {
+      "role": "programs-implementer",
+      "model": "openrouter/qwen/qwen3-coder-flash"
+    },
+    "prog-impl-b": {
+      "role": "programs-implementer",
+      "model": "openrouter/deepseek/deepseek-v4-flash"
+    },
+    "prog-val-a": {
+      "role": "programs-validator",
+      "model": "openrouter/deepseek/deepseek-v4-pro"
+    },
+    "prog-val-b": {
+      "role": "programs-validator",
+      "model": "openrouter/z-ai/glm-5.1"
+    },
+
+    "infra-impl-a": {
+      "role": "infrastructure-implementer",
+      "model": "openrouter/qwen/qwen3-coder-flash"
+    },
+    "infra-impl-b": {
+      "role": "infrastructure-implementer",
+      "model": "openrouter/deepseek/deepseek-v4-flash"
+    },
+    "infra-val-a": {
+      "role": "infrastructure-validator",
+      "model": "openrouter/deepseek/deepseek-v4-pro"
+    },
+    "infra-val-b": {
+      "role": "infrastructure-validator",
+      "model": "openrouter/z-ai/glm-5.1"
+    },
+
+    "harvest-impl-a": {
+      "role": "slr-harvest-implementer",
+      "model": "openrouter/deepseek/deepseek-v4-flash"
+    },
+    "harvest-impl-b": {
+      "role": "slr-harvest-implementer",
+      "model": "openrouter/qwen/qwen3-coder-flash"
+    },
+    "harvest-val-a": {
+      "role": "slr-harvest-validator",
+      "model": "openrouter/deepseek/deepseek-v4-pro"
+    },
+    "harvest-val-b": {
+      "role": "slr-harvest-validator",
+      "model": "openrouter/z-ai/glm-5.1"
+    },
+
+    "screen-impl-a": {
+      "role": "slr-screen-implementer",
+      "model": "openrouter/deepseek/deepseek-v4-flash"
+    },
+    "screen-impl-b": {
+      "role": "slr-screen-implementer",
+      "model": "openrouter/qwen/qwen3-coder-flash"
+    },
+    "screen-val-a": {
+      "role": "slr-screen-validator",
+      "model": "openrouter/deepseek/deepseek-v4-pro"
+    },
+    "screen-val-b": {
+      "role": "slr-screen-validator",
+      "model": "openrouter/z-ai/glm-5.1"
+    },
+
+    "extract-impl-a": {
+      "role": "slr-extract-implementer",
+      "model": "openrouter/qwen/qwen3-coder-flash"
+    },
+    "extract-impl-b": {
+      "role": "slr-extract-implementer",
+      "model": "openrouter/deepseek/deepseek-v4-flash"
+    },
+    "extract-val-a": {
+      "role": "slr-extract-validator",
+      "model": "openrouter/deepseek/deepseek-v4-pro"
+    },
+    "extract-val-b": {
+      "role": "slr-extract-validator",
+      "model": "openrouter/z-ai/glm-5.1"
+    },
+
+    "synth-impl-a": {
+      "role": "slr-synthesis-implementer",
+      "model": "openrouter/deepseek/deepseek-v4-flash"
+    },
+    "synth-impl-b": {
+      "role": "slr-synthesis-implementer",
+      "model": "openrouter/qwen/qwen3-coder-flash"
+    },
+    "synth-val-a": {
+      "role": "slr-synthesis-validator",
+      "model": "openrouter/deepseek/deepseek-v4-pro"
+    },
+    "synth-val-b": {
+      "role": "slr-synthesis-validator",
+      "model": "openrouter/z-ai/glm-5.1"
+    },
+
+    "prisma-impl-a": {
+      "role": "slr-prisma-implementer",
+      "model": "openrouter/deepseek/deepseek-v4-flash"
+    },
+    "prisma-impl-b": {
+      "role": "slr-prisma-implementer",
+      "model": "openrouter/qwen/qwen3-coder-flash"
+    },
+    "prisma-val-a": {
+      "role": "slr-prisma-validator",
+      "model": "openrouter/deepseek/deepseek-v4-pro"
+    },
+    "prisma-val-b": {
+      "role": "slr-prisma-validator",
+      "model": "openrouter/z-ai/glm-5.1"
+    },
+
+    "escalation-reviewer": {
+      "role": "escalation-arbitrator",
+      "model": "openrouter/xiaomi/mimo-v2.5-pro",
+      "mode": "read-only-review",
+      "called_by": [
+        "pm"
+      ]
+    }
+  }
+}
+```
+
+---
+
+## 7. Escalation Reviewer Identity
+
+Create this file:
+
+```txt
+.openclaw/agents/escalation-reviewer/agent.md
+```
+
+Recommended content:
+
+```md
+# ELIS Escalation Reviewer
+
+You are the ELIS escalation reviewer.
+
+Your role is to provide independent arbitration when the PM agent identifies disagreement, failed validation, high-risk changes, repeated failure, or material uncertainty.
+
+You are not a routine implementer. Your normal mode is read-only review.
+
+## Inputs
+
+You may receive:
+
+1. Original task brief.
+2. Implementer output.
+3. Validator review.
+4. Diff or file excerpts.
+5. Test results.
+6. HANDOFF.md.
+7. REVIEW.md.
+8. Relevant governance rules.
+9. PM escalation reason.
+
+## Decision options
+
+Return exactly one of:
+
+- PASS
+- FAIL
+- CONDITIONAL PASS
+- NEEDS HUMAN DECISION
+
+## Review criteria
+
+Assess:
+
+1. Whether the implementation satisfies the task.
+2. Whether the validator’s objections are technically valid.
+3. Whether the change preserves deterministic ELIS behaviour.
+4. Whether schemas, manifests, CI, release logic, documentation and tests remain consistent.
+5. Whether the evidence supports the conclusion.
+6. Whether there is hidden risk to reproducibility, auditability, governance, security or maintainability.
+7. Whether the task should return to an implementer or proceed to human decision.
+
+## Output format
+
+Return:
+
+1. Verdict.
+2. Reasoning summary.
+3. Blocking findings.
+4. Non-blocking findings.
+5. Required changes.
+6. Recommended PM decision.
+7. Confidence: High, Medium or Low.
+
+## Constraints
+
+Do not implement changes unless explicitly authorised.
+
+Do not approve a change if evidence is missing.
+
+Do not rely on assumptions when the repository, diff, test output or governance document can be checked.
+
+If the issue concerns release governance, CI, schemas, manifests, credentials, reproducibility or auditability, apply a conservative standard.
+```
+
+---
+
+## 8. PM Escalation Rule
+
+Add this section to the PM agent identity.
+
+```md
+## Escalation Rule
+
+The PM must call `escalation-reviewer` when any of the following occurs:
+
+1. Any validator returns FAIL.
+2. Two validators disagree.
+3. A validator returns CONDITIONAL PASS on a release-gating task.
+4. The task touches schemas, manifests, CI, release logic, security, credentials, auditability, reproducibility or governance documents.
+5. The same task fails validation twice.
+6. The PM cannot determine whether the implementer or validator is correct.
+7. The validator expresses material uncertainty.
+8. The expected cost of error exceeds the cost of escalation.
+
+The PM must record the escalation reason in HANDOFF.md, REVIEW.md or the task activity log.
+
+Escalation is not fallback. Fallback is used when a model fails technically. Escalation is used when judgement quality, independence or risk control requires stronger review.
+```
+
+---
+
+## 9. Recommended Operating Policy
+
+### 9.1 Normal Task
+
+```txt
+PM assigns task
+→ implementer edits
+→ validator reviews
+→ PM closes or returns task
+```
+
+### 9.2 High-Risk Task
+
+```txt
+PM assigns task
+→ implementer edits
+→ validator reviews
+→ escalation-reviewer arbitrates
+→ PM decides
+```
+
+### 9.3 Failed Validation
+
+```txt
+Validator = FAIL
+→ PM sends findings back to implementer
+→ implementer fixes
+→ validator rechecks
+→ if second failure, call escalation-reviewer
+```
+
+### 9.4 Validator Conflict
+
+```txt
+Validator A = PASS
+Validator B = FAIL
+→ PM calls escalation-reviewer
+→ escalation-reviewer gives arbitration verdict
+```
+
+---
+
+## 10. Recommended Human Oversight Rules
+
+The escalation reviewer should return `NEEDS HUMAN DECISION` when:
+
+1. The evidence is incomplete.
+2. The repository state cannot be inspected reliably.
+3. The validators disagree on a legal, methodological or governance interpretation.
+4. The change affects published ELIS methodology.
+5. The change could alter the meaning of PRISMA, screening, extraction or synthesis outputs.
+6. The change affects secrets, credentials, API keys or deployment security.
+7. The model cannot establish deterministic behaviour from the available evidence.
+
+---
+
+## 11. Final Recommended Model List
+
+```txt
+PM
+- openrouter/deepseek/deepseek-v4-pro
+- fallback: openrouter/deepseek/deepseek-v3.2
+
+Implementers
+- openrouter/qwen/qwen3-coder-flash
+- openrouter/deepseek/deepseek-v4-flash
+
+Validators
+- openrouter/deepseek/deepseek-v4-pro
+- openrouter/z-ai/glm-5.1
+
+Escalation
+- openrouter/xiaomi/mimo-v2.5-pro
+```
+
+---
+
+## 12. Benefits of the First-Version Configuration
+
+This configuration is stronger than the current DeepSeek/MiMo mirror setup because it provides:
+
+1. **Lower routine cost** by using Flash/Coder models for implementation.
+2. **Better role separation** between implementation and validation.
+3. **Higher validator independence** by including GLM-5.1 as a different model family.
+4. **Controlled use of expensive MiMo** only for arbitration and high-risk review.
+5. **Clear distinction between fallback and escalation.**
+6. **Better audit trail** because escalation must be recorded by the PM.
+7. **Better ELIS governance alignment** with reproducibility, auditability and deterministic release discipline.
+
+---
+
+## 13. Implementation Notes
+
+Before deploying this configuration:
+
+1. Verify current OpenClaw schema and supported agent registry syntax.
+2. Verify model IDs directly in OpenRouter.
+3. Confirm whether OpenClaw passes OpenRouter-specific provider routing parameters.
+4. Test each model using a preflight workflow.
+5. Ensure the PM can call the escalation reviewer explicitly.
+6. Ensure the escalation reviewer is read-only by default.
+7. Require PM to record the escalation reason in `HANDOFF.md`, `REVIEW.md`, or equivalent task logs.
+
+---
+
+## 14. Preflight Test
+
+Run a preflight task for each configured agent:
+
+```txt
+Task: Return your agent name, model ID, role, and whether you are an implementer, validator, PM or escalation reviewer. Do not edit files.
+```
+
+Expected result:
+
+1. Every agent returns the correct role.
+2. No agent uses an unapproved model.
+3. PM can call implementers.
+4. PM can call validators.
+5. PM can call escalation-reviewer.
+6. Escalation reviewer remains read-only unless explicitly authorised.
+
+---
+
+## 15. Next Step
+
+Create a small OpenClaw configuration test branch:
+
+```txt
+feature/openclaw-agent-settings-v1
+```
+
+Then add:
+
+```txt
+.openclaw/agents/pm/agent.md
+.openclaw/agents/escalation-reviewer/agent.md
+.openclaw/agents/prog-impl-a/agent.md
+.openclaw/agents/prog-val-a/agent.md
+.openclaw/agents/infra-impl-a/agent.md
+.openclaw/agents/infra-val-a/agent.md
+```
+
+After that, run a preflight validation before deploying the full matrix.

--- a/docs/openclaw/CODEX_AGENT_SETUP.md
+++ b/docs/openclaw/CODEX_AGENT_SETUP.md
@@ -22,16 +22,16 @@ PM coordinates and records decisions.
 The first-version configuration uses these model roles:
 
 ```txt
-PM:           openrouter/deepseek/deepseek-v4-pro
-Fallback:     openrouter/deepseek/deepseek-v3.2
+PM:           deepseek/deepseek-v4-pro
+Fallback:     deepseek/deepseek-v3.2
 
-Implementers: openrouter/qwen/qwen3-coder-flash
-              openrouter/deepseek/deepseek-v4-flash
+Implementers: qwen/qwen3-coder-flash
+              deepseek/deepseek-v4-flash
 
-Validators:   openrouter/deepseek/deepseek-v4-pro
-              openrouter/z-ai/glm-5.1
+Validators:   deepseek/deepseek-v4-pro
+              z-ai/glm-5.1
 
-Escalation:   openrouter/xiaomi/mimo-v2.5-pro
+Escalation:   xiaomi/mimo-v2.5-pro
 ```
 
 This structure is functional and has three advantages:
@@ -48,8 +48,8 @@ This structure is functional and has three advantages:
 
 ```txt
 pm
-Primary:  openrouter/deepseek/deepseek-v4-pro
-Fallback: openrouter/deepseek/deepseek-v3.2
+Primary:  deepseek/deepseek-v4-pro
+Fallback: deepseek/deepseek-v3.2
 ```
 
 **Role:** coordination, task assignment, handoff review, validator routing, release governance, escalation decisions.
@@ -61,8 +61,8 @@ Fallback: openrouter/deepseek/deepseek-v3.2
 ### 2.2 Implementer Agents
 
 ```txt
-impl-a: openrouter/qwen/qwen3-coder-flash
-impl-b: openrouter/deepseek/deepseek-v4-flash
+impl-a: qwen/qwen3-coder-flash
+impl-b: deepseek/deepseek-v4-flash
 ```
 
 **Role:** repository edits, workflow changes, implementation tasks, coding repairs, documentation updates, test additions.
@@ -74,8 +74,8 @@ impl-b: openrouter/deepseek/deepseek-v4-flash
 ### 2.3 Validator Agents
 
 ```txt
-val-a: openrouter/deepseek/deepseek-v4-pro
-val-b: openrouter/z-ai/glm-5.1
+val-a: deepseek/deepseek-v4-pro
+val-b: z-ai/glm-5.1
 ```
 
 **Role:** independent review, technical validation, deterministic behaviour checks, schema/manifest review, CI review, release-gate review.
@@ -87,7 +87,7 @@ val-b: openrouter/z-ai/glm-5.1
 ### 2.4 Escalation Agent
 
 ```txt
-escalation-reviewer: openrouter/xiaomi/mimo-v2.5-pro
+escalation-reviewer: xiaomi/mimo-v2.5-pro
 ```
 
 **Role:** arbitration, conflict resolution, high-risk review, repeated failure review, PM-requested independent judgement.
@@ -118,8 +118,8 @@ Therefore, MiMo-V2.5-Pro should be configured as a named escalation agent, not m
 ### 4.1 PM
 
 ```txt
-pm — openrouter/deepseek/deepseek-v4-pro
-fallback — openrouter/deepseek/deepseek-v3.2
+pm — deepseek/deepseek-v4-pro
+fallback — deepseek/deepseek-v3.2
 escalates to — escalation-reviewer
 ```
 
@@ -128,11 +128,11 @@ escalates to — escalation-reviewer
 ### 4.2 Prog — Programs
 
 ```txt
-prog-impl-a — openrouter/qwen/qwen3-coder-flash
-prog-impl-b — openrouter/deepseek/deepseek-v4-flash
+prog-impl-a — qwen/qwen3-coder-flash
+prog-impl-b — deepseek/deepseek-v4-flash
 
-prog-val-a  — openrouter/deepseek/deepseek-v4-pro
-prog-val-b  — openrouter/z-ai/glm-5.1
+prog-val-a  — deepseek/deepseek-v4-pro
+prog-val-b  — z-ai/glm-5.1
 ```
 
 ---
@@ -140,11 +140,11 @@ prog-val-b  — openrouter/z-ai/glm-5.1
 ### 4.3 Infra — Infrastructure
 
 ```txt
-infra-impl-a — openrouter/qwen/qwen3-coder-flash
-infra-impl-b — openrouter/deepseek/deepseek-v4-flash
+infra-impl-a — qwen/qwen3-coder-flash
+infra-impl-b — deepseek/deepseek-v4-flash
 
-infra-val-a  — openrouter/deepseek/deepseek-v4-pro
-infra-val-b  — openrouter/z-ai/glm-5.1
+infra-val-a  — deepseek/deepseek-v4-pro
+infra-val-b  — z-ai/glm-5.1
 ```
 
 ---
@@ -152,11 +152,11 @@ infra-val-b  — openrouter/z-ai/glm-5.1
 ### 4.4 SLR — Harvest
 
 ```txt
-harvest-impl-a — openrouter/deepseek/deepseek-v4-flash
-harvest-impl-b — openrouter/qwen/qwen3-coder-flash
+harvest-impl-a — deepseek/deepseek-v4-flash
+harvest-impl-b — qwen/qwen3-coder-flash
 
-harvest-val-a  — openrouter/deepseek/deepseek-v4-pro
-harvest-val-b  — openrouter/z-ai/glm-5.1
+harvest-val-a  — deepseek/deepseek-v4-pro
+harvest-val-b  — z-ai/glm-5.1
 ```
 
 ---
@@ -164,11 +164,11 @@ harvest-val-b  — openrouter/z-ai/glm-5.1
 ### 4.5 SLR — Screen
 
 ```txt
-screen-impl-a — openrouter/deepseek/deepseek-v4-flash
-screen-impl-b — openrouter/qwen/qwen3-coder-flash
+screen-impl-a — deepseek/deepseek-v4-flash
+screen-impl-b — qwen/qwen3-coder-flash
 
-screen-val-a  — openrouter/deepseek/deepseek-v4-pro
-screen-val-b  — openrouter/z-ai/glm-5.1
+screen-val-a  — deepseek/deepseek-v4-pro
+screen-val-b  — z-ai/glm-5.1
 ```
 
 ---
@@ -176,11 +176,11 @@ screen-val-b  — openrouter/z-ai/glm-5.1
 ### 4.6 SLR — Extract
 
 ```txt
-extract-impl-a — openrouter/qwen/qwen3-coder-flash
-extract-impl-b — openrouter/deepseek/deepseek-v4-flash
+extract-impl-a — qwen/qwen3-coder-flash
+extract-impl-b — deepseek/deepseek-v4-flash
 
-extract-val-a  — openrouter/deepseek/deepseek-v4-pro
-extract-val-b  — openrouter/z-ai/glm-5.1
+extract-val-a  — deepseek/deepseek-v4-pro
+extract-val-b  — z-ai/glm-5.1
 ```
 
 ---
@@ -188,11 +188,11 @@ extract-val-b  — openrouter/z-ai/glm-5.1
 ### 4.7 SLR — Synth
 
 ```txt
-synth-impl-a — openrouter/deepseek/deepseek-v4-flash
-synth-impl-b — openrouter/qwen/qwen3-coder-flash
+synth-impl-a — deepseek/deepseek-v4-flash
+synth-impl-b — qwen/qwen3-coder-flash
 
-synth-val-a  — openrouter/deepseek/deepseek-v4-pro
-synth-val-b  — openrouter/z-ai/glm-5.1
+synth-val-a  — deepseek/deepseek-v4-pro
+synth-val-b  — z-ai/glm-5.1
 ```
 
 ---
@@ -200,11 +200,11 @@ synth-val-b  — openrouter/z-ai/glm-5.1
 ### 4.8 SLR — Prisma
 
 ```txt
-prisma-impl-a — openrouter/deepseek/deepseek-v4-flash
-prisma-impl-b — openrouter/qwen/qwen3-coder-flash
+prisma-impl-a — deepseek/deepseek-v4-flash
+prisma-impl-b — qwen/qwen3-coder-flash
 
-prisma-val-a  — openrouter/deepseek/deepseek-v4-pro
-prisma-val-b  — openrouter/z-ai/glm-5.1
+prisma-val-a  — deepseek/deepseek-v4-pro
+prisma-val-b  — z-ai/glm-5.1
 ```
 
 ---
@@ -212,7 +212,7 @@ prisma-val-b  — openrouter/z-ai/glm-5.1
 ### 4.9 Escalation
 
 ```txt
-escalation-reviewer — openrouter/xiaomi/mimo-v2.5-pro
+escalation-reviewer — xiaomi/mimo-v2.5-pro
 ```
 
 ---
@@ -229,33 +229,33 @@ Use this as the conceptual model policy in `openclaw.json` or the equivalent Ope
   "agents": {
     "defaults": {
       "model": {
-        "primary": "openrouter/deepseek/deepseek-v4-pro",
+        "primary": "deepseek/deepseek-v4-pro",
         "fallbacks": [
-          "openrouter/deepseek/deepseek-v3.2"
+          "deepseek/deepseek-v3.2"
         ]
       },
       "models": {
-        "openrouter/deepseek/deepseek-v4-pro": {
+        "deepseek/deepseek-v4-pro": {
           "alias": "deepseek-v4-pro",
           "purpose": "PM coordination, high-quality validation, long-context reasoning"
         },
-        "openrouter/deepseek/deepseek-v3.2": {
+        "deepseek/deepseek-v3.2": {
           "alias": "deepseek-v3.2",
           "purpose": "PM fallback and lower-cost reasoning fallback"
         },
-        "openrouter/deepseek/deepseek-v4-flash": {
+        "deepseek/deepseek-v4-flash": {
           "alias": "deepseek-v4-flash",
           "purpose": "low-cost implementation, routine coding, SLR pipeline edits"
         },
-        "openrouter/qwen/qwen3-coder-flash": {
+        "qwen/qwen3-coder-flash": {
           "alias": "qwen3-coder-flash",
           "purpose": "coding-specialist implementation agent"
         },
-        "openrouter/z-ai/glm-5.1": {
+        "z-ai/glm-5.1": {
           "alias": "glm-5.1",
           "purpose": "independent validation, long-horizon code review, engineering-grade review"
         },
-        "openrouter/xiaomi/mimo-v2.5-pro": {
+        "xiaomi/mimo-v2.5-pro": {
           "alias": "mimo-v2.5-pro",
           "purpose": "escalation, arbitration, conflict resolution, high-risk review"
         }
@@ -277,9 +277,9 @@ This is a logical registry for agent assignment. The exact schema may need adjus
     "pm": {
       "role": "project-manager",
       "model": {
-        "primary": "openrouter/deepseek/deepseek-v4-pro",
+        "primary": "deepseek/deepseek-v4-pro",
         "fallbacks": [
-          "openrouter/deepseek/deepseek-v3.2"
+          "deepseek/deepseek-v3.2"
         ]
       },
       "can_call": [
@@ -317,126 +317,126 @@ This is a logical registry for agent assignment. The exact schema may need adjus
 
     "prog-impl-a": {
       "role": "programs-implementer",
-      "model": "openrouter/qwen/qwen3-coder-flash"
+      "model": "qwen/qwen3-coder-flash"
     },
     "prog-impl-b": {
       "role": "programs-implementer",
-      "model": "openrouter/deepseek/deepseek-v4-flash"
+      "model": "deepseek/deepseek-v4-flash"
     },
     "prog-val-a": {
       "role": "programs-validator",
-      "model": "openrouter/deepseek/deepseek-v4-pro"
+      "model": "deepseek/deepseek-v4-pro"
     },
     "prog-val-b": {
       "role": "programs-validator",
-      "model": "openrouter/z-ai/glm-5.1"
+      "model": "z-ai/glm-5.1"
     },
 
     "infra-impl-a": {
       "role": "infrastructure-implementer",
-      "model": "openrouter/qwen/qwen3-coder-flash"
+      "model": "qwen/qwen3-coder-flash"
     },
     "infra-impl-b": {
       "role": "infrastructure-implementer",
-      "model": "openrouter/deepseek/deepseek-v4-flash"
+      "model": "deepseek/deepseek-v4-flash"
     },
     "infra-val-a": {
       "role": "infrastructure-validator",
-      "model": "openrouter/deepseek/deepseek-v4-pro"
+      "model": "deepseek/deepseek-v4-pro"
     },
     "infra-val-b": {
       "role": "infrastructure-validator",
-      "model": "openrouter/z-ai/glm-5.1"
+      "model": "z-ai/glm-5.1"
     },
 
     "harvest-impl-a": {
       "role": "slr-harvest-implementer",
-      "model": "openrouter/deepseek/deepseek-v4-flash"
+      "model": "deepseek/deepseek-v4-flash"
     },
     "harvest-impl-b": {
       "role": "slr-harvest-implementer",
-      "model": "openrouter/qwen/qwen3-coder-flash"
+      "model": "qwen/qwen3-coder-flash"
     },
     "harvest-val-a": {
       "role": "slr-harvest-validator",
-      "model": "openrouter/deepseek/deepseek-v4-pro"
+      "model": "deepseek/deepseek-v4-pro"
     },
     "harvest-val-b": {
       "role": "slr-harvest-validator",
-      "model": "openrouter/z-ai/glm-5.1"
+      "model": "z-ai/glm-5.1"
     },
 
     "screen-impl-a": {
       "role": "slr-screen-implementer",
-      "model": "openrouter/deepseek/deepseek-v4-flash"
+      "model": "deepseek/deepseek-v4-flash"
     },
     "screen-impl-b": {
       "role": "slr-screen-implementer",
-      "model": "openrouter/qwen/qwen3-coder-flash"
+      "model": "qwen/qwen3-coder-flash"
     },
     "screen-val-a": {
       "role": "slr-screen-validator",
-      "model": "openrouter/deepseek/deepseek-v4-pro"
+      "model": "deepseek/deepseek-v4-pro"
     },
     "screen-val-b": {
       "role": "slr-screen-validator",
-      "model": "openrouter/z-ai/glm-5.1"
+      "model": "z-ai/glm-5.1"
     },
 
     "extract-impl-a": {
       "role": "slr-extract-implementer",
-      "model": "openrouter/qwen/qwen3-coder-flash"
+      "model": "qwen/qwen3-coder-flash"
     },
     "extract-impl-b": {
       "role": "slr-extract-implementer",
-      "model": "openrouter/deepseek/deepseek-v4-flash"
+      "model": "deepseek/deepseek-v4-flash"
     },
     "extract-val-a": {
       "role": "slr-extract-validator",
-      "model": "openrouter/deepseek/deepseek-v4-pro"
+      "model": "deepseek/deepseek-v4-pro"
     },
     "extract-val-b": {
       "role": "slr-extract-validator",
-      "model": "openrouter/z-ai/glm-5.1"
+      "model": "z-ai/glm-5.1"
     },
 
     "synth-impl-a": {
       "role": "slr-synthesis-implementer",
-      "model": "openrouter/deepseek/deepseek-v4-flash"
+      "model": "deepseek/deepseek-v4-flash"
     },
     "synth-impl-b": {
       "role": "slr-synthesis-implementer",
-      "model": "openrouter/qwen/qwen3-coder-flash"
+      "model": "qwen/qwen3-coder-flash"
     },
     "synth-val-a": {
       "role": "slr-synthesis-validator",
-      "model": "openrouter/deepseek/deepseek-v4-pro"
+      "model": "deepseek/deepseek-v4-pro"
     },
     "synth-val-b": {
       "role": "slr-synthesis-validator",
-      "model": "openrouter/z-ai/glm-5.1"
+      "model": "z-ai/glm-5.1"
     },
 
     "prisma-impl-a": {
       "role": "slr-prisma-implementer",
-      "model": "openrouter/deepseek/deepseek-v4-flash"
+      "model": "deepseek/deepseek-v4-flash"
     },
     "prisma-impl-b": {
       "role": "slr-prisma-implementer",
-      "model": "openrouter/qwen/qwen3-coder-flash"
+      "model": "qwen/qwen3-coder-flash"
     },
     "prisma-val-a": {
       "role": "slr-prisma-validator",
-      "model": "openrouter/deepseek/deepseek-v4-pro"
+      "model": "deepseek/deepseek-v4-pro"
     },
     "prisma-val-b": {
       "role": "slr-prisma-validator",
-      "model": "openrouter/z-ai/glm-5.1"
+      "model": "z-ai/glm-5.1"
     },
 
     "escalation-reviewer": {
       "role": "escalation-arbitrator",
-      "model": "openrouter/xiaomi/mimo-v2.5-pro",
+      "model": "xiaomi/mimo-v2.5-pro",
       "mode": "read-only-review",
       "called_by": [
         "pm"
@@ -612,19 +612,19 @@ The escalation reviewer should return `NEEDS HUMAN DECISION` when:
 
 ```txt
 PM
-- openrouter/deepseek/deepseek-v4-pro
-- fallback: openrouter/deepseek/deepseek-v3.2
+- deepseek/deepseek-v4-pro
+- fallback: deepseek/deepseek-v3.2
 
 Implementers
-- openrouter/qwen/qwen3-coder-flash
-- openrouter/deepseek/deepseek-v4-flash
+- qwen/qwen3-coder-flash
+- deepseek/deepseek-v4-flash
 
 Validators
-- openrouter/deepseek/deepseek-v4-pro
-- openrouter/z-ai/glm-5.1
+- deepseek/deepseek-v4-pro
+- z-ai/glm-5.1
 
 Escalation
-- openrouter/xiaomi/mimo-v2.5-pro
+- xiaomi/mimo-v2.5-pro
 ```
 
 ---

--- a/docs/openclaw/PM_MODEL_FAILOVER.md
+++ b/docs/openclaw/PM_MODEL_FAILOVER.md
@@ -10,13 +10,13 @@
 Primary PM model:
 
 ```text
-openrouter/xiaomi/mimo-v2.5-pro
+deepseek/deepseek-v4-pro
 ```
 
 Approved contingency model:
 
 ```text
-openai/gpt-5.4
+deepseek/deepseek-v3.2
 ```
 
 Use the contingency model when the primary model is unavailable due to:
@@ -31,7 +31,7 @@ Use the contingency model when the primary model is unavailable due to:
 ## Best Practice
 
 - Prefer keeping PM on the primary model during normal operation.
-- Treat failover to `gpt-5.4` as degraded mode.
+- Treat failover to `deepseek-v3.2` as degraded mode.
 - Record the switch in the operational handoff or incident note.
 - Do not enable automatic fallback until PM-only fallback scope is validated on the installed OpenClaw build.
 
@@ -43,7 +43,7 @@ Run on `elis-server` as the OpenClaw host user:
 
 ```bash
 openclaw config get agents.list --json
-openclaw config set agents.list.0.model openai/gpt-5.4
+openclaw config set agents.list.0.model deepseek/deepseek-v3.2
 systemctl --user restart openclaw-gateway
 openclaw doctor
 openclaw channels status --probe
@@ -52,7 +52,7 @@ openclaw config get agents.list --json
 
 Expected result:
 
-- PM agent model shows `openai/gpt-5.4`
+- PM agent model shows `deepseek/deepseek-v3.2`
 - `openclaw-gateway.service` remains active
 - Discord and Telegram still report `works`
 
@@ -63,7 +63,7 @@ Expected result:
 After primary access is restored:
 
 ```bash
-openclaw config set agents.list.0.model openrouter/xiaomi/mimo-v2.5-pro
+openclaw config set agents.list.0.model deepseek/deepseek-v4-pro
 systemctl --user restart openclaw-gateway
 openclaw doctor
 openclaw channels status --probe

--- a/docs/openclaw/PM_MODEL_FAILOVER.md
+++ b/docs/openclaw/PM_MODEL_FAILOVER.md
@@ -10,7 +10,7 @@
 Primary PM model:
 
 ```text
-anthropic/claude-opus-4-6
+openrouter/xiaomi/mimo-v2.5-pro
 ```
 
 Approved contingency model:
@@ -60,10 +60,10 @@ Expected result:
 
 ## Restore Primary Model
 
-After Anthropic access is restored:
+After primary access is restored:
 
 ```bash
-openclaw config set agents.list.0.model anthropic/claude-opus-4-6
+openclaw config set agents.list.0.model openrouter/xiaomi/mimo-v2.5-pro
 systemctl --user restart openclaw-gateway
 openclaw doctor
 openclaw channels status --probe

--- a/docs/openclaw/PM_MODEL_FAILOVER.md
+++ b/docs/openclaw/PM_MODEL_FAILOVER.md
@@ -10,13 +10,13 @@
 Primary PM model:
 
 ```text
-deepseek/deepseek-v4-pro
+openrouter/deepseek/deepseek-v4-pro
 ```
 
 Approved contingency model:
 
 ```text
-deepseek/deepseek-v3.2
+openrouter/deepseek/deepseek-v3.2
 ```
 
 Use the contingency model when the primary model is unavailable due to:
@@ -43,7 +43,7 @@ Run on `elis-server` as the OpenClaw host user:
 
 ```bash
 openclaw config get agents.list --json
-openclaw config set agents.list.0.model deepseek/deepseek-v3.2
+openclaw config set agents.list.0.model openrouter/deepseek/deepseek-v3.2
 systemctl --user restart openclaw-gateway
 openclaw doctor
 openclaw channels status --probe
@@ -52,7 +52,7 @@ openclaw config get agents.list --json
 
 Expected result:
 
-- PM agent model shows `deepseek/deepseek-v3.2`
+- PM agent model shows `openrouter/deepseek/deepseek-v3.2`
 - `openclaw-gateway.service` remains active
 - Discord and Telegram still report `works`
 
@@ -63,7 +63,7 @@ Expected result:
 After primary access is restored:
 
 ```bash
-openclaw config set agents.list.0.model deepseek/deepseek-v4-pro
+openclaw config set agents.list.0.model openrouter/deepseek/deepseek-v4-pro
 systemctl --user restart openclaw-gateway
 openclaw doctor
 openclaw channels status --probe

--- a/docs/openclaw/TARGET_LAYOUT.md
+++ b/docs/openclaw/TARGET_LAYOUT.md
@@ -316,7 +316,7 @@ The PM Agent should:
 
 Recommended PM model policy:
 
-- primary: `anthropic/claude-opus-4-6`
+- primary: `openrouter/xiaomi/mimo-v2.5-pro`
 - contingency: `openai/gpt-5.4`
 
 Best-practice rule:

--- a/docs/openclaw/TARGET_LAYOUT.md
+++ b/docs/openclaw/TARGET_LAYOUT.md
@@ -316,8 +316,8 @@ The PM Agent should:
 
 Recommended PM model policy:
 
-- primary: `deepseek/deepseek-v4-pro`
-- contingency: `deepseek/deepseek-v3.2`
+- primary: `openrouter/deepseek/deepseek-v4-pro`
+- contingency: `openrouter/deepseek/deepseek-v3.2`
 
 Best-practice rule:
 

--- a/docs/openclaw/TARGET_LAYOUT.md
+++ b/docs/openclaw/TARGET_LAYOUT.md
@@ -316,13 +316,13 @@ The PM Agent should:
 
 Recommended PM model policy:
 
-- primary: `openrouter/xiaomi/mimo-v2.5-pro`
-- contingency: `openai/gpt-5.4`
+- primary: `deepseek/deepseek-v4-pro`
+- contingency: `deepseek/deepseek-v3.2`
 
 Best-practice rule:
 
 - do not enable automatic fallback unless the installed OpenClaw build is verified to scope fallback safely for PM
-- until that is proven, treat `GPT-5.4` as a manual operator failover for PM only
+- until that is proven, treat `deepseek-v3.2` as a manual operator failover for PM only
 - record the switch as degraded mode in the operational log or handoff
 
 ---

--- a/docs/openclaw/openclaw_sanitised.json
+++ b/docs/openclaw/openclaw_sanitised.json
@@ -19,92 +19,92 @@
       {
         "id": "harvest-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-harvest",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "harvest-val-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-harvest",
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "screen-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-screen",
-        "model": "anthropic/claude-opus-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "screen-val-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-screen",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "extract-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-extract",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "extract-val-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-extract",
-        "model": "anthropic/claude-opus-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "synth-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-synth",
-        "model": "anthropic/claude-opus-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "synth-val-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-synth",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "prisma-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-prisma",
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "prisma-val-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-prisma",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "prog-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-prog-impl",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "prog-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-prog-impl",
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "prog-val-a",
         "workspace": "/home/samurai/openclaw/workspace-prog-val",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "prog-val-b",
         "workspace": "/home/samurai/openclaw/workspace-prog-val",
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "infra-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-infra-impl",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "infra-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-infra-impl",
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "infra-val-a",
         "workspace": "/home/samurai/openclaw/workspace-infra-val",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "infra-val-b",
         "workspace": "/home/samurai/openclaw/workspace-infra-val",
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       }
     ]
   },

--- a/docs/openclaw/openclaw_sanitised.json
+++ b/docs/openclaw/openclaw_sanitised.json
@@ -4,7 +4,7 @@
       {
         "id": "pm",
         "workspace": "/home/samurai/openclaw/workspace-pm",
-        "model": "openai/gpt-5-mini",
+        "model": "deepseek/deepseek-v4-pro",
         "tools": {
           "elevated": {
             "enabled": false,
@@ -19,17 +19,17 @@
       {
         "id": "harvest-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-harvest",
-        "model": "deepseek/deepseek-v4-pro"
+        "model": "qwen/qwen3-coder-flash"
       },
       {
         "id": "harvest-val-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-harvest",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "z-ai/glm-5.1"
       },
       {
         "id": "screen-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-screen",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "deepseek/deepseek-v4-flash"
       },
       {
         "id": "screen-val-a",
@@ -39,17 +39,17 @@
       {
         "id": "extract-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-extract",
-        "model": "deepseek/deepseek-v4-pro"
+        "model": "qwen/qwen3-coder-flash"
       },
       {
         "id": "extract-val-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-extract",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "z-ai/glm-5.1"
       },
       {
         "id": "synth-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-synth",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "deepseek/deepseek-v4-flash"
       },
       {
         "id": "synth-val-a",
@@ -59,7 +59,7 @@
       {
         "id": "prisma-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-prisma",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "deepseek/deepseek-v4-flash"
       },
       {
         "id": "prisma-val-a",
@@ -69,12 +69,12 @@
       {
         "id": "prog-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-prog-impl",
-        "model": "deepseek/deepseek-v4-pro"
+        "model": "qwen/qwen3-coder-flash"
       },
       {
         "id": "prog-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-prog-impl",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "deepseek/deepseek-v4-flash"
       },
       {
         "id": "prog-val-a",
@@ -84,17 +84,17 @@
       {
         "id": "prog-val-b",
         "workspace": "/home/samurai/openclaw/workspace-prog-val",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "z-ai/glm-5.1"
       },
       {
         "id": "infra-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-infra-impl",
-        "model": "deepseek/deepseek-v4-pro"
+        "model": "qwen/qwen3-coder-flash"
       },
       {
         "id": "infra-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-infra-impl",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "deepseek/deepseek-v4-flash"
       },
       {
         "id": "infra-val-a",
@@ -104,7 +104,7 @@
       {
         "id": "infra-val-b",
         "workspace": "/home/samurai/openclaw/workspace-infra-val",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "z-ai/glm-5.1"
       }
     ]
   },

--- a/openclaw/openclaw.json
+++ b/openclaw/openclaw.json
@@ -4,9 +4,28 @@
       {
         "id": "pm",
         "workspace": "/home/samurai/openclaw/workspace-pm",
-        "model": "openai/gpt-5-mini",
+        "model": "deepseek/deepseek-v4-pro",
         "subagents": {
-          "allowAgents": ["harvest-impl-a", "harvest-val-b", "screen-impl-b", "screen-val-a", "extract-impl-a", "extract-val-b", "synth-impl-b", "synth-val-a", "prisma-impl-b", "prisma-val-a", "prog-impl-a", "prog-impl-b", "prog-val-a", "prog-val-b", "infra-impl-a", "infra-impl-b", "infra-val-a", "infra-val-b"]
+          "allowAgents": [
+            "harvest-impl-a",
+            "harvest-val-b",
+            "screen-impl-b",
+            "screen-val-a",
+            "extract-impl-a",
+            "extract-val-b",
+            "synth-impl-b",
+            "synth-val-a",
+            "prisma-impl-b",
+            "prisma-val-a",
+            "prog-impl-a",
+            "prog-impl-b",
+            "prog-val-a",
+            "prog-val-b",
+            "infra-impl-a",
+            "infra-impl-b",
+            "infra-val-a",
+            "infra-val-b"
+          ]
         },
         "tools": {
           "elevated": {
@@ -22,17 +41,17 @@
       {
         "id": "harvest-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-harvest",
-        "model": "deepseek/deepseek-v4-pro"
+        "model": "qwen/qwen3-coder-flash"
       },
       {
         "id": "harvest-val-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-harvest",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "z-ai/glm-5.1"
       },
       {
         "id": "screen-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-screen",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "deepseek/deepseek-v4-flash"
       },
       {
         "id": "screen-val-a",
@@ -42,17 +61,17 @@
       {
         "id": "extract-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-extract",
-        "model": "deepseek/deepseek-v4-pro"
+        "model": "qwen/qwen3-coder-flash"
       },
       {
         "id": "extract-val-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-extract",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "z-ai/glm-5.1"
       },
       {
         "id": "synth-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-synth",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "deepseek/deepseek-v4-flash"
       },
       {
         "id": "synth-val-a",
@@ -62,7 +81,7 @@
       {
         "id": "prisma-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-prisma",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "deepseek/deepseek-v4-flash"
       },
       {
         "id": "prisma-val-a",
@@ -72,12 +91,12 @@
       {
         "id": "prog-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-prog-impl",
-        "model": "deepseek/deepseek-v4-pro"
+        "model": "qwen/qwen3-coder-flash"
       },
       {
         "id": "prog-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-prog-impl",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "deepseek/deepseek-v4-flash"
       },
       {
         "id": "prog-val-a",
@@ -87,17 +106,17 @@
       {
         "id": "prog-val-b",
         "workspace": "/home/samurai/openclaw/workspace-prog-val",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "z-ai/glm-5.1"
       },
       {
         "id": "infra-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-infra-impl",
-        "model": "deepseek/deepseek-v4-pro"
+        "model": "qwen/qwen3-coder-flash"
       },
       {
         "id": "infra-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-infra-impl",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "deepseek/deepseek-v4-flash"
       },
       {
         "id": "infra-val-a",
@@ -107,7 +126,7 @@
       {
         "id": "infra-val-b",
         "workspace": "/home/samurai/openclaw/workspace-infra-val",
-        "model": "openrouter/xiaomi/mimo-v2.5-pro"
+        "model": "z-ai/glm-5.1"
       }
     ]
   },

--- a/openclaw/openclaw.json
+++ b/openclaw/openclaw.json
@@ -5,6 +5,9 @@
         "id": "pm",
         "workspace": "/home/samurai/openclaw/workspace-pm",
         "model": "openai/gpt-5-mini",
+        "subagents": {
+          "allowAgents": ["harvest-impl-a", "harvest-val-b", "screen-impl-b", "screen-val-a", "extract-impl-a", "extract-val-b", "synth-impl-b", "synth-val-a", "prisma-impl-b", "prisma-val-a", "prog-impl-a", "prog-impl-b", "prog-val-a", "prog-val-b", "infra-impl-a", "infra-impl-b", "infra-val-a", "infra-val-b"]
+        },
         "tools": {
           "elevated": {
             "enabled": true,
@@ -19,92 +22,92 @@
       {
         "id": "harvest-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-harvest",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "harvest-val-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-harvest",
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "screen-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-screen",
-        "model": "anthropic/claude-opus-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "screen-val-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-screen",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "extract-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-extract",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "extract-val-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-extract",
-        "model": "anthropic/claude-opus-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "synth-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-synth",
-        "model": "anthropic/claude-opus-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "synth-val-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-synth",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "prisma-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-slr-prisma",
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "prisma-val-a",
         "workspace": "/home/samurai/openclaw/workspace-slr-prisma",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "prog-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-prog-impl",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "prog-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-prog-impl",
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "prog-val-a",
         "workspace": "/home/samurai/openclaw/workspace-prog-val",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "prog-val-b",
         "workspace": "/home/samurai/openclaw/workspace-prog-val",
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "infra-impl-a",
         "workspace": "/home/samurai/openclaw/workspace-infra-impl",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "infra-impl-b",
         "workspace": "/home/samurai/openclaw/workspace-infra-impl",
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       },
       {
         "id": "infra-val-a",
         "workspace": "/home/samurai/openclaw/workspace-infra-val",
-        "model": "openai/gpt-5.1-codex"
+        "model": "deepseek/deepseek-v4-pro"
       },
       {
         "id": "infra-val-b",
         "workspace": "/home/samurai/openclaw/workspace-infra-val",
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "openrouter/xiaomi/mimo-v2.5-pro"
       }
     ]
   },


### PR DESCRIPTION
Rewrites docs/openclaw/CODEX_AGENT_SETUP.md to the first-version OpenClaw model policy and aligns the related OpenClaw docs/config mirrors.

Summary:
- PM primary/fallback set to DeepSeek V4 Pro / DeepSeek V3.2
- Implementers use Qwen3 Coder Flash and DeepSeek V4 Flash
- Validators use DeepSeek V4 Pro and GLM-5.1
- MiMo remains the escalation reviewer
- Related OpenClaw catalogue/config docs updated for consistency