### PR TITLE
PE-ARCH-07: Execute Isolated Lobster Plugin Self-Test

### DIFF
--- a/.elis/pe/PE-ARCH-07/PE_TASK.md
+++ b/.elis/pe/PE-ARCH-07/PE_TASK.md
@@ -1,0 +1,70 @@
+# PE-ARCH-07 — Execute Isolated Lobster Plugin Self-Test
+
+## Objective
+Run the first controlled Lobster plugin self-test in the isolated `lobster-test` OpenClaw profile, without enabling Lobster in production and without running any production PE workflows.
+
+## Scope
+Documentation, planning, and harmless self-test evidence only. No production config edits. No production PE dispatch. No automatic push/PR/merge.
+
+## Required deliverables
+1. `.elis/pe/PE-ARCH-07/PE_TASK.md` — this file
+2. `HANDOFF.md` — planning or implementation handoff with complete status packet
+3. `docs/reports/PE_ARCH_07_Lobster_Self_Test_Report.md` — optional if test evidence is recorded
+4. `docs/runbooks/ELIS_Lobster_Plugin_Self_Test_Runbook.md` — only if results need to be appended
+5. `docs/architecture/ELIS_Lobster_Plugin_Test_Enablement.md` — only if findings change the enablement model
+
+## Current state analysis
+
+### What exists
+- `PE-ARCH-06` documented the isolated Lobster profile procedure and the test-profile enablement model
+- The Lobster plugin must remain isolated to the `lobster-test` profile
+- Production OpenClaw configuration must remain untouched
+- `CURRENT_PE.md` remains the authoritative active-PE registry and must be updated for this PE
+- PE-AGT-01 remains held and Increment 3 remains paused
+
+### What must happen next
+- Confirm the isolated `lobster-test` profile exists and is isolated from production
+- Verify Lobster registration in the test profile only
+- Run only the documented harmless self-test
+- Capture the command, output, rollback note, and evidence
+- Preserve production config and production PE workflows unchanged
+
+### What must remain unchanged
+- ❌ Production OpenClaw config
+- ❌ Production Lobster enablement
+- ❌ Production PE workflows
+- ❌ PE-AGT-01 continuation / resumption
+- ❌ PE-OPS-01 Increment 3 resumption
+- ❌ Push / PR / merge before validation and Carlos authorisation
+- ❌ Any non-reversible test state
+
+## Proposed staffing (provider-guarded)
+- **Implementer**: infra-impl-b
+- **Validator**: infra-val-a
+
+> Do not dispatch implementation until provider status is rechecked and confirmed PASS, or Carlos explicitly waives the provider guard.
+
+## Self-test command plan
+```bash
+ls ~/.openclaw/profiles/lobster-test/openclaw.json && echo "PROFILE_CONFIG_OK"
+grep -q '"extensions".*"lobster"' ~/.openclaw/profiles/lobster-test/openclaw.json && echo "LOBSTER_REGISTERED"
+ls ~/.openclaw/openclaw.json && echo "PROD_CONFIG_EXISTS"
+grep -c '"extensions"' ~/.openclaw/openclaw.json || echo "PROD_NO_EXTENSIONS"
+test -f /opt/openclaw/lib/node_modules/openclaw/dist/extensions/lobster/index.js && echo "EXTENSION_BINARY_OK"
+```
+
+## Acceptance criteria
+- [ ] The isolated test profile is defined clearly and does not alter production config
+- [ ] Lobster is documented as enabled only in `lobster-test`
+- [ ] The self-test stays harmless and does not run a production PE workflow
+- [ ] Activation / verification / rollback / failure modes are documented or referenced
+- [ ] `HANDOFF.md` carries a clear status packet for the next validation step
+- [ ] `python scripts/check_current_pe.py` passes once the planning update is applied
+- [ ] No production config or runtime config is modified
+- [ ] No workflow execution is claimed outside the isolated test profile
+
+## Mandatory principles
+- **Do not modify production config** — this PE is to plan and validate an isolated test-profile self-test, not to execute production changes
+- **Do not claim production readiness** — the test profile is isolated and non-production by design
+- **Do not run production workflows** — any Lobster use must remain within the isolated test profile
+- **All work within this repository only**: `/opt/elis/repo`

--- a/CURRENT_PE.md
+++ b/CURRENT_PE.md
@@ -132,7 +132,7 @@
 | PE-ARCH-03      | architecture   | infra-impl-a         | infra-val-b        | feature/pe-arch-03-lobster-dry-run-stub                                 | merged          | 2026-05-02   |
 | PE-ARCH-04      | architecture   | infra-impl-b         | infra-val-a        | feature/pe-arch-04-lobster-controlled-workflow-dry-run                  | merged          | 2026-05-02   |
 | PE-ARCH-05      | architecture   | infra-impl-a         | infra-val-b        | feature/pe-arch-05-lobster-plugin-controlled-test-profile               | merged          | 2026-05-02   |
-| PE-ARCH-06      | architecture   | infra-impl-a         | infra-val-b        | feature/pe-arch-06-controlled-lobster-plugin-activation-self-test       | planning        | 2026-05-02   |
+| PE-ARCH-06      | architecture   | infra-impl-a         | infra-val-b        | feature/pe-arch-06-controlled-lobster-plugin-activation-self-test       | merged          | 2026-05-02   |
 | PE-ARCH-07      | architecture   | infra-impl-b         | infra-val-a        | feature/pe-arch-07-execute-isolated-lobster-plugin-self-test            | planning        | 2026-05-02   |
 | PE-AGT-01       | infra          | infra-impl-a         | infra-val-b        | feature/pe-agt-01-pm-agent-review                                       | blocked         | 2026-05-02   |
 

--- a/CURRENT_PE.md
+++ b/CURRENT_PE.md
@@ -24,7 +24,7 @@
 | PE      | PE-ARCH-07 |
 | Branch  | feature/pe-arch-07-execute-isolated-lobster-plugin-self-test |
 
-> **Active PE.** PE-ARCH-07 — Execute Isolated Lobster Plugin Self-Test. PE-AGT-01 remains held; PE-ARCH-06 stays planning until separately resolved.
+> **Active PE.** PE-ARCH-07 — Execute Isolated Lobster Plugin Self-Test. Implementation is in progress; PE-AGT-01 remains held and PE-ARCH-06 stays planning until separately resolved.
 
 ---
 
@@ -35,7 +35,7 @@
 | infra-impl-b | Implementer |
 | infra-val-a  | Validator |
 
-> Active PE roles: infra-impl-b = Implementer, infra-val-a = Validator. PE-ARCH-07 follows the alternating infra track; provider guard still applies before dispatch.
+> Active PE roles: infra-impl-b = Implementer, infra-val-a = Validator. PE-ARCH-07 follows the alternating infra track; provider guard was satisfied and implementation is now in progress.
 
 ---
 
@@ -133,7 +133,7 @@
 | PE-ARCH-04      | architecture   | infra-impl-b         | infra-val-a        | feature/pe-arch-04-lobster-controlled-workflow-dry-run                  | merged          | 2026-05-02   |
 | PE-ARCH-05      | architecture   | infra-impl-a         | infra-val-b        | feature/pe-arch-05-lobster-plugin-controlled-test-profile               | merged          | 2026-05-02   |
 | PE-ARCH-06      | architecture   | infra-impl-a         | infra-val-b        | feature/pe-arch-06-controlled-lobster-plugin-activation-self-test       | merged          | 2026-05-02   |
-| PE-ARCH-07      | architecture   | infra-impl-b         | infra-val-a        | feature/pe-arch-07-execute-isolated-lobster-plugin-self-test            | planning        | 2026-05-02   |
+| PE-ARCH-07      | architecture   | infra-impl-b         | infra-val-a        | feature/pe-arch-07-execute-isolated-lobster-plugin-self-test            | implementing    | 2026-05-02   |
 | PE-AGT-01       | infra          | infra-impl-a         | infra-val-b        | feature/pe-agt-01-pm-agent-review                                       | blocked         | 2026-05-02   |
 
 Valid status values:

--- a/CURRENT_PE.md
+++ b/CURRENT_PE.md
@@ -21,10 +21,10 @@
 
 | Field   | Value |
 |---------|-------|
-| PE      | PE-AGT-01 |
-| Branch  | feature/pe-agt-01-pm-agent-review |
+| PE      | PE-ARCH-07 |
+| Branch  | feature/pe-arch-07-execute-isolated-lobster-plugin-self-test |
 
-> **Active PE.** PE-AGT-01 — PM Agent Review. PE-ARCH-05 is merged; PE-AGT-01 remains held pending authorised continuation.
+> **Active PE.** PE-ARCH-07 — Execute Isolated Lobster Plugin Self-Test. PE-AGT-01 remains held; PE-ARCH-06 stays planning until separately resolved.
 
 ---
 
@@ -32,10 +32,10 @@
 
 | Agent       | Role |
 |-------------|------|
-| infra-impl-a | Implementer |
-| infra-val-b  | Validator |
+| infra-impl-b | Implementer |
+| infra-val-a  | Validator |
 
-> Active PE roles: infra-impl-a = Implementer, infra-val-b = Validator. PE-AGT-01 follows the alternating infra track.
+> Active PE roles: infra-impl-b = Implementer, infra-val-a = Validator. PE-ARCH-07 follows the alternating infra track; provider guard still applies before dispatch.
 
 ---
 
@@ -133,6 +133,7 @@
 | PE-ARCH-04      | architecture   | infra-impl-b         | infra-val-a        | feature/pe-arch-04-lobster-controlled-workflow-dry-run                  | merged          | 2026-05-02   |
 | PE-ARCH-05      | architecture   | infra-impl-a         | infra-val-b        | feature/pe-arch-05-lobster-plugin-controlled-test-profile               | merged          | 2026-05-02   |
 | PE-ARCH-06      | architecture   | infra-impl-a         | infra-val-b        | feature/pe-arch-06-controlled-lobster-plugin-activation-self-test       | planning        | 2026-05-02   |
+| PE-ARCH-07      | architecture   | infra-impl-b         | infra-val-a        | feature/pe-arch-07-execute-isolated-lobster-plugin-self-test            | planning        | 2026-05-02   |
 | PE-AGT-01       | infra          | infra-impl-a         | infra-val-b        | feature/pe-agt-01-pm-agent-review                                       | blocked         | 2026-05-02   |
 
 Valid status values:

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -138,3 +138,50 @@ Opened PE-ARCH-06 — Controlled Lobster Plugin Activation Self-Test as a planni
 - `docs/architecture/ELIS_Lobster_Plugin_Test_Enablement.md` only if needed
 - `HANDOFF.md`
 - `workflows/README.md` only if the invocation contract changes
+
+# PE-ARCH-07 Planning Note
+
+## Summary
+Opened PE-ARCH-07 — Execute Isolated Lobster Plugin Self-Test as the next architecture PE. The goal is to validate the Lobster plugin in the isolated `lobster-test` profile without enabling production Lobster or running production PE workflows.
+
+## PE context
+
+| Field | Value |
+|-------|-------|
+| PE-ID | PE-ARCH-07 |
+| Title | Execute Isolated Lobster Plugin Self-Test |
+| Branch | `feature/pe-arch-07-execute-isolated-lobster-plugin-self-test` |
+| Implementer | infra-impl-b (provider-guarded; alternation-aligned) |
+| Validator | infra-val-a |
+| Status | planning |
+
+## Notes
+- The isolated `lobster-test` profile is the only target.
+- Production OpenClaw config remains untouched.
+- PE-AGT-01 remains held.
+- PE-OPS-01 Increment 3 remains paused.
+- Do not dispatch implementation until the worktree is prepared and provider status is confirmed or explicitly waived by Carlos.
+
+## Expected deliverables for the implementation step
+- `.elis/pe/PE-ARCH-07/PE_TASK.md`
+- `HANDOFF.md`
+- `docs/reports/PE_ARCH_07_Lobster_Self_Test_Report.md` (if evidence is recorded)
+- `docs/runbooks/ELIS_Lobster_Plugin_Self_Test_Runbook.md` (only if appending results)
+- `docs/architecture/ELIS_Lobster_Plugin_Test_Enablement.md` (only if findings change the enablement model)
+
+## Status packet
+
+| Field | Value |
+|-------|-------|
+| PE | PE-ARCH-07 |
+| Branch | `feature/pe-arch-07-execute-isolated-lobster-plugin-self-test` |
+| Current state | planning |
+| Last activity | Opened PE-ARCH-07, created task packet, and recorded the isolated self-test plan |
+| Expected artefacts | `PE_TASK.md` ✅, `HANDOFF.md` ✅ |
+| Missing artefacts | None for planning; implementation artefacts not yet expected |
+| Errors | None |
+| Next owner | infra-impl-b (after provider status confirmation) |
+| Next action | Prepare the isolated worktree and dispatch implementation only after Carlos authorises |
+| Provider guard | Implementation is provisionally assigned to infra-impl-b to satisfy alternation; do not dispatch until provider status is verified PASS or Carlos waives the guard |
+| Production config | Untouched |
+| Safe to dispatch implementation | Yes, once the worktree is prepared and the provider guard is satisfied |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,187 +1,43 @@
-# PE-ARCH-05 Lobster Plugin Controlled Test Profile — Handoff
+# PE-ARCH-07 — Execute Isolated Lobster Plugin Self-Test
 
 ## Summary
-Documented the architecture and procedure for enabling the bundled Lobster plugin in an isolated OpenClaw test profile (`lobster-test`). Delivered a 4-file documentation package covering the test-profile architecture, isolation model, safe invocation path, enablement/preflight/self-test/rollback runbook, and explicit no-production-readiness statements. This PE is documentation-only; no test profile was created, no production config was modified, no Lobster workflow was executed.
+Implemented the isolated `lobster-test` profile fixture, ran the harmless Lobster self-test checks, and documented the results. Production OpenClaw config was not modified and no production PE workflow was run.
 
 ## PE context
 
 | Field | Value |
-|-------|-------|
-| PE-ID | PE-ARCH-05 |
-| Title | Enable Bundled Lobster Plugin in a Controlled Test Profile |
-| Branch | `feature/pe-arch-05-lobster-plugin-controlled-test-profile` |
-| Worktree | `/opt/elis/agent-worktrees/PE-ARCH-05-infra-impl-b` |
+|---|---|
+| PE-ID | PE-ARCH-07 |
+| Title | Execute Isolated Lobster Plugin Self-Test |
+| Branch | `feature/pe-arch-07-execute-isolated-lobster-plugin-self-test` |
+| Worktree | `/opt/elis/agent-worktrees/PE-ARCH-07-infra-impl-b` |
 | Implementer | infra-impl-b |
 | Validator | infra-val-a |
 | Status | implementing → handoff-written |
 
-## Implementation summary
-
-### What was delivered
-
-| File | Action | Description |
-|------|--------|-------------|
-| `.elis/pe/PE-ARCH-05/PE_TASK.md` | Created | PE task packet with scope, current state analysis, acceptance criteria, and mandatory principles |
-| `docs/architecture/ELIS_Lobster_Plugin_Test_Enablement.md` | Created | Architecture analysis: OpenClaw profiles model, isolation boundaries, test-profile-only guardrails, safe invocation path, security boundaries, rollback procedure, and explicit no-production-readiness statement |
-| `docs/runbooks/ELIS_Lobster_Plugin_Enablement_Runbook.md` | Created | Step-by-step runbook: preflight checks (4 categories), test-profile creation, self-test (4 verifications), daily-use invocation, rollback (5 steps), troubleshooting table, quick-reference appendix, and no-production-readiness reminder |
-| `HANDOFF.md` | Overwritten | This file — implementation handoff with complete status packet (replaces stale PE-ARCH-04 handoff) |
-
-### Key architectural choices
-
-1. **Profile isolation**: Uses OpenClaw's native profile mechanism (`OPENCLAW_PROFILE` env / `--profile` flag) to create a fully isolated gateway with its own config, data directory, and port binding. Production config (`~/.openclaw/openclaw.json`) is never touched.
-2. **Lobster extension registration**: The Lobster extension is registered only in `~/.openclaw/profiles/lobster-test/openclaw.json` via the `"extensions": ["lobster"]` key. No modifications to production config.
-3. **Safe invocation path**: Agents invoke Lobster via `node /opt/openclaw/lib/node_modules/openclaw/dist/extensions/lobster/index.js run ...`, not through a system-level binary. This keeps the invocation scoped to the existing OpenClaw installation.
-4. **Guardrails**: Every invocation requires profile-isolation preflight, dry-run, and human approval gates. Explicit no-production-readiness statements in every document.
-
-### What was NOT done
-
-- ❌ No production config modified (`~/.openclaw/openclaw.json` untouched)
-- ❌ No test profile created (documentation-only PE)
-- ❌ No gateway restarted or started
-- ❌ No Lobster workflow executed
-- ❌ No `.lobster` files modified
-- ❌ No workflows/README.md modified
-- ❌ No CI configuration modified
-- ❌ No pushes, PRs, or merges
-
-## Changed files
+## What changed
 
 | File | Action |
-|------|--------|
-| `.elis/pe/PE-ARCH-05/PE_TASK.md` | Created |
-| `docs/architecture/ELIS_Lobster_Plugin_Test_Enablement.md` | Created |
-| `docs/runbooks/ELIS_Lobster_Plugin_Enablement_Runbook.md` | Created |
-| `HANDOFF.md` | Overwritten (was stale PE-ARCH-04 handoff) |
+|---|---|
+| `CURRENT_PE.md` | Updated PE-ARCH-07 from planning to implementing |
+| `docs/reports/PE_ARCH_07_Lobster_Self_Test_Report.md` | Created |
+| `docs/runbooks/ELIS_Lobster_Plugin_Self_Test_Runbook.md` | Created |
 
-## Checks run
+## Self-test evidence
 
-| Check | Result |
-|-------|--------|
-| `pwd` | `/opt/elis/agent-worktrees/PE-ARCH-05-infra-impl-b` ✅ |
-| `git rev-parse --abbrev-ref HEAD` | `feature/pe-arch-05-lobster-plugin-controlled-test-profile` ✅ |
-| `git rev-parse HEAD` | `877498a206528dc2e759e1fd092c29d2da53de7c` (pre-commit) |
-| `git status --short` | See below |
-| `test -f .elis/pe/PE-ARCH-05/PE_TASK.md` | ✅ Created |
-| `test -f docs/architecture/ELIS_Lobster_Plugin_Test_Enablement.md` | ✅ Created |
-| `test -f docs/runbooks/ELIS_Lobster_Plugin_Enablement_Runbook.md` | ✅ Created |
-| `test -f HANDOFF.md` | ✅ Created |
-| `python scripts/check_current_pe.py` | TBD (will run before commit) |
-| No production config modified | ✅ Confirmed (no writes outside worktree) |
-| No `.lobster` files modified | ✅ Confirmed (`git diff --name-only` shows no `.lobster` changes) |
-| No workflow execution claimed | ✅ Confirmed — all deliverables state documentation-only status |
+- Test profile created at `~/.openclaw/profiles/lobster-test/openclaw.json`
+- Lobster registered in the test profile
+- Production config exists and still has no `extensions` section
+- Lobster extension binary is reachable at `/opt/openclaw/lib/node_modules/openclaw/dist/extensions/lobster/index.js`
+- No production PE workflow was run
 
 ## Status packet
 
 | Field | Value |
-|-------|-------|
-| PE | PE-ARCH-05 |
-| Branch | `feature/pe-arch-05-lobster-plugin-controlled-test-profile` |
+|---|---|
 | Current state | implement-handoff-complete |
-| Last activity | Created PE task packet + Lobster test-profile enablement architecture + runbook + handoff |
-| Expected artefacts | `PE_TASK.md` ✅, `ELIS_Lobster_Plugin_Test_Enablement.md` ✅, `ELIS_Lobster_Plugin_Enablement_Runbook.md` ✅, `HANDOFF.md` ✅ |
-| Missing artefacts | None |
-| Errors | None |
-| Next owner | infra-val-a (validator) |
-| Next action | REVIEW.md — verify artefacts, confirm no production config changes, confirm no false execution claims, confirm no-production-readiness statements present, run checks, issue PASS/FAIL verdict |
-| Lobster plugin state | Documented: bundled but disabled in production; test-profile enablement path specified; no active test profile |
-| Invocation contract | Documented in `docs/architecture/ELIS_Lobster_Plugin_Test_Enablement.md` |
-| Test-profile isolation | Documented — OpenClaw native profile mechanism, separate config/data/logs, localhost-only port binding |
-| No-production-readiness | Stated explicitly in all 3 authored documents |
-| False execution claims | Avoided — all deliverables state current state truthfully |
-| Working tree clean | TBD (before commit) |
-| Ready for validator | ✅ Yes (after commit) |
-
-## Commit tracking (to be populated)
-
-| Field | Value |
-|-------|-------|
-| HEAD (before commit) | `877498a206528dc2e759e1fd092c29d2da53de7c` |
-| Commit status | Pending (will commit after all artefacts verified) |
-| GPG-signed | Not configured (bot commit) |
-
-## Validator notes
-- All deliverables are documentation-only. No code, CI, or workflow modification.
-- The test-profile enablement path describes a future action, not a current one.
-- No `.lobster` file is claimed as executable.
-- The no-production-readiness statement appears in all three authored documents.
-- Verify that no file outside the four expected deliverables was modified.
-- Verify that production config (`~/.openclaw/openclaw.json`) is not referenced as modified.
-- Verify that no Lobster workflow execution or test-profile creation is claimed.
-
----
-
-# PE-ARCH-06 Planning Note
-
-## Summary
-Opened PE-ARCH-06 — Controlled Lobster Plugin Activation Self-Test as a planning entry only. This prepares the isolated OpenClaw test-profile enablement task without dispatching implementation.
-
-## PE context
-
-| Field | Value |
-|-------|-------|
-| PE-ID | PE-ARCH-06 |
-| Title | Controlled Lobster Plugin Activation Self-Test |
-| Branch | `feature/pe-arch-06-controlled-lobster-plugin-activation-self-test` |
-| Implementer | infra-impl-a (provisional; provider guard pending recheck) |
-| Validator | infra-val-b (provisional) |
-| Status | planning |
-
-## Notes
-- PE-AGT-01 remains held.
-- PE-OPS-01 Increment 3 remains paused.
-- No implementation work, test profile creation, or Lobster execution has been dispatched yet.
-- The next step is to validate provider status and then dispatch implementation only if Carlos authorises it.
-
-## Expected deliverables for the future implementation step
-- `.elis/pe/PE-ARCH-06/PE_TASK.md`
-- `docs/runbooks/ELIS_Lobster_Plugin_Self_Test_Runbook.md`
-- `docs/architecture/ELIS_Lobster_Plugin_Test_Enablement.md` only if needed
-- `HANDOFF.md`
-- `workflows/README.md` only if the invocation contract changes
-
-# PE-ARCH-07 Planning Note
-
-## Summary
-Opened PE-ARCH-07 — Execute Isolated Lobster Plugin Self-Test as the next architecture PE. The goal is to validate the Lobster plugin in the isolated `lobster-test` profile without enabling production Lobster or running production PE workflows.
-
-## PE context
-
-| Field | Value |
-|-------|-------|
-| PE-ID | PE-ARCH-07 |
-| Title | Execute Isolated Lobster Plugin Self-Test |
-| Branch | `feature/pe-arch-07-execute-isolated-lobster-plugin-self-test` |
-| Implementer | infra-impl-b (provider-guarded; alternation-aligned) |
-| Validator | infra-val-a |
-| Status | planning |
-
-## Notes
-- The isolated `lobster-test` profile is the only target.
-- Production OpenClaw config remains untouched.
-- PE-AGT-01 remains held.
-- PE-OPS-01 Increment 3 remains paused.
-- Do not dispatch implementation until the worktree is prepared and provider status is confirmed or explicitly waived by Carlos.
-
-## Expected deliverables for the implementation step
-- `.elis/pe/PE-ARCH-07/PE_TASK.md`
-- `HANDOFF.md`
-- `docs/reports/PE_ARCH_07_Lobster_Self_Test_Report.md` (if evidence is recorded)
-- `docs/runbooks/ELIS_Lobster_Plugin_Self_Test_Runbook.md` (only if appending results)
-- `docs/architecture/ELIS_Lobster_Plugin_Test_Enablement.md` (only if findings change the enablement model)
-
-## Status packet
-
-| Field | Value |
-|-------|-------|
-| PE | PE-ARCH-07 |
-| Branch | `feature/pe-arch-07-execute-isolated-lobster-plugin-self-test` |
-| Current state | planning |
-| Last activity | Opened PE-ARCH-07, created task packet, and recorded the isolated self-test plan |
-| Expected artefacts | `PE_TASK.md` ✅, `HANDOFF.md` ✅ |
-| Missing artefacts | None for planning; implementation artefacts not yet expected |
-| Errors | None |
-| Next owner | infra-impl-b (after provider status confirmation) |
-| Next action | Prepare the isolated worktree and dispatch implementation only after Carlos authorises |
-| Provider guard | Implementation is provisionally assigned to infra-impl-b to satisfy alternation; do not dispatch until provider status is verified PASS or Carlos waives the guard |
+| Next owner | infra-val-a |
+| Next action | Review the repo artefacts, confirm the self-test evidence, and write REVIEW.md |
 | Production config | Untouched |
-| Safe to dispatch implementation | Yes, once the worktree is prepared and the provider guard is satisfied |
+| Test profile | Present and isolated |
+| Ready for validator | Yes |

--- a/docs/reports/PE_ARCH_07_Lobster_Self_Test_Report.md
+++ b/docs/reports/PE_ARCH_07_Lobster_Self_Test_Report.md
@@ -1,0 +1,34 @@
+# PE-ARCH-07 Lobster Self-Test Report
+
+## Summary
+Implemented the isolated `lobster-test` profile fixture and ran the harmless self-test checks against it. The test stayed out of production config and did not run any production PE workflow.
+
+## Results
+- Test profile created: yes
+- Test profile path: `~/.openclaw/profiles/lobster-test/openclaw.json`
+- Lobster registered in test profile: yes
+- Production config untouched: yes
+- Lobster extension binary reachable: yes
+- Production PE workflow run: no
+
+## Evidence
+Commands run:
+```bash
+ls ~/.openclaw/profiles/lobster-test/openclaw.json && echo "PROFILE_CONFIG_OK"
+grep -q '"extensions".*"lobster"' ~/.openclaw/profiles/lobster-test/openclaw.json && echo "LOBSTER_REGISTERED"
+ls ~/.openclaw/openclaw.json && echo "PROD_CONFIG_EXISTS"
+grep -c '"extensions"' ~/.openclaw/openclaw.json || echo "PROD_NO_EXTENSIONS"
+test -f /opt/openclaw/lib/node_modules/openclaw/dist/extensions/lobster/index.js && echo "EXTENSION_BINARY_OK"
+```
+
+Observed output:
+- `PROFILE_CONFIG_OK`
+- `LOBSTER_REGISTERED`
+- `PROD_CONFIG_EXISTS`
+- `PROD_NO_EXTENSIONS`
+- `EXTENSION_BINARY_OK`
+
+## Notes
+- The self-test was formatting-sensitive; the profile JSON was normalised so the planned grep check could validate the Lobster registration line cleanly.
+- No production OpenClaw config file was modified.
+- No Lobster workflow execution was attempted.

--- a/docs/runbooks/ELIS_Lobster_Plugin_Self_Test_Runbook.md
+++ b/docs/runbooks/ELIS_Lobster_Plugin_Self_Test_Runbook.md
@@ -1,0 +1,38 @@
+# ELIS Lobster Plugin Self-Test Runbook
+
+**Runbook ID**: RB-LOBSTER-TEST-02
+**PE context**: PE-ARCH-07 (`feature/pe-arch-07-execute-isolated-lobster-plugin-self-test`)
+**Author**: infra-impl-b
+**Date**: 2026-05-02
+
+## Purpose
+
+Document the isolated `lobster-test` profile self-test used for PE-ARCH-07. This is a harmless profile check only: no production config changes, no production PE workflow runs, and no Lobster enablement outside the test profile.
+
+## Self-test procedure used
+
+```bash
+ls ~/.openclaw/profiles/lobster-test/openclaw.json && echo "PROFILE_CONFIG_OK"
+grep -q '"extensions".*"lobster"' ~/.openclaw/profiles/lobster-test/openclaw.json && echo "LOBSTER_REGISTERED"
+ls ~/.openclaw/openclaw.json && echo "PROD_CONFIG_EXISTS"
+grep -c '"extensions"' ~/.openclaw/openclaw.json || echo "PROD_NO_EXTENSIONS"
+test -f /opt/openclaw/lib/node_modules/openclaw/dist/extensions/lobster/index.js && echo "EXTENSION_BINARY_OK"
+```
+
+## Observed results
+
+- `PROFILE_CONFIG_OK`
+- `LOBSTER_REGISTERED`
+- `PROD_CONFIG_EXISTS`
+- `PROD_NO_EXTENSIONS`
+- `EXTENSION_BINARY_OK`
+
+## Rollback note
+
+If the test profile ever needs removal, delete only `~/.openclaw/profiles/lobster-test/` after stopping the test-profile gateway. Production `~/.openclaw/openclaw.json` remains untouched.
+
+## Non-goals
+
+- No production OpenClaw edits
+- No production Lobster enablement
+- No production PE workflow execution


### PR DESCRIPTION
## Objective
Run the isolated Lobster plugin self-test in the `lobster-test` profile only, without touching production OpenClaw config or running any production PE workflow.

## Changed files
- `CURRENT_PE.md`
- `HANDOFF.md`
- `docs/reports/PE_ARCH_07_Lobster_Self_Test_Report.md`
- `docs/runbooks/ELIS_Lobster_Plugin_Self_Test_Runbook.md`

## Validation
- Result: PASS
- Commit validated: `a3248ef84b97297a05711656ceb32655bb8305d1`
- Self-test result: PASS
- Only `lobster-test` profile used: yes
- Production config untouched: yes
- Lobster enabled in production: no
- No production PE workflow run: yes
- `CURRENT_PE.md` transition coherent: yes
- `check_current_pe.py`: PASS
- Evidence sufficient: yes

## Note
- Commit message uses `PM-CHORE` prefix; validation treated this as non-blocking.

## Holds
- Increment 3 remains paused.
- PE-AGT-01 remains held.

## Merge policy
- No automatic merge is authorised.
