### PR TITLE
PE-OPS-FIXED-WORKSPACES-01: add fixed workspace governance

### DIFF
--- a/.elis/pe/PE-OPS-FIXED-WORKSPACES-01/PE_TASK.md
+++ b/.elis/pe/PE-OPS-FIXED-WORKSPACES-01/PE_TASK.md
@@ -1,0 +1,127 @@
+# PE-OPS-FIXED-WORKSPACES-01 — PE Task Packet
+
+## PE_ID
+PE-OPS-FIXED-WORKSPACES-01
+
+## Objective
+Replace the PE-specific worktree model with a fixed agent workspace model and enforce a strict write-boundary rule.
+
+## Background
+ELIS governance must move from PE-scoped worktrees to agent-scoped fixed workspaces. GitHub remains the permanent system of record. Each agent has a fixed semi-persistent workspace, not a fully disposable one.
+
+## Governance lane
+Strict PE
+
+## Reason PE-GOV-RISK-TIER-01 is paused
+PE-GOV-RISK-TIER-01 is preserved as blocked pending fixed-workspace governance. This PE must not silently overwrite the active PE state.
+
+## Fixed agent workspace model
+Each agent writes only to its own fixed workspace path, bound to agent identity rather than PE ID.
+
+Agent runtime/context files must be preserved or regenerated during workspace reset.
+Disposable repo/task state may be cleaned after PE commit/PR/merge, abandonment, or supersession.
+
+Preserve unless explicitly authorised:
+- AGENTS.md
+- SKILLS.md
+- SOUL.md
+- agent profile/config/context files
+- tool manifests
+- OpenClaw/Hermes bootstrap files required for agent operation
+
+Cleanup must target only disposable repository/task state, stale branches, uncommitted PE outputs, build artefacts, and temporary files.
+
+Canonical examples:
+- /opt/elis/agent-worktrees/pm
+- /opt/elis/agent-worktrees/infra-impl-a
+- /opt/elis/agent-worktrees/infra-impl-b
+- /opt/elis/agent-worktrees/infra-val-a
+- /opt/elis/agent-worktrees/infra-val-b
+- /opt/elis/agent-worktrees/github-agent
+
+## System of record
+GitHub is the permanent system of record. Local agent workspaces are fixed, semi-persistent execution workspaces.
+
+## Agent write-boundary rule
+- PM writes only to the PM workspace.
+- Implementers write only to their own implementer workspace.
+- Validators write only to their own validator workspace.
+- Supervisor writes only to its own diagnostic/workspace area if explicitly allowed.
+- PO Advisor has no repo/worktree/GitHub write authority.
+- No PM, Implementer, Validator, Supervisor, or PO Advisor may push, open PRs, merge, comment, label, approve, request changes, or otherwise write to GitHub directly.
+- GitHub Agent may write to GitHub only after explicit PM/PO approval, under the applicable governance lane.
+- No agent may write to another agent’s workspace.
+
+## Required documents
+### Opening / planning
+- CURRENT_PE.md
+- .elis/pe/PE-OPS-FIXED-WORKSPACES-01/PE_TASK.md
+
+### Deliverable scope
+- AGENTS.md
+- docs/governance/ELIS_PE_Operating_Protocol.md
+- docs/governance/ELIS_GitHub_Agent_Operating_Model.md
+- docs/governance/ELIS_Worktree_Preflight_Checklist.md
+- docs/governance/ELIS_PE_Dispatch_Checklist.md
+- docs/templates/PE_TASK.template.md
+- docs/templates/HANDOFF.template.md
+- docs/governance/ELIS_PO_Advisor_Operating_Model.md only if needed
+- docs/governance/ELIS_OpenClaw_Native_Operating_Model.md only if needed
+- docs/governance/ELIS_No_Silent_Failure_Recovery.md only if needed
+
+## Acceptance gates
+- pre-dispatch fixed workspace certificate
+- workspace reset-to-clean procedure
+- approved branch/base checkout
+- proof of pwd, git root, branch, HEAD, and clean status
+- post-run proof that writes occurred only inside the agent’s own fixed workspace
+- confirmation no GitHub write occurred except by GitHub Agent
+- wrong-worktree quarantine rule
+- no-copy rule for wrong-worktree output
+
+## Wrong-worktree quarantine rule
+If an agent writes in the wrong workspace, quarantine the output, do not copy it into the correct workspace, and treat the run as invalid until explicitly re-established in the correct fixed workspace.
+
+## No-copy rule
+Wrong-worktree output must never be copied, replayed, or reused as canonical deliverable content.
+
+## Opening-step restrictions
+- opening edits are limited to CURRENT_PE.md and .elis/pe/PE-OPS-FIXED-WORKSPACES-01/PE_TASK.md
+- do not edit deliverable governance/template files during opening
+- do not dispatch implementer during opening
+- do not modify Hermes/OpenClaw config
+- do not perform GitHub actions
+- do not push/open PR/merge during opening
+
+## Out of scope
+- Hermes/OpenClaw config changes
+- dispatching implementers
+- GitHub actions
+- PR creation
+- merges
+- non-governance code changes
+
+## Implementation deliverables
+- Update governance documents to define the fixed workspace model
+- Define the GitHub write-boundary rule and GitHub Agent exception
+- Define fixed-workspace preflight and quarantine behavior
+- Define PE task and handoff template requirements for workspace evidence
+- Preserve PE-GOV-RISK-TIER-01 as blocked pending this governance
+
+## Validation deliverables
+- Verify all governance language is internally consistent
+- Verify acceptance gates are explicit and testable
+- Verify wrong-worktree and no-copy rules are unambiguous
+- Verify no config/dispatch/PR/merge actions are introduced
+- Verify the blocked state for PE-GOV-RISK-TIER-01 is preserved
+
+## Acceptance criteria
+This PE is acceptable when the governance texts clearly establish:
+1. fixed agent workspace ownership,
+2. GitHub as system of record,
+3. strict write boundaries,
+4. GitHub Agent exception only with explicit approval,
+5. required preflight and proof gates,
+6. wrong-worktree quarantine,
+7. no-copy rule,
+8. preservation of PE-GOV-RISK-TIER-01 as blocked pending this governance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,35 +240,49 @@ ADR format and lifecycle are defined in `docs/decisions/README.md`.
 
 ## 3) Worktree lifecycle — mandatory for every PE
 
-### 3.1 Why worktrees
-Worktrees prevent:
+### 3.1 Why fixed workspaces
+Fixed workspaces (persistent worktrees per role slot) prevent:
 - checkout failures ("local changes would be overwritten"),
 - branch contamination (PE1 edits leaking into PE2),
 - agent collisions on shared files (e.g., `HANDOFF.md` / `REVIEW_PE<N>.md`),
-- VS Code Source Control accumulating stale GitHub connections from old branches.
+- stale worktree accumulation (no per-PE worktree lifecycle),
+- agent path confusion (each agent always knows its own fixed path).
 
 ### 3.2 When to use
-Worktrees are **required for every PE**, regardless of whether parallel work exists.
-The main repo folder always stays on `main`. Each PE branch lives in its own worktree.
+Fixed workspaces are **required for every PE**. Each agent role slot has a persistent worktree:
+```
+/opt/elis/agent-worktrees/<role>-<slot>
+```
+Examples: `/opt/elis/agent-worktrees/infra-impl-b`, `/opt/elis/agent-worktrees/infra-val-a`
 
-### 3.3 Worktree lifecycle rule
-**Create one worktree per PE at the start of the PE. Remove it immediately after the PR merges.**
-Never leave a worktree open for a merged branch.
+The main repo folder always stays on `main`. The branch checked out in each fixed workspace changes per PE; the worktree path does not.
 
-### 3.4 Commands (Windows / PowerShell friendly)
-From the *main* repo folder:
+### 3.3 Fixed workspace lifecycle
+**At PE start: reset the fixed workspace to a clean state and check out the PE branch.**
+After PE merge: the workspace is not removed (it is persistent). The branch is left in place until the next PE assignment, when it will be reset again.
+
+### 3.4 Reset procedure (start of each PE)
+From the fixed workspace root:
 
 ```bash
-# PE START — Implementer creates worktree on first commit
+# PE START — reset fixed workspace for new PE assignment
 git fetch --all --prune
-git worktree add ../ELIS_worktrees/pe-oc-XX feature/pe-oc-XX-description
+git checkout <pe-branch> 2>/dev/null || git checkout -b <pe-branch> origin/$BASE
+git rebase origin/$BASE 2>/dev/null || true
+git status -sb  # confirm clean
+```
 
-# Verify
-git worktree list
+If switching away from a previous PE branch that still has uncommitted work:
+```bash
+git stash  # or git reset --hard if state is disposable
+git checkout <new-pe-branch>
+```
 
-# PR MERGED — remove worktree immediately
-git worktree remove ../ELIS_worktrees/pe-oc-XX
-git worktree list   # confirm removed
+### 3.5 Commands
+```bash
+# Verify fixed workspace identity
+echo "Fixed workspace: $(pwd)"
+git worktree list | grep "$(pwd)"
 ```
 
 ---
@@ -379,6 +393,11 @@ Rules:
 - Completed steps must be marked `[x]` immediately, with pasted command output confirming the step.
 - If a step fails and is retried, keep it `[→]` until verification passes.
 
+**GitHub write boundary reminder for Implementer:**
+- Do NOT push, create PRs, or merge. These are PM/GitHub Agent operations.
+- Local commits only. PM receives Status Packet and handles remote writes.
+- If PM instructs push, verify the instruction came from PM explicitly. Never auto-push.
+
 **Tool note (both agents):** use the `TodoWrite` tool to maintain this list. Set status to
 `in_progress` before starting each step; set `completed` immediately after the step is
 verified with pasted output. Never batch completions.
@@ -448,6 +467,12 @@ Rules:
 - Completed steps must be marked `[x]` immediately, with pasted command output confirming the step.
 - In re-validation rounds, restart Updated Todos from step 1 and include round ID.
 
+**GitHub write boundary reminder for Validator:**
+- Do NOT push, create PRs, or merge. These are PM/GitHub Agent operations.
+- Validator local commits are limited to REVIEW file + adversarial tests.
+- PR comments and formal GitHub reviews are authorised when explicitly assigned by PM.
+- Never push implementation file changes.
+
 **Tool note (both agents):** use the `TodoWrite` tool to maintain this list. Set status to
 `in_progress` before starting each step; set `completed` immediately after the step is
 verified with pasted output. Never batch completions.
@@ -505,6 +530,9 @@ git log -5 --oneline --decorate
 ### 6.3 Scope evidence (against `origin/<base-branch>`)
 ```bash
 # BASE=$(grep "Base branch" CURRENT_PE.md | awk '{print $NF}')
+# The fixed workspace path MUST be the correct role+slot path:
+echo "Fixed workspace: $(pwd)"
+git rev-parse --show-toplevel
 git diff --name-status origin/$BASE..HEAD
 git diff --stat        origin/$BASE..HEAD
 ```
@@ -523,8 +551,19 @@ python -m pytest -q
 ### 6.5 PR evidence (if applicable)
 ```bash
 # BASE=$(grep "Base branch" CURRENT_PE.md | awk '{print $NF}')
-gh pr list --state open --base $BASE
-gh pr view <PR_NUMBER>
+# GitHub write boundary: implementer/validator run gh read-only commands only.
+# Push, PR creation, merge are PM or GitHub Agent operations.
+gh pr list --state open --base $BASE   # read-only — allowed for all roles
+git log -1 --oneline                    # confirm current commit
+```
+
+### 6.6 GitHub write boundary checklist (pre-remote-write gate)
+```bash
+# Verify role is authorised for remote write
+echo "Role: $(grep -i 'agent.*role' AGENTS.md 2>/dev/null || echo 'unknown')"
+# If role is implementer or validator: DO NOT PUSH. Notify PM instead.
+# Check CURRENT_PE.md for the authorised GitHub write operator:
+grep 'github.*write\|GitHub.*operator\|push.*authorised' CURRENT_PE.md 2>/dev/null
 ```
 
 ---
@@ -571,6 +610,8 @@ See `AUDITS.md` for the full audit spec and report templates.
 - Do not open, read, or reference any file listed in `.agentignore`.
 - Do not include secret values in Status Packets, HANDOFF.md, or any PR content.
 - Do not proceed if `check_agent_scope.py` returns exit code 1.
+- **Do NOT push, PR, or merge** as implementer or validator. Remote GitHub writes are PM/GitHub Agent operations.
+- **Do NOT work outside your fixed workspace.** Verify `pwd` matches your role's assigned path before any operation.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,25 @@ git stash  # or git reset --hard if state is disposable
 git checkout <new-pe-branch>
 ```
 
+### 3.4a Wrong-worktree quarantine and no-copy rules
+If an agent detects it is operating from the wrong worktree:
+1. Stop all file operations immediately.
+2. Do not copy, move, or commit any files from the wrong worktree.
+3. Report the mismatch to PM with full evidence (`pwd`, `git rev-parse --show-toplevel`, assigned path from CURRENT_PE.md).
+4. PM resets the correct fixed workspace and re-dispatches.
+5. Any artefacts produced from the wrong worktree are invalid.
+
+**No-copy rule:** Agents must never copy or transfer files between worktrees. If a file from one worktree is needed in another, commit it to the canonical repo from the correct worktree, then fetch in the target worktree.
+
+### 3.4b Fixed Workspace Binding Certificate
+Before any PE work begins, the agent must produce a **Fixed Workspace Binding Certificate** from within the fixed workspace. This certificate is mandatory evidence in the opening Status Packet (§6). See `docs/governance/ELIS_PE_Operating_Protocol.md §5.1b` for the full specification.
+
+### 3.4c Persistent vs disposable file separation
+Fixed workspaces contain **disposable repo/task state** (source code, HANDOFF, REVIEW, `.elis/` PE workspace). **Persistent agent runtime/context files** (AGENTS.md, SKILLS.md, SOUL.md, tool manifests, OpenClaw/Hermes bootstrap files) must reside outside the fixed worktree.
+- Do not write persistent runtime files into the fixed worktree.
+- If a persistent file accidentally lands in the worktree, move it out before the worktree is reset for the next PE.
+- When resetting a fixed workspace for a new PE, only disposable repo/task state is cleaned. Persistent runtime files are never modified during reset.
+
 ### 3.5 Commands
 ```bash
 # Verify fixed workspace identity
@@ -321,7 +340,21 @@ EOF
 1. **Preflight — before any work begins:**
    - Read all canonical references (Section 1).
    - Confirm your role assignment for this PE with the PM.
-   - Paste the opening Status Packet to the PM. No work starts before the PM acknowledges.
+   - **Produce the Fixed Workspace Binding Certificate** from inside the fixed workspace:
+     ```bash
+     echo "PE ID: $(grep 'PE ID' CURRENT_PE.md | head -1)"
+     echo "Agent ID: <agent-surface-name>"
+     echo "Fixed workspace: $(pwd)"
+     echo "Git root: $(git rev-parse --show-toplevel)"
+     echo "Branch: $(git branch --show-current)"
+     echo "HEAD: $(git rev-parse HEAD)"
+     echo "Base commit: $(git rev-parse origin/$BASE)"
+     echo "Clean status: $(git status --short --untracked-files=all)"
+     echo "Allowed files: <from PE_TASK.md>"
+     echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+     echo "Result: PASS"
+     ```
+   - Paste the opening Status Packet (including the binding certificate) to the PM. No work starts before the PM acknowledges.
 2. Rebase onto current `<base-branch>`:
    ```bash
    # BASE=$(grep "Base branch" CURRENT_PE.md | awk '{print $NF}')
@@ -610,8 +643,11 @@ See `AUDITS.md` for the full audit spec and report templates.
 - Do not open, read, or reference any file listed in `.agentignore`.
 - Do not include secret values in Status Packets, HANDOFF.md, or any PR content.
 - Do not proceed if `check_agent_scope.py` returns exit code 1.
-- **Do NOT push, PR, or merge** as implementer or validator. Remote GitHub writes are PM/GitHub Agent operations.
-- **Do NOT work outside your fixed workspace.** Verify `pwd` matches your role's assigned path before any operation.
+- **Do NOT push, PR, or merge** as implementer, validator, or supervisor. Remote GitHub writes are GitHub Agent operations only, executed after explicit PM/PO approval.
+- **PM must NOT write to GitHub directly.** PM coordinates and approves; only the GitHub Agent executes GitHub write operations.
+- **Do NOT work outside your fixed workspace.** Verify `pwd` matches your role's assigned path before any operation. If the path is wrong, quarantine (stop all operations, do not copy files) and report to PM.
+- **Do NOT copy or transfer files between worktrees.** Use the canonical repo as the intermediary via commit+fetch from the correct worktree.
+- **Do NOT proceed without a PASS result on the Fixed Workspace Binding Certificate.**
 
 ---
 

--- a/CURRENT_PE.md
+++ b/CURRENT_PE.md
@@ -21,10 +21,10 @@
 
 | Field   | Value |
 |---------|-------|
-| PE      | PE-GOV-RISK-TIER-01 |
-| Branch  | feature/pe-gov-risk-tier-01-add-risk-tiered-pe-protocol |
+| PE      | PE-OPS-FIXED-WORKSPACES-01 |
+| Branch  | feature/pe-ops-fixed-workspaces-01-adopt-fixed-agent-workspace-and-github-write-boundary-model |
 
-> **Planning mode.** PE-GOV-RISK-TIER-01 — Add Risk-Tiered PE Protocol opened. PE-GOV-01 remains merged; PE-OPS-PO-ADVISOR-01 remains merged.
+> **Planning mode.** PE-GOV-RISK-TIER-01 remains blocked pending fixed-workspace governance. PE-OPS-FIXED-WORKSPACES-01 — Adopt Fixed Agent Workspace and GitHub Write Boundary Model opened.
 
 ---
 
@@ -32,10 +32,10 @@
 
 | Agent       | Role |
 |-------------|------|
-| infra-impl-a | Implementer |
-| infra-val-b  | Validator |
+| infra-impl-b | Implementer |
+| infra-val-a  | Validator |
 
-> Historical PE roles: infra-impl-b = Implementer, infra-val-a = Validator. PE-GOV-RISK-TIER-01 follows governance alternation from PE-GOV-01.
+> Historical PE roles: infra-impl-a = Implementer, infra-val-b = Validator. PE-OPS-FIXED-WORKSPACES-01 follows governance alternation from PE-GOV-RISK-TIER-01.
 
 ---
 
@@ -44,7 +44,8 @@
 | PE-ID       | Domain          | Implementer-agentId  | Validator-agentId  | Branch                                            | Status          | Last-updated |
 |-------------|-----------------|----------------------|--------------------|---------------------------------------------------|-----------------|--------------|
 | PE-GOV-01   | governance      | infra-impl-b         | infra-val-a        | feature/pe-gov-01-operating-protocol-templates    | merged          | 2026-05-03   |
-| PE-GOV-RISK-TIER-01 | governance | infra-impl-a         | infra-val-b        | feature/pe-gov-risk-tier-01-add-risk-tiered-pe-protocol | planning        | 2026-05-06   |
+| PE-GOV-RISK-TIER-01 | governance | infra-impl-a         | infra-val-b        | feature/pe-gov-risk-tier-01-add-risk-tiered-pe-protocol | blocked         | 2026-05-06   |
+| PE-OPS-FIXED-WORKSPACES-01 | fixed-workspaces | infra-impl-b | infra-val-a | feature/pe-ops-fixed-workspaces-01-adopt-fixed-agent-workspace-and-github-write-boundary-model | planning | 2026-05-06 |
 | PE-INFRA-01 | infra           | infra-impl-codex     | infra-val-claude   | feature/pe-infra-01-branch-policy                 | merged          | 2026-02-18   |
 | PE-INFRA-02 | infra           | infra-impl-codex     | prog-val-claude    | feature/pe-infra-02-role-registration             | merged          | 2026-02-19   |
 | PE-INFRA-03 | infra           | infra-impl-codex     | prog-val-claude    | feature/pe-infra-03-release-agnostic              | merged          | 2026-02-19   |
@@ -245,6 +246,7 @@ PM housekeeping entries (prefix `PM-CHORE-XX`):
 | PM-CHORE-86  | Opened PE-OPS-PO-ADVISOR-01 (Deploy ELIS PO Advisor on Hermes) with `infra-impl-b` as Implementer and `infra-val-a` as Validator per alternation rule. Advisory-only scope: task packet and registry update only; no Hermes/OpenClaw config changes, no dispatch, no PR/merge. | 2026-05-06 |
 | PM-CHORE-87  | Closed PE-OPS-PO-ADVISOR-01 as merged (PR #414, PASS verdict — infra-val-a). Plan-complete mode restored: PE and Branch cleared; no active PE; PE-OPS-PO-ADVISOR-01 registry row updated to merged. Merge SHA `a060529ec7919751d5e4a930851b0a58fb225b17`. | 2026-05-06 |
 | PM-CHORE-88  | Opened PE-GOV-RISK-TIER-01 (Add Risk-Tiered PE Protocol) with `infra-impl-a` as Implementer and `infra-val-b` as Validator per alternation rule. Standard-Light PE scope: protocol and template governance only; no Hermes/OpenClaw config changes, no dispatch, no PR/merge. | 2026-05-06 |
+| PM-CHORE-89  | Opened PE-OPS-FIXED-WORKSPACES-01 (Adopt Fixed Agent Workspace and GitHub Write Boundary Model) with `infra-impl-b` as Implementer and `infra-val-a` as Validator per alternation rule. Governance scope: fixed workspace model and strict write-boundary rules only; PE-GOV-RISK-TIER-01 preserved as blocked pending fixed-workspace governance; no Hermes/OpenClaw config changes, no dispatch, no PR/merge. | 2026-05-06 |
 
 
 Alternation rule:

--- a/docs/governance/ELIS_GitHub_Agent_Operating_Model.md
+++ b/docs/governance/ELIS_GitHub_Agent_Operating_Model.md
@@ -1,17 +1,22 @@
 # ELIS GitHub Agent Operating Model
 
+**Status:** Canonical — v1.1
+**Date:** 2026-05-06
+**Owner:** Carlos Rocha, Product Owner
+**Applies to:** All ELIS agents with GitHub operations capability
+
 ## 1. Purpose
-This document defines the operating model for a dedicated ELIS GitHub Agent that performs write-capable GitHub operations under explicit gates, while preserving ELIS auditability, role separation, and Carlos/PO approval authority.
+This document defines the GitHub Write Boundary Model for ELIS: the operating model that governs which roles may perform which GitHub write operations, under what gates, and with what approval. It supersedes ad-hoc permission patterns and codifies the boundary explicitly for every agent role.
 
 ## 2. Scope
 In scope:
-- GitHub Agent role definition
-- permission boundaries by role
-- allowed and forbidden GitHub operations
+- Role-based permission boundaries for GitHub operations
+- allowed and forbidden GitHub operations per role
 - PR, check, label, comment, review, and merge gates
 - identity verification rules
 - evidence packet requirements
 - manual fallback path when automation fails
+- relationship to the fixed agent workspace model
 
 Out of scope:
 - OpenClaw runtime/config changes
@@ -19,112 +24,85 @@ Out of scope:
 - merge authority without Carlos/PO approval
 - unrelated platform recovery procedures
 
-## 3. Role Model
-### 3.1 GitHub Agent
-A permanent ELIS role with PE-scoped activation. It is the only role intended to perform write-capable GitHub operations by default. The GitHub Agent executes authorised GitHub operations; it does not independently approve scope, validation, or merge.
+## 3. Core Principle: No Default GitHub Write Access
+No agent role has default GitHub write access. Every GitHub write operation requires:
+1. The action is within the role's authorised boundary (see §5)
+2. The agent's fixed workspace identity is verified
+3. The PE is active and the branch is current
+4. PM or PO has authorised the specific operation
 
-### 3.2 PM
-Owns PE coordination, authorization checkpoints, and fallback escalation.
+## 4. Role Model
+### 4.1 Implementer
+Produces branch work and implementation artefacts in the fixed implementer workspace. Local git operations only (commit). No default remote write access.
 
-### 3.3 Implementer
-Produces branch work and implementation artefacts. No broad GitHub write by default.
+**Workspace:** `/opt/elis/agent-worktrees/<role>-<slot>` (e.g. `infra-impl-b`)
 
-### 3.4 Validator
-Performs independent review. Read-only by default unless an explicit review/comment surface is authorised.
+### 4.2 Validator
+Performs independent review. Local git operations only (commit REVIEW file, adversarial tests). PR comments and formal GitHub reviews when explicitly authorised by PM.
 
-### 3.5 Carlos / PO
+**Workspace:** `/opt/elis/agent-worktrees/<role>-<slot>` (e.g. `infra-val-a`)
+
+### 4.3 PM
+Owns PE coordination, authorisation checkpoints, and fallback escalation. Authorised for remote GitHub operations including push, PR creation, labels, comments.
+
+### 4.4 GitHub Agent (Dedicated Bot)
+A permanent ELIS role with PE-scoped activation for write-capable GitHub operations: push, PR lifecycle, labels, comments, review requests, check reporting. Does not independently approve scope, validation, or merge.
+
+### 4.5 Carlos / PO
 Final approval authority for merge, scope exceptions, and any escalation that changes repository state.
 
-## 4. Identity Model
-- GitHub operations use permanent bot identities.
-- GitHub Agent activation is PE-scoped.
-- Identity must be verified before any write-capable GitHub action.
-- GitHub identity and execution identity are not assumed to be the same thing.
-- The Discord exec approval loop is separate from GitHub protected-branch and bot-identity risk.
-
 ## 5. Permission Matrix
-### 5.1 GitHub Agent
-Allowed:
-- create/update PRs
-- push branches when authorised
-- read and report checks
-- add labels/comments when authorised
-- request reviews when authorised
-- report mergeability and gate status
 
-Forbidden:
-- merge without explicit Carlos/PO approval
-- act outside the authorised PE scope
-- bypass branch protection
-- fabricate evidence or checks
+| Operation | Implementer | Validator | PM | GitHub Agent | PO/Carlos |
+|-----------|-------------|-----------|----|-------------|-----------|
+| Local commit | ✅ Allowed | ✅ Allowed | ✅ Allowed | N/A | N/A |
+| git push (remote) | ❌ No | ❌ No | ✅ With PM discretion | ✅ When authorised | ❌ (delegates) |
+| PR creation | ❌ No | ❌ No | ✅ With PM discretion | ✅ When authorised | ❌ (delegates) |
+| PR merge | ❌ No | ❌ No | ❌ No | ❌ No | ✅ PO approval |
+| PR comment | ❌ No | ✅ When authorised | ✅ With PM discretion | ✅ When authorised | ✅ |
+| Formal GitHub review | ❌ No | ✅ When authorised | N/A | ❌ No | ✅ |
+| Label management | ❌ No | ❌ No | ✅ With PM discretion | ✅ When authorised | ✅ |
+| Branch protection changes | ❌ No | ❌ No | ❌ No | ❌ No | ✅ PO approval |
+| Read repo state | ✅ Allowed | ✅ Allowed | ✅ Allowed | ✅ Allowed | ✅ Allowed |
 
-### 5.2 Implementer
-Allowed:
-- local branch work
-- commit implementation changes in the PE worktree
-- produce handoff evidence
-
-Forbidden:
-- broad GitHub write by default
-- PR creation unless explicitly authorised
-- merge
-- branch protection changes
-
-### 5.3 Validator
-Allowed:
-- read repository state
-- review PRs when explicitly authorised
-- comment or review only on an authorised surface
-- limited GitHub write access, if authorised, to review/comment artefacts only
-
-Forbidden:
-- broad GitHub write by default
-- branch push
-- file edits
-- merge
-- self-review
-- altering implementation files unless explicitly authorised
-
-### 5.4 PM
-Allowed:
-- authorize GitHub operations
-- choose fallback path
-- monitor gates and evidence
-
-Forbidden:
-- merging without Carlos/PO approval
-- bypassing identity or gate checks
+### 5.1 Fixed Workspace Constraint
+All agents are bound to their fixed workspace path. Remote GitHub operations must originate from the correct fixed workspace. A push or PR attempt from a wrong or unverified workspace path is a workflow violation regardless of role.
 
 ## 6. Allowed and Forbidden Operations
 ### Allowed
-- branch push under explicit authorisation
-- PR creation under explicit authorisation
-- checks reporting
-- label/comment/review-request actions when authorised
-- merge review coordination
+- local git commits in the fixed workspace (all execution roles)
+- branch push under explicit PM authorisation (PM or GitHub Agent)
+- PR creation under explicit PM authorisation (PM or GitHub Agent)
+- checks reporting (GitHub Agent)
+- PR comments and review requests when explicitly authorised (Validator, GitHub Agent)
+- formal GitHub review when explicitly authorised (Validator)
+- merge review coordination (PM)
 
 ### Forbidden
-- direct merge without Carlos/PO approval
-- unauthorised PR mutation
-- unauthorised label or comment actions
-- actions from stale, wrong, or unverified identity contexts
-- bypassing protected-branch rules
+- any git push, PR creation, or merge by implementer or validator unless explicitly authorised
+- direct merge without Carlos/PO approval (all roles)
+- unauthorised PR mutation (any role)
+- unauthorised label or comment actions (any role)
+- actions from stale, wrong, or unverified fixed workspace identity (any role)
+- bypassing protected-branch rules (any role)
+- merging from the fixed implementer or validator workspace (implementer, validator)
 
 ## 7. PR / Check / Merge Gates
-A GitHub operation is permitted only when the following are true:
-- PE is active and scoped
-- identity is verified
-- branch and commit context match the PE
-- required evidence packet is present
-- the requested action is within the role boundary
-- merge has explicit Carlos/PO approval
+A GitHub write operation is permitted only when:
+1. PE is active and scoped in CURRENT_PE.md
+2. Agent fixed workspace identity is verified (pwd + git rev-parse --show-toplevel matches assigned path)
+3. Branch and commit context match the PE
+4. Required evidence packet is present (see §8)
+5. The requested action is within the role boundary (see §5)
+6. Merge has explicit Carlos/PO approval
 
-Merge never occurs automatically without explicit Carlos/PO approval.
+Merge never occurs without explicit Carlos/PO approval. Gate 2 does not auto-merge.
 
 ## 8. Evidence Packet
-Every GitHub operation must have a compact evidence packet including:
+Every GitHub write operation must have a compact evidence packet including:
 - PE_ID
-- role and agent identity
+- role and agent identity (surface name, e.g. `infra-impl-b`)
+- fixed workspace path
 - branch name
 - commit SHA or PR number
 - requested GitHub action
@@ -150,22 +128,24 @@ When automation fails:
 - Discord exec approval loops are runtime-envelope issues, not GitHub self-review failures.
 - GitHub protected-branch and bot-identity failures are separate risks and must be reported distinctly.
 - Any identity mismatch, stale branch, or ambiguous authorisation state blocks the operation.
+- Fixed workspace path mismatch blocks all GitHub operations, including local commits, until verified.
 
-## 11. Open PO Decisions
-- exact validator write surface for comments/reviews
-- whether implementers may ever request PR creation
-- whether manual fallback is PM-owned, GitHub-Agent-owned, or human-owned
-
-## 12. Non-goals
+## 11. Non-goals
 - no OpenClaw config changes
 - no automatic merge authority
 - no implementation of GitHub automation outside this governance model
 - no revision of unrelated PE rules
 
-## 13. Cross-References
+## 12. Cross-References
+- `docs/governance/ELIS_PE_Operating_Protocol.md` (worktree rules, fixed workspace model)
+- `docs/governance/ELIS_Worktree_Preflight_Checklist.md` (path verification)
+- `docs/governance/ELIS_PE_Dispatch_Checklist.md` (dispatch readiness)
 - `docs/decisions/ADR-011-github-actions-authority-for-portable-gates.md`
-- `docs/openclaw/BOT_ACCOUNTS_SETUP.md`
-- `docs/_active/GITHUB_SINGLE_ACCOUNT_VALIDATION_RUNBOOK.md`
-- `docs/governance/ELIS_PE_Operating_Protocol.md`
-- `docs/governance/ELIS_PE_Dispatch_Checklist.md`
 - `docs/governance/ELIS_Discord_PO_PM_Checkpoint_Governance.md`
+
+## 13. Version History
+
+| Version | Date       | Author | Changes |
+|---------|------------|--------|---------|
+| 1.1     | 2026-05-06 | PM     | Adopt fixed workspace model. Replace bot-centric model with role-based permission matrix. Clarify no-default-write principle. Gate 2 no longer auto-merges. |
+| 1.0     | 2026-05-03 | PM     | Initial GitHub Agent operating model. |

--- a/docs/governance/ELIS_GitHub_Agent_Operating_Model.md
+++ b/docs/governance/ELIS_GitHub_Agent_Operating_Model.md
@@ -43,7 +43,7 @@ Performs independent review. Local git operations only (commit REVIEW file, adve
 **Workspace:** `/opt/elis/agent-worktrees/<role>-<slot>` (e.g. `infra-val-a`)
 
 ### 4.3 PM
-Owns PE coordination, authorisation checkpoints, and fallback escalation. Authorised for remote GitHub operations including push, PR creation, labels, comments.
+Owns PE coordination, authorisation checkpoints, and fallback escalation. PM must **not** write to GitHub directly. All GitHub write operations (push, PR, labels, comments) must be executed by the GitHub Agent after explicit PM approval. PM coordinates and approves but does not operate GitHub write tools.
 
 ### 4.4 GitHub Agent (Dedicated Bot)
 A permanent ELIS role with PE-scoped activation for write-capable GitHub operations: push, PR lifecycle, labels, comments, review requests, check reporting. Does not independently approve scope, validation, or merge.
@@ -51,19 +51,30 @@ A permanent ELIS role with PE-scoped activation for write-capable GitHub operati
 ### 4.5 Carlos / PO
 Final approval authority for merge, scope exceptions, and any escalation that changes repository state.
 
+### 4.6 Supervisor
+- Monitors PE workflow integrity and role compliance
+- Reads repo state (branches, PRs, CI status, artefact existence)
+- Detects role boundary violations (e.g., implementer pushing, PM writing to GitHub)
+- Detects missing artefacts (HANDOFF, REVIEW, Status Packet)
+- Reports findings to PM
+- Must not write to GitHub (no commits, push, PR, label, or comment)
+- Must not dispatch agents
+- Must not perform implementation or validation
+- Must not approve or merge
+
 ## 5. Permission Matrix
 
-| Operation | Implementer | Validator | PM | GitHub Agent | PO/Carlos |
-|-----------|-------------|-----------|----|-------------|-----------|
-| Local commit | ✅ Allowed | ✅ Allowed | ✅ Allowed | N/A | N/A |
-| git push (remote) | ❌ No | ❌ No | ✅ With PM discretion | ✅ When authorised | ❌ (delegates) |
-| PR creation | ❌ No | ❌ No | ✅ With PM discretion | ✅ When authorised | ❌ (delegates) |
-| PR merge | ❌ No | ❌ No | ❌ No | ❌ No | ✅ PO approval |
-| PR comment | ❌ No | ✅ When authorised | ✅ With PM discretion | ✅ When authorised | ✅ |
-| Formal GitHub review | ❌ No | ✅ When authorised | N/A | ❌ No | ✅ |
-| Label management | ❌ No | ❌ No | ✅ With PM discretion | ✅ When authorised | ✅ |
-| Branch protection changes | ❌ No | ❌ No | ❌ No | ❌ No | ✅ PO approval |
-| Read repo state | ✅ Allowed | ✅ Allowed | ✅ Allowed | ✅ Allowed | ✅ Allowed |
+| Operation | Implementer | Validator | PM | GitHub Agent | Supervisor | PO/Carlos |
+|-----------|-------------|-----------|----|-------------|------------|-----------|
+| Local commit | ✅ Allowed | ✅ Allowed | ✅ Allowed | N/A | ❌ No | N/A |
+| git push (remote) | ❌ No | ❌ No | ❌ No | ✅ When authorised | ❌ No | ❌ (delegates) |
+| PR creation | ❌ No | ❌ No | ❌ No | ✅ When authorised | ❌ No | ❌ (delegates) |
+| PR merge | ❌ No | ❌ No | ❌ No | ❌ No | ❌ No | ✅ PO approval |
+| PR comment | ❌ No | ✅ When authorised | ❌ No | ✅ When authorised | ❌ No | ✅ |
+| Formal GitHub review | ❌ No | ✅ When authorised | N/A | ❌ No | ❌ No | ✅ |
+| Label management | ❌ No | ❌ No | ❌ No | ✅ When authorised | ❌ No | ✅ |
+| Branch protection changes | ❌ No | ❌ No | ❌ No | ❌ No | ❌ No | ✅ PO approval |
+| Read repo state | ✅ Allowed | ✅ Allowed | ✅ Allowed | ✅ Allowed | ✅ Allowed | ✅ Allowed |
 
 ### 5.1 Fixed Workspace Constraint
 All agents are bound to their fixed workspace path. Remote GitHub operations must originate from the correct fixed workspace. A push or PR attempt from a wrong or unverified workspace path is a workflow violation regardless of role.
@@ -71,15 +82,17 @@ All agents are bound to their fixed workspace path. Remote GitHub operations mus
 ## 6. Allowed and Forbidden Operations
 ### Allowed
 - local git commits in the fixed workspace (all execution roles)
-- branch push under explicit PM authorisation (PM or GitHub Agent)
-- PR creation under explicit PM authorisation (PM or GitHub Agent)
+- branch push under explicit PM/PO approval (GitHub Agent only)
+- PR creation under explicit PM/PO approval (GitHub Agent only)
 - checks reporting (GitHub Agent)
 - PR comments and review requests when explicitly authorised (Validator, GitHub Agent)
 - formal GitHub review when explicitly authorised (Validator)
 - merge review coordination (PM)
 
 ### Forbidden
-- any git push, PR creation, or merge by implementer or validator unless explicitly authorised
+- any git push, PR creation, or merge by implementer, validator, supervisor, or PM
+- PM writing to GitHub directly (PM coordinates and approves; GitHub Agent executes)
+- Supervisor writing to GitHub (read-only monitoring role)
 - direct merge without Carlos/PO approval (all roles)
 - unauthorised PR mutation (any role)
 - unauthorised label or comment actions (any role)
@@ -137,8 +150,8 @@ When automation fails:
 - no revision of unrelated PE rules
 
 ## 12. Cross-References
-- `docs/governance/ELIS_PE_Operating_Protocol.md` (worktree rules, fixed workspace model)
-- `docs/governance/ELIS_Worktree_Preflight_Checklist.md` (path verification)
+- `docs/governance/ELIS_PE_Operating_Protocol.md` (worktree rules, fixed workspace model, Supervisor role, Fixed Workspace Binding Certificate, wrong-worktree quarantine)
+- `docs/governance/ELIS_Worktree_Preflight_Checklist.md` (path verification, binding certificate)
 - `docs/governance/ELIS_PE_Dispatch_Checklist.md` (dispatch readiness)
 - `docs/decisions/ADR-011-github-actions-authority-for-portable-gates.md`
 - `docs/governance/ELIS_Discord_PO_PM_Checkpoint_Governance.md`
@@ -147,5 +160,6 @@ When automation fails:
 
 | Version | Date       | Author | Changes |
 |---------|------------|--------|---------|
+| 1.2     | 2026-05-07 | PM     | Add Supervisor role to permission matrix. Resolve PM GitHub write conflict: PM must not write to GitHub directly; only GitHub Agent may write after explicit PM/PO approval. Update Allowed/Forbidden sections. |
 | 1.1     | 2026-05-06 | PM     | Adopt fixed workspace model. Replace bot-centric model with role-based permission matrix. Clarify no-default-write principle. Gate 2 no longer auto-merges. |
 | 1.0     | 2026-05-03 | PM     | Initial GitHub Agent operating model. |

--- a/docs/governance/ELIS_No_Silent_Failure_Recovery.md
+++ b/docs/governance/ELIS_No_Silent_Failure_Recovery.md
@@ -39,8 +39,9 @@ A "silent failure" occurs when an agent run produces no verifiable artefacts, om
 ### 2.3 Wrong-Path Success
 | Symptom | Example | Detection Method |
 |---------|---------|-----------------|
-| Output from wrong repo | Agent reports files changed in `/opt/elis/repo` instead of worktree | Check `git rev-parse --show-toplevel` in the Status Packet |
-| Cross-worktree contamination | Agent writes to another PE's worktree | `git status -sb` from correct worktree shows no changes |
+| Output from wrong repo | Agent reports files changed in `/opt/elis/repo` instead of fixed worktree | Check `git rev-parse --show-toplevel` in the Status Packet — must match fixed workspace |
+| Wrong fixed workspace | Agent reports files changed in wrong role's fixed workspace (e.g. `infra-impl-a` instead of `infra-impl-b`) | Check `pwd` in Status Packet against assigned role+slot path |
+| Cross-PE contamination | Agent's branch still has files from a prior PE | Run `git diff --name-status origin/$BASE..HEAD` — prior PE files should not appear |
 
 ---
 
@@ -123,7 +124,7 @@ PM determines the recovery path:
 |-----------|----------|
 | Artefacts missing (A1-A2) | PM directs agent to retry with explicit artefact requirements |
 | Evidence fabricated (A3) | PM directs agent to re-run and paste actual output; may escalate to PO |
-| Wrong path (B1-B2) | PM stops session; re-dispatches with correct worktree; logs to LESSONS_LEARNED.md |
+| Wrong path (B1-B2) | PM stops session; re-dispatches with correct fixed workspace; reset workspace to clean state; logs to LESSONS_LEARNED.md |
 | Stale branch (B3) | PM stops session; agent rebases; re-dispatches |
 | Platform failure (P1) | PM tasks Platform Monitor with diagnosis and repair |
 | Rate-limit (P2) | PM waits for cooldown; may split work into smaller PEs |
@@ -166,4 +167,5 @@ Escalate to PO if:
 
 | Version | Date       | Author | Changes |
 |---------|------------|--------|---------|
+| 1.1     | 2026-05-06 | PM     | Update for fixed workspace model. Add wrong fixed workspace detection. Update recovery for fixed workspace paths. |
 | 1.0     | 2026-05-03 | PM     | Initial canonical consolidation from ELIS_General_Guidance.md §2.3, §6.5, AGENTS.md §2.4, LESSONS_LEARNED.md LL-02, LL-13, LL-16. |

--- a/docs/governance/ELIS_PE_Dispatch_Checklist.md
+++ b/docs/governance/ELIS_PE_Dispatch_Checklist.md
@@ -44,11 +44,15 @@ This checklist ensures every PE dispatch follows a consistent, verifiable proces
 
 ### 2.3 Worktree
 
-- [ ] Worktree exists at `/opt/elis/agent-worktrees/<PE-ID>-<agent-id>`
+- [ ] Worktree exists at `/opt/elis/agent-worktrees/<role>-<slot>` (fixed workspace — e.g. `infra-impl-b`, not a PE-ID-based path)
 - [ ] Worktree is isolated (no other active agent writes here)
 - [ ] Worktree branch matches the PE branch in CURRENT_PE.md
 - [ ] Worktree is on the correct base branch commit (`git rebase origin/$BASE` is current)
 - [ ] Worktree is clean or has only approved staged changes
+- [ ] Fixed Workspace Binding Certificate can be produced — agent will include in opening Status Packet
+- [ ] Wrong-worktree quarantine understood: any path mismatch stops all work immediately
+- [ ] No-copy rule understood: agents never copy/transfer files between worktrees
+- [ ] Persistent agent runtime files (AGENTS.md, SKILLS.md, SOUL.md, tool manifests, OpenClaw/Hermes bootstrap) are outside the fixed worktree — only disposable repo/task state lives inside
 - [ ] No OpenClaw workspace binding to `/opt/elis/repo`
 - [ ] No shared mutable working directory between active agents
 

--- a/docs/governance/ELIS_PE_Dispatch_Checklist.md
+++ b/docs/governance/ELIS_PE_Dispatch_Checklist.md
@@ -90,7 +90,8 @@ This checklist ensures every PE dispatch follows a consistent, verifiable proces
 - [ ] Gate 1 has passed or CI bot has assigned the Validator
 - [ ] Validator has explicit PM or CI-bot assignment (`@agent — assigned as Validator. Begin review.`)
 - [ ] Validator has a fresh session ID (`<PE-ID>-val-YYYYMMDD-HHMMSS`)
-- [ ] Validator session uses a separate validation worktree
+- [ ] Validator session uses a fixed validation workspace (`/opt/elis/agent-worktrees/<role>-<slot>`, distinct from implementer workspace)
+- [ ] Validator fixed workspace has been reset: clean state, correct branch checked out
 - [ ] Validator knows the implementer's commit SHA
 
 ---
@@ -102,21 +103,23 @@ After completing the checklist, PM decides:
 | Condition | Action |
 |-----------|--------|
 | All checks pass | Dispatch implementer or validator |
-| Worktree issue | Fix worktree; recheck |
+| Fixed worktree issue | Reset fixed workspace or create PE branch; recheck |
 | Registry/plan issue | Fix CURRENT_PE.md or PE_TASK.md; recheck |
 | Provider/rate-limit issue | Platform Monitor investigates; recheck |
 | Task packet incomplete | PM completes task packet; recheck |
+| GitHub boundary violation | Report to PM; do not dispatch; escalate to PO |
 | PO decision needed | Escalate to PO; wait for resolution |
 
 ---
 
 ## 4. Post-Dispatch Verification
 
-- [ ] Agent confirms correct worktree path (Step 0 output evidence)
-- [ ] Agent confirms correct branch
+- [ ] Agent confirms correct fixed worktree path (Step 0 output evidence — must match role+slot path)
+- [ ] Agent confirms correct branch for the current PE
 - [ ] Agent confirms task packet is accessible
 - [ ] PM receives Status Packet at start of implementation/validation
 - [ ] Watchdog confirms artefacts after implementer commit
+- [ ] No GitHub write operations originated from the wrong role or workspace
 
 ---
 
@@ -124,4 +127,5 @@ After completing the checklist, PM decides:
 
 | Version | Date       | Author | Changes |
 |---------|------------|--------|---------|
+| 1.1     | 2026-05-06 | PM     | Adopt fixed workspace paths. Add GitHub write boundary gates to artefact checklist. Update worktree, implementer start, validator start sections for fixed workspaces. |
 | 1.0     | 2026-05-03 | PM     | Initial canonical consolidation. |

--- a/docs/governance/ELIS_PE_Operating_Protocol.md
+++ b/docs/governance/ELIS_PE_Operating_Protocol.md
@@ -1,7 +1,7 @@
 # ELIS PE Operating Protocol
 
-**Status:** Canonical — v1.0  
-**Date:** 2026-05-03  
+**Status:** Canonical — v1.1  
+**Date:** 2026-05-06  
 **Owner:** Carlos Rocha, Product Owner  
 **Applies to:** All ELIS agents (PM, Gatekeeper, Watchdog, Implementers, Validators, Platform Monitor)  
 **Authoritative sources:** AGENTS.md, CLAUDE.md, ELIS_General_Guidance.md, LESSONS_LEARNED.md  
@@ -40,17 +40,47 @@ All implementation commits must precede validation. Validators review committed 
 ### 2.7 No Silent Failure Recovery
 A run that produces no required artefacts (commit, HANDOFF, Status Packet, or REVIEW) is not a success. Valid outcomes are PASS, FAIL, or BLOCKED — each backed by evidence. Recovery from silent failure is a separate, PO-authorised process.
 
-### 2.8 Worktree and Provider Preflight Required
+### 2.8 Fixed Agent Workspace Model
+Every agent role has a persistent, dedicated worktree path that persists across PEs. This replaces the per-PE worktree pattern.
+
+**Fixed worktree paths:**
+- `infra-impl-a` → `/opt/elis/agent-worktrees/infra-impl-a`
+- `infra-impl-b` → `/opt/elis/agent-worktrees/infra-impl-b`
+- `infra-val-a`  → `/opt/elis/agent-worktrees/infra-val-a`
+- `infra-val-b`   → `/opt/elis/agent-worktrees/infra-val-b`
+- (same pattern for programme and SLR roles)
+
+The worktree is reset and rebased at the start of each PE assignment. The branch checked out in the fixed worktree changes per PE. The worktree path itself does not.
+
+**Advantages:**
+- Agent sessions always bind to the same filesystem path
+- Shell and PM know exactly where each agent works
+- No stale worktrees accumulate per PE
+- CI/CD runners, monitoring, and recovery scripts use stable paths
+
+### 2.9 Worktree and Provider Preflight Required
 Before any PE execution begins, the agent must verify:
-- Correct worktree path and branch
+- Correct fixed worktree path (role-specific, not PE-specific)
+- Correct branch checked out for the current PE
 - Provider/model availability and credentials
 - Clean or expected working-tree state
 - Task packet exists and is current
 
-### 2.9 No Automatic Push, PR, or Merge
+### 2.10 GitHub Write Boundary Model
+gitHub write access is gated by role and explicit authorisation. No agent may perform a GitHub write operation unless the action is within its authorised boundary.
+
+**Allowed GitHub writes per role:**
+- **Implementer:** Local branch commits only. No git push, PR creation, or remote writes unless explicitly authorised by PM.
+- **Validator:** Local commits to the shared PE branch (REVIEW file, adversarial tests only). PR comments and formal GitHub reviews when explicitly authorised.
+- **PM:** All GitHub operations including push, PR creation, label/comment, merge (with PO approval for merge).
+- **GitHub Agent (dedicated bot):** Push, PR ops, labels/comments, merge status reporting under PE-scoped activation.
+
+**All roles:** Merge requires explicit PO approval. No automatic merge.
+
+### 2.11 No Automatic Push, PR, or Merge
 Agents never push, open PRs, or merge without explicit PM direction. These actions are PM-owned.
 
-### 2.10 Discord / PO Checkpoint Governance
+### 2.12 Discord / PO Checkpoint Governance
 Discord is for human-visible coordination, but the PE thread is the operational checkpoint trail. Use the main Discord channel for portfolio-level control and escalation, and use the PE thread for compact checkpoint updates, audit notes, and continuation markers. GitHub remains the canonical evidence record; Discord never replaces commits, PRs, CI output, or versioned artefacts.
 
 See `docs/governance/ELIS_Discord_PO_PM_Checkpoint_Governance.md` for thread usage, message-boundary, and checkpoint packet rules.
@@ -67,7 +97,7 @@ See `docs/governance/ELIS_Discord_PO_PM_Checkpoint_Governance.md` for thread usa
 
 ### 3.2 Pre-Dispatch (Gatekeeper)
 1. PM runs Gatekeeper preflight (or requests Gatekeeper readiness check).
-2. Gatekeeper verifies: worktree path, branch, task packet existence, clean state, provider readiness, artefact gates.
+2. Gatekeeper verifies: fixed worktree path for the role, branch matches PE, task packet existence, clean state after reset/rebase, provider readiness, artefact gates.
 3. Gatekeeper returns one of: `READY`, `NOT_READY`, `NEEDS_PLATFORM_FIX`, `NEEDS_PO_DECISION`.
 4. PM dispatches only on `READY` or PO-authorised override.
 
@@ -98,10 +128,13 @@ See `docs/governance/ELIS_Discord_PO_PM_Checkpoint_Governance.md` for thread usa
 Gate 1 is a CI-driven automated check. On a READY verdict from Gatekeeper, PM dispatches the Validator. Gate 1 CI runs on the feature branch and assigns the Validator via PR comment. The Validator may start only after receiving explicit PM or CI-bot assignment.
 
 ### 3.7 Gate 2 (Merge)
-Gate 2 is a CI-driven automated merge. On a PASS verdict from the Validator (PR comment + formal GitHub review), CI checks re-run. If all required checks pass, the PR auto-merges if:
+Gate 2 is a PE-completion gate. On a PASS verdict from the Validator (PR comment + formal GitHub review), CI checks re-run. Merge is PM-owned and requires:
 - Branch protection rules are satisfied
 - No `pm-review-required` label is set
 - Validator is the correct assigned agent
+- Explicit PO approval (per §3.8)
+
+Gate 2 does not auto-merge. The PM merges after confirming all gates are green and PO has approved.
 
 ### 3.8 PO Approval and Override
 PO approval is required for:
@@ -214,22 +247,30 @@ PO approval is required for:
 
 ## 5. Worktree and Workspace Rules
 
-### 5.1 Worktree Isolation
-Every active PE uses a dedicated Git worktree:
+### 5.1 Fixed Agent Worktree Model
+Each agent role has a persistent, dedicated worktree path that does not change between PEs:
 ```
-/opt/elis/agent-worktrees/<PE-ID>-<agent-id>
+/opt/elis/agent-worktrees/<role>-<slot>
 ```
+Examples: `/opt/elis/agent-worktrees/infra-impl-b`, `/opt/elis/agent-worktrees/infra-val-a`
 
-### 5.2 No Shared Mutable Working Directory
-Two active agents must never write to the same working directory. Rule: one PE branch + one active writer at a time.
+### 5.2 Worktree Reset Between PEs
+At the start of each PE assignment, the fixed worktree is:
+1. Cleaned of uncommitted changes (stash or discard disposable state)
+2. Fetched from origin
+3. Rebased onto the current `origin/$BASE`
+4. Switched to the PE branch (created if new)
 
-### 5.3 Canonical Repository
+### 5.3 No Shared Mutable Working Directory
+Two active agents must never write to the same working directory. Each fixed worktree hosts exactly one role. Rule: one PE branch + one active writer at a time.
+
+### 5.4 Canonical Repository
 `/opt/elis/repo` is the canonical ELIS repository. It must remain clean unless a controlled, approved PE is actively modifying it.
 
-### 5.4 No OpenClaw Workspace on Canonical Repo
+### 5.5 No OpenClaw Workspace on Canonical Repo
 OpenClaw workspace must not be directly bound to `/opt/elis/repo`. OpenClaw may write bootstrap/context files into its workspace.
 
-### 5.5 Path Preflight
+### 5.6 Path Preflight
 Before any PE work, the agent must run:
 ```bash
 pwd
@@ -237,7 +278,7 @@ git rev-parse --show-toplevel
 git status --short --branch
 git branch --show-current
 ```
-The verified path must match the assigned PE worktree.
+The verified path must match the agent's fixed worktree path. The branch must match the current PE branch from CURRENT_PE.md.
 
 ---
 
@@ -351,4 +392,5 @@ Agents must not self-initiate recovery from silent failure. All recovery is PM-d
 
 | Version | Date       | Author     | Changes |
 |---------|------------|------------|---------|
+| 1.1     | 2026-05-06 | PM         | Adopt fixed agent worktree model and GitHub write boundary model. Worktree paths are now role+slot based, not PE-ID based. Gate 2 no longer auto-merges. Explicit write boundaries per role. |
 | 1.0     | 2026-05-03 | PM         | Initial canonical consolidation from AGENTS.md, CLAUDE.md, ELIS_General_Guidance.md, LESSONS_LEARNED.md, and accumulated PM directives. |

--- a/docs/governance/ELIS_PE_Operating_Protocol.md
+++ b/docs/governance/ELIS_PE_Operating_Protocol.md
@@ -70,12 +70,23 @@ Before any PE execution begins, the agent must verify:
 gitHub write access is gated by role and explicit authorisation. No agent may perform a GitHub write operation unless the action is within its authorised boundary.
 
 **Allowed GitHub writes per role:**
-- **Implementer:** Local branch commits only. No git push, PR creation, or remote writes unless explicitly authorised by PM.
+- **Implementer:** Local branch commits only. No git push, PR creation, or remote writes.
 - **Validator:** Local commits to the shared PE branch (REVIEW file, adversarial tests only). PR comments and formal GitHub reviews when explicitly authorised.
-- **PM:** All GitHub operations including push, PR creation, label/comment, merge (with PO approval for merge).
-- **GitHub Agent (dedicated bot):** Push, PR ops, labels/comments, merge status reporting under PE-scoped activation.
+- **PM:** Remote GitHub operations are **prohibited** for PM. PM coordinates and approves but must not write to GitHub directly. Only the GitHub Agent may execute GitHub write operations after explicit PM/PO approval.
+- **GitHub Agent (dedicated bot):** Push, PR ops, labels/comments, merge status reporting under PE-scoped activation. May act only after receiving explicit PM/PO authorisation for the specific operation.
+- **Supervisor:** Monitors PE workflow integrity and role compliance. Read-only access to repo state. Must not write to GitHub directly.
 
 **All roles:** Merge requires explicit PO approval. No automatic merge.
+
+### 2.10a Wrong-Worktree Quarantine
+If an agent detects it is operating from the wrong worktree (i.e., `pwd` or `git rev-parse --show-toplevel` does not match its assigned fixed workspace path):
+1. The agent must stop all file operations immediately.
+2. No file may be copied, moved, or committed from the wrong worktree.
+3. The agent must report the mismatch to PM with full evidence (`pwd`, `git rev-parse --show-toplevel`, assigned path from CURRENT_PE.md).
+4. PM must reset the correct fixed workspace and re-dispatch.
+5. Any artefacts produced from the wrong worktree are invalid and must not be used.
+
+**No-copy rule:** Agents must never copy or transfer files between worktrees. If a file from one worktree is needed in another, the file must be committed to the canonical repo from the correct worktree and then fetched in the target worktree.
 
 ### 2.11 No Automatic Push, PR, or Merge
 Agents never push, open PRs, or merge without explicit PM direction. These actions are PM-owned.
@@ -172,6 +183,18 @@ PO approval is required for:
 - Treat silent or artefact-free runs as success
 - Merge without approved process
 - Override role boundaries
+- **Write to GitHub directly.** All GitHub write operations (push, PR creation, label/comment, merge) must be executed by the GitHub Agent after explicit PM/PO approval. PM coordinates and approves but never operates GitHub write tools.
+
+### 4.7 Supervisor
+- Monitors PE workflow integrity and role compliance
+- Reads repo state (branches, PRs, CI status, artefact existence)
+- Detects role boundary violations (e.g. implementer pushing, PM writing to GitHub)
+- Detects missing artefacts (HANDOFF, REVIEW, Status Packet)
+- Reports findings to PM
+- Must not write to GitHub (no commits, push, PR, label, or comment)
+- Must not dispatch agents
+- Must not perform implementation or validation
+- Must not approve or merge
 
 ### 4.2 Implementer
 - Works only in the assigned PE worktree
@@ -254,6 +277,35 @@ Each agent role has a persistent, dedicated worktree path that does not change b
 ```
 Examples: `/opt/elis/agent-worktrees/infra-impl-b`, `/opt/elis/agent-worktrees/infra-val-a`
 
+### 5.1a Wrong-Worktree Quarantine
+If an agent detects it is operating from the wrong worktree (i.e., `pwd` or `git rev-parse --show-toplevel` does not match its assigned fixed workspace path):
+1. Stop all file operations immediately.
+2. Do not copy, move, or commit any files from the wrong worktree.
+3. Report the mismatch to PM with full evidence.
+4. PM resets the correct fixed workspace and re-dispatches.
+5. Any artefacts produced from the wrong worktree are invalid and must not be used.
+
+**No-copy rule:** Agents must never copy or transfer files between worktrees. If a file from one worktree is needed in another, the file must be committed to the canonical repo from the correct worktree and then fetched in the target worktree.
+
+### 5.1b Fixed Workspace Binding Certificate
+Before any PE work begins, the agent must produce a **Fixed Workspace Binding Certificate** from within the fixed workspace. This certificate must include:
+
+| Field | Description |
+|-------|-------------|
+| PE ID | The PE identifier from CURRENT_PE.md |
+| Agent ID | The agent's surface name (e.g. `infra-impl-b`) |
+| Fixed workspace path | Output of `pwd` |
+| Git root | Output of `git rev-parse --show-toplevel` |
+| Branch | Output of `git branch --show-current` |
+| HEAD | Output of `git rev-parse HEAD` |
+| Base/Expected commit | Commit SHA of `origin/$BASE` (`$BASE` from CURRENT_PE.md) |
+| Clean status | Output of `git status --short --untracked-files=all` |
+| Allowed file scope | List of allowed files from PE_TASK.md |
+| Timestamp | ISO 8601 timestamp of certificate creation |
+| Result | `PASS` (certificate matches) or `FAIL` (mismatch found) |
+
+The certificate must be included in the opening Status Packet before any implementation or validation work begins. A FAIL result blocks all further work until PM resolves the mismatch.
+
 ### 5.2 Worktree Reset Between PEs
 At the start of each PE assignment, the fixed worktree is:
 1. Cleaned of uncommitted changes (stash or discard disposable state)
@@ -267,18 +319,45 @@ Two active agents must never write to the same working directory. Each fixed wor
 ### 5.4 Canonical Repository
 `/opt/elis/repo` is the canonical ELIS repository. It must remain clean unless a controlled, approved PE is actively modifying it.
 
-### 5.5 No OpenClaw Workspace on Canonical Repo
+### 5.5 Persistent Agent Runtime Files vs Disposable Repo/Task State
+Agent workspaces contain two categories of files that must be clearly distinguished:
+
+**Persistent Agent Runtime/Context Files (must be preserved across PEs):**
+- `AGENTS.md` — agent workflow rules and operating model
+- `SKILLS.md` or equivalent skill manifest
+- `SOUL.md` or equivalent agent identity/character files
+- Tool manifests and capability declarations
+- OpenClaw/Hermes bootstrap and system configuration files
+- Agent context cache and session continuity files
+
+**Disposable Repo/Task State (reset at each PE boundary):**
+- Git working tree (source code, tests, docs)
+- `HANDOFF.md`, `REVIEW_PE<N>.md` (PE-specific artefacts)
+- Branch-specific config and state
+- CI caches and build artefacts
+- All files within the `.elis/` PE workspace tree
+
+**Separation rule:**
+- Persistent files must reside outside the fixed worktree (e.g., in the agent's OpenClaw workspace or dedicated runtime directory).
+- When a fixed worktree is reset at PE start, only disposable repo/task state is cleaned. Persistent runtime files are never deleted or modified during reset.
+- Agents must not write persistent runtime files into the fixed worktree. If a write lands in the worktree by mistake, it must be moved out before the worktree is cleaned for the next PE.
+
+### 5.5a No OpenClaw Workspace on Canonical Repo
 OpenClaw workspace must not be directly bound to `/opt/elis/repo`. OpenClaw may write bootstrap/context files into its workspace.
 
-### 5.6 Path Preflight
-Before any PE work, the agent must run:
+### 5.6 Path Preflight (Fixed Workspace Binding)
+Before any PE work, the agent must produce the **Fixed Workspace Binding Certificate** (§5.1b). This is mandatory evidence in every opening Status Packet.
+
+Minimum preflight commands:
 ```bash
 pwd
 git rev-parse --show-toplevel
 git status --short --branch
 git branch --show-current
+git rev-parse HEAD
+git log -1 --oneline
 ```
-The verified path must match the agent's fixed worktree path. The branch must match the current PE branch from CURRENT_PE.md.
+The verified path must match the agent's fixed worktree path. The branch must match the current PE branch from CURRENT_PE.md. A path mismatch is a `FAIL` result on the certificate and blocks all further work.
 
 ---
 

--- a/docs/governance/ELIS_Worktree_Preflight_Checklist.md
+++ b/docs/governance/ELIS_Worktree_Preflight_Checklist.md
@@ -1,10 +1,10 @@
 # ELIS Worktree Preflight Checklist
 
-**Status:** Canonical — v1.0  
-**Date:** 2026-05-03  
+**Status:** Canonical — v1.1  
+**Date:** 2026-05-06  
 **Owner:** Carlos Rocha, Product Owner  
 **Applies to:** All ELIS agents before starting any PE work  
-**Authoritative sources:** ELIS_General_Guidance.md §5, AGENTS.md §2.2, LESSONS_LEARNED.md  
+**Authoritative sources:** ELIS_General_Guidance.md §5, AGENTS.md §2.2, LESSONS_LEARNED.md, ELIS_PE_Operating_Protocol.md §5 (Fixed Workspace Model)  
 **Canonical record:** GitHub (this document)
 
 ---
@@ -27,18 +27,19 @@ git branch --show-current
 ```
 
 ### Expected Results
-- `pwd`: must match the assigned PE worktree, e.g. `/opt/elis/agent-worktrees/PE-GOV-01-infra-impl-b`
-- `git rev-parse --show-toplevel`: must return the worktree root, NOT `/opt/elis/repo`
-- `git status --short --branch`: clean state or only expected files
-- `git branch --show-current`: must match the PE branch, e.g. `feature/pe-gov-01-operating-protocol-templates`
+- `pwd`: must match the agent's **fixed worktree path**, e.g. `/opt/elis/agent-worktrees/infra-impl-b` (NOT a per-PE path)
+- `git rev-parse --show-toplevel`: must return the fixed worktree root, NOT `/opt/elis/repo`
+- `git status --short --branch`: clean state or only expected files after reset
+- `git branch --show-current`: must match the PE branch for the current assignment, e.g. `feature/pe-ops-fixed-workspaces-01-adopt-fixed-agent-workspace-and-github-write-boundary-model`
 
 ---
 
 ## 3. Worktree Isolation Checklist
 
 ### 3.1 General Isolation
-- [ ] Worktree path follows convention: `/opt/elis/agent-worktrees/<PE-ID>-<agent-id>`
-- [ ] No other active agent writes to this same worktree
+- [ ] Worktree path follows fixed workspace convention: `/opt/elis/agent-worktrees/<role>-<slot>` (e.g. `infra-impl-b`, `infra-val-a`)
+- [ ] The branch checked out in this fixed worktree matches the current PE branch from CURRENT_PE.md
+- [ ] No other active agent writes to this same fixed worktree
 - [ ] No shared mutable working directory between active agents
 - [ ] OpenClaw workspace is NOT bound to `/opt/elis/repo`
 - [ ] Read `.agentignore` — none of those files may be open or in context
@@ -63,14 +64,15 @@ A command such as `cd /opt/elis/repo && git status` does not change where OpenCl
 
 ## 4. Branch and Base Checklist
 
-### 4.1 Branch
+### 4.1 Branch in Fixed Workspace
 - [ ] Branch name matches CURRENT_PE.md registry for this PE
-- [ ] Branch is created from the base branch declared in CURRENT_PE.md
+- [ ] Branch exists and is checked out in the fixed worktree
+- [ ] If the PE branch does not exist yet in the fixed worktree, create it from the base: `git checkout -b feature/<pe-branch> origin/$BASE`
 - [ ] No commits from unrelated PEs on this branch
 
 ### 4.2 Base
 - [ ] Base branch is up to date (`git fetch origin && git merge-base origin/$BASE HEAD` returns the tip of `origin/$BASE`)
-- [ ] If another PE merged since branch creation, rebase: `git rebase origin/$BASE`
+- [ ] If another PE merged since the branch was created or last rebased, rebase: `git rebase origin/$BASE`
 - [ ] Drift check: `git merge-base origin/$BASE HEAD` should equal the tip of `origin/$BASE`
 
 ---
@@ -90,15 +92,18 @@ A command such as `cd /opt/elis/repo && git status` does not change where OpenCl
 ### 6.1 Clean State
 - [ ] `git status -sb` shows clean or expected state
 - [ ] If dirty: the state is expected and authorised for this phase
-- [ ] No uncommitted files from a previous session (stashing across sessions is prohibited)
+- [ ] No uncommitted files from a previous (now-completed) PE session (stashing across sessions is prohibited)
+- [ ] All outstanding changes from a prior PE are committed, stashed-and-cleared, or resolved
 
-### 6.2 When Starting from a Fresh Worktree
-- [ ] Worktree is checked out from the base branch
-- [ ] No lingering files from unrelated work
-- [ ] Branch exists and is checked out
+### 6.2 Fixed Workspace Reset (Start of Each New PE)
+- [ ] Worktree is reset: stale branch state is cleaned (stash/discard disposable state)
+- [ ] Base is fetched: `git fetch origin`
+- [ ] Branch is checked out or created for the current PE
+- [ ] No lingering files from the prior PE's branch
+- [ ] Rebase if needed: `git rebase origin/$BASE`
 
-### 6.3 When Resuming Work
-- [ ] Previous commit is on the correct branch
+### 6.3 When Resuming Work (Same PE, Same Branch)
+- [ ] Previous commit is on the correct PE branch
 - [ ] `git log -1 --oneline` shows the expected previous work
 - [ ] No merge conflicts in progress
 
@@ -154,4 +159,5 @@ echo "Task packet: $(ls .elis/pe/*/PE_TASK.md 2>/dev/null || echo NOT FOUND)"
 
 | Version | Date       | Author | Changes |
 |---------|------------|--------|---------|
+| 1.1     | 2026-05-06 | PM     | Adopt fixed workspace paths (role+slot, not PE-ID). Add fixed workspace reset checklist. Update expected path patterns and branch instructions. |
 | 1.0     | 2026-05-03 | PM     | Initial canonical consolidation from ELIS_General_Guidance.md §5, AGENTS.md, LESSONS_LEARNED.md. |

--- a/docs/governance/ELIS_Worktree_Preflight_Checklist.md
+++ b/docs/governance/ELIS_Worktree_Preflight_Checklist.md
@@ -32,6 +32,26 @@ git branch --show-current
 - `git status --short --branch`: clean state or only expected files after reset
 - `git branch --show-current`: must match the PE branch for the current assignment, e.g. `feature/pe-ops-fixed-workspaces-01-adopt-fixed-agent-workspace-and-github-write-boundary-model`
 
+### Fixed Workspace Binding Certificate
+Before any PE work begins, the agent must produce a **Fixed Workspace Binding Certificate** as defined in `docs/governance/ELIS_PE_Operating_Protocol.md §5.1b`. This certificate is mandatory evidence in the opening Status Packet.
+
+Certificate fields:
+| Field | Source |
+|-------|--------|
+| PE ID | CURRENT_PE.md |
+| Agent ID | Agent's surface name (e.g. `infra-impl-b`) |
+| Fixed workspace path | `pwd` |
+| Git root | `git rev-parse --show-toplevel` |
+| Branch | `git branch --show-current` |
+| HEAD | `git rev-parse HEAD` |
+| Base/expected commit | `git rev-parse origin/$BASE` (`$BASE` from CURRENT_PE.md) |
+| Clean status | `git status --short --untracked-files=all` |
+| Allowed file scope | From PE_TASK.md |
+| Timestamp | ISO 8601 timestamp |
+| Result | PASS (matches) or FAIL (mismatch) |
+
+A FAIL result blocks all work until PM resolves the mismatch.
+
 ---
 
 ## 3. Worktree Isolation Checklist
@@ -43,6 +63,8 @@ git branch --show-current
 - [ ] No shared mutable working directory between active agents
 - [ ] OpenClaw workspace is NOT bound to `/opt/elis/repo`
 - [ ] Read `.agentignore` — none of those files may be open or in context
+- [ ] Wrong-worktree quarantine understood: if `pwd` or `git rev-parse --show-toplevel` does not match assigned path, stop all operations immediately
+- [ ] No-copy rule understood: never copy or transfer files between worktrees
 
 ### 3.2 Repository Path Safety
 - [ ] Canonical repo path: `/opt/elis/repo` — do not modify directly unless this PE is authorised
@@ -102,7 +124,13 @@ A command such as `cd /opt/elis/repo && git status` does not change where OpenCl
 - [ ] No lingering files from the prior PE's branch
 - [ ] Rebase if needed: `git rebase origin/$BASE`
 
-### 6.3 When Resuming Work (Same PE, Same Branch)
+### 6.3 Separate Persistent Runtime Files from Disposable Repo State
+- [ ] Persistent agent runtime/context files (AGENTS.md, SKILLS.md, SOUL.md, tool manifests, OpenClaw/Hermes bootstrap files) reside outside the fixed worktree
+- [ ] Disposable repo/task state (source code, HANDOFF, REVIEW, `.elis/` PE workspace) is cleaned during reset
+- [ ] No persistent runtime files are written into the fixed worktree
+- [ ] If any persistent file accidental lands in the worktree, it is moved out before the worktree is reset for the next PE
+
+### 6.4 When Resuming Work (Same PE, Same Branch)
 - [ ] Previous commit is on the correct PE branch
 - [ ] `git log -1 --oneline` shows the expected previous work
 - [ ] No merge conflicts in progress

--- a/docs/templates/HANDOFF.template.md
+++ b/docs/templates/HANDOFF.template.md
@@ -17,6 +17,21 @@
 - Session: `<PE-ID>-<phase>-YYYYMMDD-HHMMSS`
 - Worktree: `/opt/elis/agent-worktrees/<role>-<slot>` (fixed workspace)
 
+## Fixed Workspace Binding Certificate
+| Field | Value |
+|-------|-------|
+| PE ID | `<PE-ID>` |
+| Agent ID | `<agent-id>` |
+| Fixed workspace path | `<pwd output>` |
+| Git root | `<git rev-parse --show-toplevel output>` |
+| Branch | `<git branch --show-current output>` |
+| HEAD | `<git rev-parse HEAD output>` |
+| Base/expected commit | `<git rev-parse origin/$BASE output>` |
+| Clean status | `<git status --short --untracked-files=all output>` |
+| Allowed file scope | `<list from PE_TASK.md>` |
+| Timestamp | `<ISO 8601 timestamp>` |
+| Result | PASS |
+
 ---
 
 ## §6.1 Working-Tree State

--- a/docs/templates/HANDOFF.template.md
+++ b/docs/templates/HANDOFF.template.md
@@ -15,7 +15,7 @@
 - PE: `<PE-ID>`
 - Agent: `<agent-id>`
 - Session: `<PE-ID>-<phase>-YYYYMMDD-HHMMSS`
-- Worktree: `/opt/elis/agent-worktrees/<PE-ID>-<agent-id>`
+- Worktree: `/opt/elis/agent-worktrees/<role>-<slot>` (fixed workspace)
 
 ---
 

--- a/docs/templates/PE_TASK.template.md
+++ b/docs/templates/PE_TASK.template.md
@@ -37,7 +37,11 @@ This template defines the structured approach for implementing a PE within the E
 - Path must match the agent's fixed workspace (`/opt/elis/agent-worktrees/<role>-<slot>`), not a per-PE path
 - All artefacts committed to fixed workspace only; no writes to canonical repo
 - Fixed workspace reset at start of each PE: fetch + clean + checkout correct branch + rebase onto `origin/$BASE`
-- GitHub write boundary: implementer does not push/PR/merge. Validator commits only REVIEW + tests locally. PM/GitHub Agent handles remote writes.
+- **Fixed Workspace Binding Certificate** required in opening Status Packet (see `docs/governance/ELIS_PE_Operating_Protocol.md §5.1b`)
+- **Wrong-worktree quarantine:** if path does not match, stop immediately, do not copy/commit files, report to PM
+- **No-copy rule:** never copy or transfer files between worktrees; use commit+fetch from correct worktree
+- **Persistent vs disposable separation:** runtime/context files (AGENTS.md, SKILLS.md, SOUL.md, tool manifests, OpenClaw/Hermes bootstrap) reside outside worktree; only repo/task state lives inside
+- GitHub write boundary: implementer/validator/supervisor do not push/PR/merge. PM does not write to GitHub directly. Only GitHub Agent executes remote GitHub writes after explicit PM/PO approval.
 
 ## Allowed Files
 - <list files this PE may create or modify>

--- a/docs/templates/PE_TASK.template.md
+++ b/docs/templates/PE_TASK.template.md
@@ -9,7 +9,9 @@ This template defines the structured approach for implementing a PE within the E
 ## Repository Structure
 - Canonical repository: `/opt/elis/repo`
 - Assigned worktree root: `/opt/elis/agent-worktrees/`
-- Assigned worktree: `/opt/elis/agent-worktrees/<PE-ID>-<agent-id>`
+- Assigned worktree: `/opt/elis/agent-worktrees/<role>-<slot>` (fixed workspace — e.g. `infra-impl-b`)
+  - Implementer: `/opt/elis/agent-worktrees/<implementer-role-slot>`
+  - Validator: `/opt/elis/agent-worktrees/<validator-role-slot>`
 
 ## Branch
 `feature/<pe-id-branch-name>`
@@ -28,12 +30,14 @@ This template defines the structured approach for implementing a PE within the E
 - `docs/governance/ELIS_Provider_Preflight_Checklist.md` — provider readiness
 - `docs/governance/ELIS_No_Silent_Failure_Recovery.md` — artefact and evidence requirements
 
-## Worktree Safety Practices
+## Fixed Workspace Safety Practices
 - No OpenClaw workspace directly bound to `/opt/elis/repo`
 - No shared mutable working directory between active agents
 - Mandatory wrong-path checks before execution: `pwd`, `git rev-parse --show-toplevel`, `git branch --show-current`
-- All artefacts committed to worktree only; no writes to canonical repo
-- Rebase onto `origin/$BASE` before starting if other PEs merged since branch creation
+- Path must match the agent's fixed workspace (`/opt/elis/agent-worktrees/<role>-<slot>`), not a per-PE path
+- All artefacts committed to fixed workspace only; no writes to canonical repo
+- Fixed workspace reset at start of each PE: fetch + clean + checkout correct branch + rebase onto `origin/$BASE`
+- GitHub write boundary: implementer does not push/PR/merge. Validator commits only REVIEW + tests locally. PM/GitHub Agent handles remote writes.
 
 ## Allowed Files
 - <list files this PE may create or modify>


### PR DESCRIPTION
PE ID: PE-OPS-FIXED-WORKSPACES-01
Governance lane: Strict PE
Temporary GitHub Agent exception: GitHub Agent is not yet deployed/configured. This PR uses the current manual/PM GitHub path. PE-OPS-FIXED-WORKSPACES-01 introduces the governance rule that future GitHub writes must be performed only by GitHub Agent after explicit PM/PO approval.
Implementer: infra-impl-b
Validator: infra-val-a
Reviewed commit: 50ba6981009530673195ab25562460e01fdf2c6e
Validator verdict: PASS
Previous blockers resolved
No Hermes/OpenClaw config changes
No Discord/channel/permission changes
No code/CI/secrets/token changes
Runtime/context files were not committed