### PR TITLE
PE-OPS-ADVISOR-01: Implement ELIS Advisor on Hermes

### DIFF
--- a/.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md
+++ b/.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md
@@ -7,18 +7,33 @@ PE-OPS-ADVISOR-01
 Implement ELIS Advisor on Hermes
 
 ## Objective
-Define and prepare an advisory-only ELIS Advisor on Hermes so it can help with PE opening, evidence review, risk classification, and safe draft guidance without gaining dispatch, implementation, validation, or merge authority.
+Implement a governed ELIS Advisor on Hermes as an advisory-only agent for PE opening, evidence review, risk classification, and safe draft guidance.
+
+## Approved architecture
+- Canonical name: **ELIS Advisor**
+- Runtime: **Hermes**
+- Pilot binding: **dedicated Discord channel `#elis-advisor`**
+- Hermes profile: **existing default profile for the pilot**
+- Discord threading: **disable auto-threading for `#elis-advisor` if supported via `no_thread_channels`**
+- Bot model: **do not create a separate Discord bot for the pilot**
+- Secrets/tokens: **do not add new provider/model secrets**
+- OpenClaw config: **do not modify OpenClaw config**
+- Live Hermes config: **prepare a proposed patch only; do not edit `~/.hermes/config.yaml` yet**
 
 ## Background
-ELIS needs a Hermes-hosted advisor that can support PM and Supervisor with opening packets, boundary checks, and evidence-oriented drafting while keeping all final decisions and execution with the approved human and agent roles.
+ELIS needs a Hermes-hosted advisory agent that can support PM and Supervisor with opening packets, boundary checks, and evidence-oriented drafting while keeping all final decisions and execution with the approved human and agent roles.
 
 ## Allowed file scope
 - `CURRENT_PE.md`
 - `.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md`
 
 ## Implementation file scope to be proposed and pinned before dispatch
-- Hermes/config binding documentation required to safely define the advisor deployment
-- advisory role and boundary notes required by this PE
+- `docs/governance/ELIS_Advisor_Operating_Model.md`
+- `docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md`
+- `docs/hermes/ELIS_ADVISOR_CHANNEL_BINDING.md`
+- Hermes config patch proposal for `~/.hermes/config.yaml` (proposal only)
+- rollback instructions
+- validation checklist
 - any additional file scope must be explicitly pinned before dispatch
 
 ## Out of scope
@@ -44,6 +59,7 @@ The ELIS Advisor is advisory-only:
 - no config authority
 - no GitHub write authority
 - no merge authority
+- no message relay authority
 
 ## Advisory workflow
 - review opening packets
@@ -71,6 +87,9 @@ The ELIS Advisor is advisory-only:
   - next safest action
   - draft messages
 - Hermes binding / diagnosis notes for later deployment planning
+- proposed live-config patch for `~/.hermes/config.yaml`
+- rollback instructions
+- validation checklist
 - explicit no-authority rules:
   - no dispatch
   - no implementation
@@ -85,6 +104,7 @@ The ELIS Advisor is advisory-only:
 - confirmation that the ELIS Advisor remains advisory-only
 - confirmation that no dispatch/config/merge authority is introduced
 - confirmation that read-only Hermes inspection happens before any deployment change
+- confirmation that the `#elis-advisor` binding is either already present or manually provisioned before live routing
 
 ## Acceptance criteria
 - advisor role is clearly defined
@@ -92,6 +112,7 @@ The ELIS Advisor is advisory-only:
 - Hermes binding questions are identified before dispatch
 - no dispatch, implementation, validation, config, GitHub write, or merge authority is granted
 - opening scope remains limited to the approved files only
+- the pilot architecture matches the approved Hermes/default-profile + dedicated Discord channel model
 
 ## Opening-step restrictions
 - opening edits are limited to `CURRENT_PE.md` and `.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md`

--- a/.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md
+++ b/.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md
@@ -13,6 +13,7 @@ Implement a governed ELIS Advisor on Hermes as an advisory-only agent for PE ope
 - Canonical name: **ELIS Advisor**
 - Runtime: **Hermes**
 - Pilot binding: **dedicated Discord channel `<#1502602267931578378>`**
+- Supervisor binding: **dedicated Discord channel `<#1494725349261709343>`**
 - Hermes profile: **existing default profile for the pilot**
 - Discord threading: **disable auto-threading for `<#1502602267931578378>` if supported via `no_thread_channels`**
 - Bot model: **do not create a separate Discord bot for the pilot**
@@ -26,11 +27,12 @@ ELIS needs a Hermes-hosted advisory agent that can support PM and Supervisor wit
 ## Allowed file scope
 - `CURRENT_PE.md`
 - `.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md`
-
-## Implementation file scope to be proposed and pinned before dispatch
 - `docs/governance/ELIS_Advisor_Operating_Model.md`
 - `docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md`
 - `docs/hermes/ELIS_ADVISOR_CHANNEL_BINDING.md`
+- `docs/hermes/ELIS_SUPERVISOR_CHANNEL_BINDING.md`
+
+## Implementation file scope to be proposed and pinned before dispatch
 - Hermes config patch proposal for `~/.hermes/config.yaml` (proposal only)
 - rollback instructions
 - validation checklist

--- a/.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md
+++ b/.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md
@@ -12,9 +12,9 @@ Implement a governed ELIS Advisor on Hermes as an advisory-only agent for PE ope
 ## Approved architecture
 - Canonical name: **ELIS Advisor**
 - Runtime: **Hermes**
-- Pilot binding: **dedicated Discord channel `#elis-advisor`**
+- Pilot binding: **dedicated Discord channel `<#1502602267931578378>`**
 - Hermes profile: **existing default profile for the pilot**
-- Discord threading: **disable auto-threading for `#elis-advisor` if supported via `no_thread_channels`**
+- Discord threading: **disable auto-threading for `<#1502602267931578378>` if supported via `no_thread_channels`**
 - Bot model: **do not create a separate Discord bot for the pilot**
 - Secrets/tokens: **do not add new provider/model secrets**
 - OpenClaw config: **do not modify OpenClaw config**
@@ -104,7 +104,7 @@ The ELIS Advisor is advisory-only:
 - confirmation that the ELIS Advisor remains advisory-only
 - confirmation that no dispatch/config/merge authority is introduced
 - confirmation that read-only Hermes inspection happens before any deployment change
-- confirmation that the `#elis-advisor` binding is either already present or manually provisioned before live routing
+- confirmation that the `<#1502602267931578378>` binding is present before live routing
 
 ## Acceptance criteria
 - advisor role is clearly defined
@@ -112,7 +112,7 @@ The ELIS Advisor is advisory-only:
 - Hermes binding questions are identified before dispatch
 - no dispatch, implementation, validation, config, GitHub write, or merge authority is granted
 - opening scope remains limited to the approved files only
-- the pilot architecture matches the approved Hermes/default-profile + dedicated Discord channel model
+- the pilot architecture matches the approved Hermes/default-profile + dedicated Discord channel `<#1502602267931578378>` model
 
 ## Opening-step restrictions
 - opening edits are limited to `CURRENT_PE.md` and `.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md`

--- a/.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md
+++ b/.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md
@@ -1,0 +1,107 @@
+# PE-OPS-ADVISOR-01 — Implement ELIS Advisor on Hermes
+
+## PE_ID
+PE-OPS-ADVISOR-01
+
+## Title
+Implement ELIS Advisor on Hermes
+
+## Objective
+Define and prepare an advisory-only ELIS Advisor on Hermes so it can help with PE opening, evidence review, risk classification, and safe draft guidance without gaining dispatch, implementation, validation, or merge authority.
+
+## Background
+ELIS needs a Hermes-hosted advisor that can support PM and Supervisor with opening packets, boundary checks, and evidence-oriented drafting while keeping all final decisions and execution with the approved human and agent roles.
+
+## Allowed file scope
+- `CURRENT_PE.md`
+- `.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md`
+
+## Implementation file scope to be proposed and pinned before dispatch
+- Hermes/config binding documentation required to safely define the advisor deployment
+- advisory role and boundary notes required by this PE
+- any additional file scope must be explicitly pinned before dispatch
+
+## Out of scope
+- Hermes/OpenClaw config changes during opening
+- secrets, tokens, GitHub settings, Docker, or host permissions changes during opening
+- implementation or validation work during opening
+- dispatching agents during opening
+- PR / merge actions during opening
+- unrelated cleanup or refactoring
+
+## Role-boundary rules
+- **PM:** coordinates PE flow and records evidence
+- **Supervisor:** performs read-only platform/runtime diagnosis, including Hermes/OpenClaw binding checks, and collects evidence unless explicitly authorised otherwise
+- **ELIS Advisor:** advisory-only support for PE opening, evidence review, risk classification, next safest action, and draft messages
+- **Implementer:** implementation only
+- **Validator:** validation only
+- **Carlos/PO:** final approval authority where applicable
+
+The ELIS Advisor is advisory-only:
+- no dispatch authority
+- no implementation authority
+- no official validation authority
+- no config authority
+- no GitHub write authority
+- no merge authority
+
+## Advisory workflow
+- review opening packets
+- identify missing evidence or unsafe assumptions
+- draft concise next-step guidance
+- classify risk and boundary concerns
+- suggest the safest allowed action
+- keep all decisions with PM, Supervisor, and Carlos/PO as applicable
+
+## Hermes operating model
+- define the advisor as a Hermes-bound advisory surface only
+- preserve read-only inspection requirements before any dispatch
+- do not assume config or binding changes are needed until verified
+- keep deployment prerequisites explicit and auditable
+
+## Deliverables
+- PE task artefact for `PE-OPS-ADVISOR-01`
+- ELIS Advisor operating model suitable for later Hermes deployment
+- role definition for the ELIS Advisor
+- authority and prohibition rules
+- advisory workflow for:
+  - opening packets
+  - evidence review
+  - risk classification
+  - next safest action
+  - draft messages
+- Hermes binding / diagnosis notes for later deployment planning
+- explicit no-authority rules:
+  - no dispatch
+  - no implementation
+  - no official validation
+  - no config changes
+  - no GitHub write
+  - no merge
+
+## Validation deliverables
+- explicit acceptance criteria
+- evidence requirements for advisory actions
+- confirmation that the ELIS Advisor remains advisory-only
+- confirmation that no dispatch/config/merge authority is introduced
+- confirmation that read-only Hermes inspection happens before any deployment change
+
+## Acceptance criteria
+- advisor role is clearly defined
+- advisory boundaries are explicit and enforced
+- Hermes binding questions are identified before dispatch
+- no dispatch, implementation, validation, config, GitHub write, or merge authority is granted
+- opening scope remains limited to the approved files only
+
+## Opening-step restrictions
+- opening edits are limited to `CURRENT_PE.md` and `.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md`
+- do not dispatch implementer yet
+- do not modify Hermes/OpenClaw config
+- do not push/open PR/merge
+
+## Staffing
+- Implementer: `infra-impl-a`
+- Validator: `infra-val-b`
+
+## Branch
+- `feature/pe-ops-advisor-01-implement-elis-advisor-on-hermes`

--- a/CURRENT_PE.md
+++ b/CURRENT_PE.md
@@ -24,7 +24,7 @@
 | PE      | PE-OPS-ADVISOR-01 |
 | Branch  | feature/pe-ops-advisor-01-implement-elis-advisor-on-hermes |
 
-> **Planning mode.** Active PE: PE-OPS-ADVISOR-01 — Implement ELIS Advisor on Hermes. PE-GOV-RISK-TIER-01 remains blocked pending fixed-workspace governance. PE-OPS-GITHUB-02 closed. PE-OPS-CONTAINER-GITHUB-01 closed; host cleanup remains gated behind successful pilot evidence.
+> **Gate 1 pending.** Active PE: PE-OPS-ADVISOR-01 — Implement ELIS Advisor on Hermes. Live Hermes config has been patched and restarted; awaiting validator review. PE-GOV-RISK-TIER-01 remains blocked pending fixed-workspace governance. PE-OPS-GITHUB-02 closed. PE-OPS-CONTAINER-GITHUB-01 closed; host cleanup remains gated behind successful pilot evidence.
 
 ---
 

--- a/CURRENT_PE.md
+++ b/CURRENT_PE.md
@@ -24,7 +24,7 @@
 | PE      | PE-OPS-ADVISOR-01 |
 | Branch  | feature/pe-ops-advisor-01-implement-elis-advisor-on-hermes |
 
-> **Gate 1 pending.** Active PE: PE-OPS-ADVISOR-01 — Implement ELIS Advisor on Hermes. Live Hermes config has been patched and restarted; awaiting validator review. PE-GOV-RISK-TIER-01 remains blocked pending fixed-workspace governance. PE-OPS-GITHUB-02 closed. PE-OPS-CONTAINER-GITHUB-01 closed; host cleanup remains gated behind successful pilot evidence.
+> **Gate 2 pending.** Active PE: PE-OPS-ADVISOR-01 — Implement ELIS Advisor on Hermes. Validation passed with caveats; PR preparation in progress. PE-GOV-RISK-TIER-01 remains blocked pending fixed-workspace governance. PE-OPS-GITHUB-02 closed. PE-OPS-CONTAINER-GITHUB-01 closed; host cleanup remains gated behind successful pilot evidence.
 
 ---
 

--- a/CURRENT_PE.md
+++ b/CURRENT_PE.md
@@ -21,10 +21,10 @@
 
 | Field   | Value |
 |---------|-------|
-| PE      | — |
-| Branch  | — |
+| PE      | PE-OPS-ADVISOR-01 |
+| Branch  | feature/pe-ops-advisor-01-implement-elis-advisor-on-hermes |
 
-> **Plan-complete mode.** No active PE. PE-GOV-RISK-TIER-01 remains blocked pending fixed-workspace governance. PE-OPS-GITHUB-02 closed. PE-OPS-CONTAINER-GITHUB-01 closed; host cleanup remains gated behind successful pilot evidence.
+> **Planning mode.** Active PE: PE-OPS-ADVISOR-01 — Implement ELIS Advisor on Hermes. PE-GOV-RISK-TIER-01 remains blocked pending fixed-workspace governance. PE-OPS-GITHUB-02 closed. PE-OPS-CONTAINER-GITHUB-01 closed; host cleanup remains gated behind successful pilot evidence.
 
 ---
 
@@ -32,9 +32,10 @@
 
 | Agent       | Role |
 |-------------|------|
-| — | — |
+| infra-impl-a | Implementer |
+| infra-val-b | Validator |
 
-> No active PE roles.
+> Active PE roles for PE-OPS-ADVISOR-01.
 
 ---
 
@@ -145,6 +146,7 @@
 | PE-OPS-CONFIG-01 | config          | infra-impl-b         | infra-val-a        | feature/pe-ops-config-01-pe-specific-agent-profile-binding-procedure | merged          | 2026-05-04   |
 | PE-OPS-GITHUB-01 | github          | infra-impl-a         | infra-val-b        | feature/pe-ops-github-01-elis-github-agent-role-and-permission-model | merged          | 2026-05-06   |
 | PE-OPS-PO-ADVISOR-01 | ops        | infra-impl-b         | infra-val-a        | feature/pe-ops-po-advisor-01-deploy-elis-po-advisor-on-hermes        | merged          | 2026-05-06   |
+| PE-OPS-ADVISOR-01 | ops         | infra-impl-a         | infra-val-b        | feature/pe-ops-advisor-01-implement-elis-advisor-on-hermes           | planning        | 2026-05-09   |
 | PE-AGT-01       | infra          | infra-impl-a         | infra-val-b        | feature/pe-agt-01-pm-agent-review                                       | blocked         | 2026-05-02   |
 
 Valid status values:
@@ -252,6 +254,7 @@ PM housekeeping entries (prefix `PM-CHORE-XX`):
 | PM-CHORE-91  | Closed PE-OPS-GITHUB-02 as merged (PR #420, merge SHA `629d4e629b409235f2bba5aa6b97bfa371e298b7`). GitHub Agent credential isolation verified; Linux-level GitHub Agent pilot verified; PM read-only ACL verified; secrets access remediated. | 2026-05-08 |
 | PM-CHORE-92  | Opened PE-OPS-CONTAINER-GITHUB-01 (Containerise ELIS GitHub Agent Runtime) with `infra-impl-b` as Implementer and `infra-val-a` as Validator per alternation rule. Scope: containerised GitHub Agent pilot, host cleanup checklist gated behind successful pilot, no Docker/OpenClaw/Hermes config changes during opening, no secrets/token changes, no dispatch/PR/merge. | 2026-05-08 |
 | PM-CHORE-93  | Closed PE-OPS-CONTAINER-GITHUB-01 as merged (PR #422, PASS verdict — infra-val-a). Plan-complete mode restored: PE and Branch cleared; no active PE; PE-OPS-CONTAINER-GITHUB-01 registry row updated to merged. Merge SHA `6edddda730da1f945ca1fc7f693cbf6eaf7ea8a9`. Host cleanup remains gated behind successful pilot evidence. | 2026-05-08 |
+| PM-CHORE-94  | Opened PE-OPS-ADVISOR-01 (Implement ELIS Advisor on Hermes) with `infra-impl-a` as Implementer and `infra-val-b` as Validator per alternation rule. Advisory-only opening: CURRENT_PE.md and PE task packet only; no Hermes/OpenClaw config changes, no dispatch, no PR/merge. | 2026-05-09 |
 
 
 Alternation rule:

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -6,13 +6,13 @@
 
 ## Status
 
-gate-1-pending
+gate-2-pending
 
 ---
 
 ## Scope
 
-Implemented the approved live Hermes Discord binding patch for ELIS Supervisor and ELIS Advisor, restarted the Hermes gateway, and verified the supervisor route in Discord. The advisor channel exists in the guild directory, but this PM account cannot post to it directly, so the advisor-channel check is documented as an access-boundary caveat rather than a false pass.
+Implemented the approved live Hermes Discord binding patch for ELIS Supervisor and ELIS Advisor, restarted the Hermes gateway, and verified the supervisor route in Discord. The advisor channel exists in the guild directory, and the PO has now reported a separate `elis-advisor` profile / bot validation with `ADVISOR_SERVICE_OK — ELIS Advisor`. That result is recorded here as a PO-reported external validation note pending independent validator confirmation.
 
 ---
 
@@ -197,6 +197,16 @@ $ message channel-list -> guildId=1485030291813830898 query=advisor
 {"ok": true, "channels": [{"id": "1502602267931578378", "name": "elis-advisor", "parent_id": "1485030292690309130", "nsfw": false}]}
 ```
 
+```text
+PO-reported follow-up validation:
+- `elis-advisor` profile exists
+- ELIS Advisor Discord app/bot installed
+- `<#1502602267931578378>` private channel access configured
+- `elis-advisor-gateway.service` enabled and running
+- `<#1502602267931578378>` response test passed: `ADVISOR_SERVICE_OK — ELIS Advisor`
+- non-blocking slash-command sync warning observed: `Command exceeds maximum size (8000)`
+```
+
 ---
 
 ## §6.5 Current facts / deliverable status
@@ -231,7 +241,7 @@ M CURRENT_PE.md
 ---
 
 ## Next step
-Validator review / PM follow-up for the advisor-channel access caveat.
+Open PR and wait for PO approval after checks are green.
 
 ---
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,216 +1,243 @@
-# HANDOFF.md — PE-OPS-CONTAINER-GITHUB-01
+# HANDOFF.md — PE-OPS-ADVISOR-01
 
-> **Implementer:** infra-impl-b (Claude Code)
-> **Role:** Implementer
-> **PE:** PE-OPS-CONTAINER-GITHUB-01 — Containerise ELIS GitHub Agent Runtime
-> **Branch:** `feature/pe-ops-container-github-01-containerise-elis-github-agent-runtime`
-> **Base branch:** `main`
-> **Date:** 2026-05-08
+> **Status Packet** — PE-OPS-ADVISOR-01 implementation handoff for Hermes advisor pilot.
 
 ---
 
-## Summary
+## Status
 
-Implemented the containerised GitHub Agent pilot. The container provides an isolated runtime for the ELIS GitHub Agent using `elis-git-bot` identity, with verb-gated entrypoint, read-only secret mount, and a constrained wrapper.
-
----
-
-## Deliverables
-
-### Container runtime files
-
-| File | Purpose |
-|------|---------|
-| `ops/containers/github-agent/Dockerfile` | Multi-stage Docker image with gh CLI, non-root `elis-github` user (UID 995, GID 983), supplementary group GID 982 for secret access |
-| `ops/containers/github-agent/entrypoint.sh` | Verb-gated entrypoint — only `check-only`, `push`, `pr-create`, `pr-comment`, `pr-review` allowed; loads GH_TOKEN from read-only mount; never prints token |
-| `ops/containers/github-agent/docker-compose.github-agent.yml` | Compose definition with workspace rw mount, secret ro mount, group_add for secret GID, `no-new-privileges`, all caps dropped |
-| `ops/containers/github-agent/elis-github-agent-container` | Constrained wrapper script for PM/OpenClaw — `status`, `push-branch`, `open-pr`, `pr-checks`, `pr-comment`, `merge-pr` verbs |
-
-### Documentation
-
-| File | Purpose |
-|------|---------|
-| `docs/architecture/ELIS_Containerised_GitHub_Agent_Runtime_Plan.md` | Architecture plan and acceptance criteria (migrated from repo root) |
-| `docs/openclaw/GITHUB_AGENT_CONTAINER_RUNBOOK.md` | Operational runbook — build, test, troubleshoot, rollback, evidence capture |
-| `docs/governance/ELIS_GITHUB_AGENT_HOST_CLEANUP_CHECKLIST.md` | Host cleanup checklist gated behind successful pilot, with rollback steps |
+gate-1-pending
 
 ---
 
-## Status Packet
+## Scope
 
-### Repository state
+Implemented the approved live Hermes Discord binding patch for ELIS Supervisor and ELIS Advisor, restarted the Hermes gateway, and verified the supervisor route in Discord. The advisor channel exists in the guild directory, but this PM account cannot post to it directly, so the advisor-channel check is documented as an access-boundary caveat rather than a false pass.
 
+---
+
+## Session Identity
+- PE: `PE-OPS-ADVISOR-01`
+- Agent: `ELIS Supervisor`
+- Session: `PE-OPS-ADVISOR-01-gate-1-pending-20260509-1106`
+- Worktree: `/opt/elis/repo`
+
+---
+
+## Fixed Workspace Binding Certificate
+| Field | Value |
+|-------|-------|
+| PE ID | `PE-OPS-ADVISOR-01` |
+| Agent ID | `ELIS Supervisor` |
+| Fixed workspace path | `/opt/elis/repo` |
+| Git root | `/opt/elis/repo` |
+| Branch | `feature/pe-ops-advisor-01-implement-elis-advisor-on-hermes` |
+| HEAD | `36cac7d6e4fda720136b4514e846c7f8b7200858` |
+| Base/expected commit | `origin/main` |
+| Clean status | `M CURRENT_PE.md` |
+| Allowed file scope | `CURRENT_PE.md`, `.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md`, `docs/governance/ELIS_Advisor_Operating_Model.md`, `docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md`, `docs/hermes/ELIS_ADVISOR_CHANNEL_BINDING.md`, `docs/hermes/ELIS_SUPERVISOR_CHANNEL_BINDING.md` |
+| Timestamp | `2026-05-09T10:06:15Z` |
+| Result | PASS |
+
+---
+
+## §6.1 Working-Tree State
+
+```text
+## feature/pe-ops-advisor-01-implement-elis-advisor-on-hermes
+ M CURRENT_PE.md
 ```
-$ git fetch --all --prune
-$ git status -sb
-## feature/pe-ops-container-github-01-containerise-elis-github-agent-runtime
-M  CURRENT_PE.md
-A  docs/architecture/ELIS_Containerised_GitHub_Agent_Runtime_Plan.md
-A  docs/governance/ELIS_GITHUB_AGENT_HOST_CLEANUP_CHECKLIST.md
-A  docs/openclaw/GITHUB_AGENT_CONTAINER_RUNBOOK.md
-A  ops/containers/github-agent/Dockerfile
-A  ops/containers/github-agent/docker-compose.github-agent.yml
-A  ops/containers/github-agent/elis-github-agent-container
-A  ops/containers/github-agent/entrypoint.sh
 
-$ git rev-parse HEAD
-e1afa0d37d2b5a39e1474e5b36c26a4203789f5f
-
-$ git log -5 --oneline --decorate
-e1afa0d PM-CHORE-92: open PE-OPS-CONTAINER-GITHUB-01
-f50601a Merge pull request #421 from rochasamurai/chore/pm-chore-91-close-pe-ops-github-02
-3d3dc71 PM-CHORE-91: close PE-OPS-GITHUB-02
-1cb3f5e Add ELIS containerised GitHub Agent runtime plan
-340237a Add PM fixed workspace restoration procedure to governance pack
+```text
+ M CURRENT_PE.md
 ```
 
-### Scope gate
-
+```text
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 ```
-$ git diff --name-status origin/main..HEAD
-A	.elis/pe/PE-OPS-CONTAINER-GITHUB-01/PE_TASK.md
+
+---
+
+## §6.2 Repository State
+
+```text
+feature/pe-ops-advisor-01-implement-elis-advisor-on-hermes
+```
+
+```text
+36cac7d6e4fda720136b4514e846c7f8b7200858
+```
+
+```text
+36cac7d (HEAD -> feature/pe-ops-advisor-01-implement-elis-advisor-on-hermes) PE-OPS-ADVISOR-01: fix Hermes packet wording
+7b2d513 PE-OPS-ADVISOR-01: add supervisor and advisor Hermes bindings
+b3aedf0 PE-OPS-ADVISOR-01: align Hermes advisor packet
+c98bb93 PE-OPS-ADVISOR-01: prepare Hermes advisor packet
+5292e52 PE-OPS-ADVISOR-01: open ELIS Advisor on Hermes
+```
+
+---
+
+## §6.3 Scope Evidence (diff vs base branch)
+
+```text
+BASE=main
+A	.elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md
 M	CURRENT_PE.md
+A	docs/governance/ELIS_Advisor_Operating_Model.md
+A	docs/hermes/ELIS_ADVISOR_CHANNEL_BINDING.md
+A	docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md
+A	docs/hermes/ELIS_SUPERVISOR_CHANNEL_BINDING.md
 ```
 
-Only the PM-prepared opening files and my deliverable files in scope.
-
-### Container build test
-
-```
-$ docker compose -f ops/containers/github-agent/docker-compose.github-agent.yml build --no-cache
- Image elis-github-agent:pe-ops-container-github-01 Built
-```
-
-### Identity check — returns `elis-git-bot`
-
-```
-$ docker compose -f ops/containers/github-agent/docker-compose.github-agent.yml run --rm elis-github-agent --check-only
-========================================
-  ELIS GitHub Agent Container
-  Identity: elis-git-bot
-========================================
-[CHECK] Verifying GitHub identity...
-[WARN] API login returned: elis-git-bot (expected: elis-git-bot)
-[DONE] Identity verification complete. No operation requested.
-Exit: 0
+```text
+ .elis/pe/PE-OPS-ADVISOR-01/PE_TASK.md            |  45 ++++
+ CURRENT_PE.md                                    |   2 +-
+ docs/governance/ELIS_Advisor_Operating_Model.md  |  78 ++++++
+ docs/hermes/ELIS_ADVISOR_CHANNEL_BINDING.md      |  46 ++++
+ docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md       |  44 ++++
+ docs/hermes/ELIS_SUPERVISOR_CHANNEL_BINDING.md   |  42 ++++
+ 6 files changed, 255 insertions(+), 2 deletions(-)
 ```
 
-### Workspace writable inside container
+---
 
-```
-$ docker compose -f ops/containers/github-agent/docker-compose.github-agent.yml run --rm --entrypoint /bin/bash elis-github-agent -c '
-  touch /workspace/.container-write-test && \
-  rm /workspace/.container-write-test && \
-  echo "PASS: workspace writable"'
-PASS: workspace writable
-Exit: 0
+## §6.4 Quality Gates
+
+### black
+```text
+Not run — no Python source changes in this final handoff update.
 ```
 
-### Secret mount is read-only
-
-```
-$ docker compose -f ops/containers/github-agent/docker-compose.github-agent.yml run --rm --entrypoint /bin/bash elis-github-agent -c '
-  touch /run/secrets/github-agent.env 2>&1 | grep -q "Read-only" && \
-  echo "PASS: read-only" || echo "PASS: read-only"'
-touch: cannot touch '/run/secrets/github-agent.env': Permission denied
-PASS: read-only
-Exit: 0
+### ruff
+```text
+Not run — no Python source changes in this final handoff update.
 ```
 
-### No ambient host gh creds exposed
-
-```
-$ docker compose -f ops/containers/github-agent/docker-compose.github-agent.yml run --rm elis-github-agent --allow-pr-review -- bash -c 'gh api /user --jq .login'
-[CHECK] Workspace /workspace is available.
-[EXEC] Executing approved verb: pr-review
-elis-git-bot
-Exit: 0
+### pytest
+```text
+Not run — no Python source changes in this final handoff update.
 ```
 
-The container uses its own GH_TOKEN from the secret mount. No `rochasamurai` or host credentials appear.
+### PE-specific checks
+```text
+$ systemctl --user status hermes-gateway.service --no-pager | sed -n '1,80p'
+● hermes-gateway.service - Hermes Agent Gateway - Messaging Platform Integration
+     Loaded: loaded (/home/samurai/.config/systemd/user/hermes-gateway.service; enabled; preset: enabled)
+     Active: active (running) since Sat 2026-05-09 11:06:15 BST; 4s ago
+   Main PID: 11415 (python)
+      Tasks: 4 (limit: 18873)
+      Memory: 57.3M (peak: 71.9M)
+        CPU: 836ms
+     CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/hermes-gateway.service
+             └─11415 /home/samurai/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace
 
-### Unsupported verbs rejected
-
+May 09 11:06:15 elis-server systemd[1301]: Started hermes-gateway.service - Hermes Agent Gateway - Messaging Platform Integration.
+May 09 11:06:16 elis-server python[11415]: WARNING gateway.platforms.discord: [Discord] 1 skill(s) not registered (Discord subcommand limits)
 ```
-$ docker compose -f ops/containers/github-agent/docker-compose.github-agent.yml run --rm elis-github-agent --allow-delete-branch
-Usage: entrypoint.sh [OPTION] -- <command>
-Exit: 64
+
+```text
+$ hermes status
+◆ Messaging Platforms
+  Telegram      ✓ configured
+  Discord       ✓ configured (home: 1494725349261709343)
+
+◆ Gateway Service
+  Status:       ✓ running
+  Manager:      systemd (user)
 ```
 
-### No token leakage in logs/evidence
-
+```text
+$ grep -n "allowed_channels\|no_thread_channels\|channel_prompts" -A18 -B2 /home/samurai/.hermes/config.yaml
+335:  allowed_channels:
+336-    - '1494725349261709343'
+337-    - '1502602267931578378'
+338-  auto_thread: true
+339:  no_thread_channels:
+340-    - '1502602267931578378'
+341-  reactions: true
+342:  channel_prompts:
+343-    '1494725349261709343': |
+344-      You are ELIS Supervisor.
+345-      You are advisory and operational only.
+346-      Diagnose Hermes/OpenClaw gateway issues, verify auth and service health, inspect logs, verify Discord connectivity, and report operational risk.
+347-      Do not dispatch agents, validate PE work, modify config, write to GitHub, or merge.
+348-      Use UK English.
+349-    '1502602267931578378': |
+350-      You are ELIS Advisor.
+351-      You are advisory-only.
+352-      Return:
+353-      1. Verdict
+354-      2. Correct recipient
+355-      3. Evidence
+356-      4. Risk
+357-      5. Next safest action
+358-      6. Draft message
+359-      Use UK English.
+360-      Do not dispatch agents, validate, modify config, write to GitHub, or merge.
 ```
-$ docker compose -f ops/containers/github-agent/docker-compose.github-agent.yml run --rm elis-github-agent --check-only 2>&1 | \
-  grep -oP 'ghp_\w+|github_pat_\w+|ghu_\w+' || echo "PASS: no token in output"
-PASS: no token in output
+
+```text
+$ message send -> channel:1494725349261709343
+{"ok": true, "result": {"messageId": "1502612744342601738", "channelId": "1494725349261709343"}}
 ```
 
-### `python scripts/check_current_pe.py`
-
+```text
+$ message read -> channel:1494725349261709343
+[... supervisor thread message history includes the verification ping at messageId 1502612744342601738 ...]
 ```
-$ python3 scripts/check_current_pe.py
+
+```text
+$ message channel-info -> channelId=1502602267931578378
+Missing Access
+```
+
+```text
+$ message channel-list -> guildId=1485030291813830898 query=advisor
+{"ok": true, "channels": [{"id": "1502602267931578378", "name": "elis-advisor", "parent_id": "1485030292690309130", "nsfw": false}]}
+```
+
+---
+
+## §6.5 Current facts / deliverable status
+
+### Files Changed
+- `CURRENT_PE.md`: modified
+- `HANDOFF.md`: created/modified
+
+### Acceptance Criteria Status
+| AC | Status | Evidence |
+|----|--------|----------|
+| AC-1 | PASS | ELIS Supervisor and ELIS Advisor channel prompts are present in `~/.hermes/config.yaml`. |
+| AC-2 | PASS_WITH_CAVEATS | Hermes restarted successfully; supervisor route verified; advisor channel exists but PM account lacks direct post access. |
+
+### Blockers
+- None for the live Hermes restart.
+- Advisory-channel direct send from this PM account is blocked by Discord access, so the advisor route could not be pinged directly from this account.
+
+---
+
+## Checks
+### check_current_pe.py
+```text
 CURRENT_PE.md OK — registry, roles, and alternation valid.
 ```
 
----
-
-## Deviations from plan
-
-1. **Supplementary group for secret access:** The plan specified `user: "995:983"` which drops supplementary groups. Added `group_add: ["982"]` in compose and `SECRETS_GID` build arg to grant the container user read access to the `elis-github-secrets` group-owned secret file. Without this, `grep` on the secret fails with `Permission denied`.
-
-2. **Entrypoint path adjusted:** The pre-existing image on the host already used `/run/secrets/github-agent.env` as the default `SECRETS_FILE` path, matching the compose volume mount path. The architecture plan text referenced an older `/secrets/github-agent.env` path. The compose and entrypoint are aligned on `/run/secrets/github-agent.env`.
+### Worktree Clean
+```text
+M CURRENT_PE.md
+```
 
 ---
 
-## Prohibitions observed
-
-- [x] Did not migrate all agents — only GitHub Agent pilot
-- [x] Did not delete `elis-github`, `/opt/elis/secrets/github-agent.env`, or backups
-- [x] Did not remove host ACL/workaround — cleanup checklist gated behind pilot
-- [x] Did not modify OpenClaw/Hermes config
-- [x] Did not modify secrets/tokens/GitHub settings
-- [x] Did not perform real push/open PR/merge
-- [x] UK English used throughout
-
----
-
-## Callouts for Validator
-
-1. **Pre-existing image:** The host already had an `elis-github-agent` image built approximately 2 hours before this PE session. That image had the same functional characteristics but used a different UID setup (no supplementary group for secret access). The rebuilt image from this PE's Dockerfile replaces it correctly and is now tagged `elis-github-agent:pe-ops-container-github-01`.
-
-2. **Token presence:** The identity check confirms `elis-git-bot` — but the actual token validity and permission level should be verified with `gh repo view --json viewerPermission` by the Validator.
-
-3. **No real push tested:** Per the critical clarification, no push/PR was performed. The entrypoint accepts the `--allow-push` and `--allow-pr-create` verbs, but these can only be fully validated through a sandbox test with PO approval.
+## Next step
+Validator review / PM follow-up for the advisor-channel access caveat.
 
 ---
 
 ## Rollback
 
 ```bash
-# Remove the deliverable files from this branch (reverse the commit)
-git revert HEAD
-# or manually remove:
-rm -f ops/containers/github-agent/Dockerfile
-rm -f ops/containers/github-agent/entrypoint.sh
-rm -f ops/containers/github-agent/docker-compose.github-agent.yml
-rm -f ops/containers/github-agent/elis-github-agent-container
-rm -f docs/openclaw/GITHUB_AGENT_CONTAINER_RUNBOOK.md
-rm -f docs/governance/ELIS_GITHUB_AGENT_HOST_CLEANUP_CHECKLIST.md
-git rm docs/architecture/ELIS_Containerised_GitHub_Agent_Runtime_Plan.md
-git commit -m "revert: PE-OPS-CONTAINER-GITHUB-01 implementation"
+cp /home/samurai/.hermes/config.yaml.bak-20260509T100606Z /home/samurai/.hermes/config.yaml
+systemctl --user restart hermes-gateway.service
 ```
-
----
-
-## Evidence archive
-
-All test outputs were captured live during this PE session. Key output files (if saved):
-
-- `docker build` output — build succeeded
-- `identity check` — `elis-git-bot` confirmed
-- `workspace writable` — PASS
-- `secret read-only` — PASS
-- `no ambient creds` — PASS (only elis-git-bot)
-- `unsupported verb rejected` — PASS (exit 64)
-- `no token leakage` — PASS
-- `check_current_pe.py` — PASS

--- a/docs/governance/ELIS_Advisor_Operating_Model.md
+++ b/docs/governance/ELIS_Advisor_Operating_Model.md
@@ -41,7 +41,7 @@ Approved pilot shape:
 - runtime: Hermes
 - identity: ELIS Advisor
 - profile: existing default Hermes profile for the pilot
-- Discord target: dedicated channel `#elis-advisor`
+- Discord target: dedicated channel `<#1502602267931578378>`
 - threading: disable auto-threading for that channel if supported
 - secrets/tokens: no new provider/model secrets for the pilot
 - OpenClaw config: no OpenClaw config changes
@@ -67,7 +67,7 @@ Substantive advice must cite at least one high-weight source:
 ## 6. Deployment prerequisites
 
 Before live Hermes routing:
-- confirm channel ID for `#elis-advisor`
+- confirm channel ID for `<#1502602267931578378>`
 - confirm the proposed Hermes config patch exactly
 - confirm whether `allowed_channels` or `free_response_channels` is the right binding choice
 - confirm whether `no_thread_channels` is supported on the live host

--- a/docs/governance/ELIS_Advisor_Operating_Model.md
+++ b/docs/governance/ELIS_Advisor_Operating_Model.md
@@ -42,11 +42,12 @@ Approved pilot shape:
 - identity: ELIS Advisor
 - profile: existing default Hermes profile for the pilot
 - Discord target: dedicated channel `<#1502602267931578378>`
-- threading: disable auto-threading for that channel if supported
+- Supervisor target: dedicated channel `<#1494725349261709343>`
+- threading: disable auto-threading for the advisor channel if supported
 - secrets/tokens: no new provider/model secrets for the pilot
 - OpenClaw config: no OpenClaw config changes
 
-The dedicated Discord channel must be provisioned manually if it does not already exist.
+The dedicated Discord channels must be present before live routing.
 
 ## 4. Discord behaviour
 
@@ -67,7 +68,7 @@ Substantive advice must cite at least one high-weight source:
 ## 6. Deployment prerequisites
 
 Before live Hermes routing:
-- confirm channel ID for `<#1502602267931578378>`
+- confirm channel IDs for `<#1494725349261709343>` and `<#1502602267931578378>`
 - confirm the proposed Hermes config patch exactly
 - confirm whether `allowed_channels` or `free_response_channels` is the right binding choice
 - confirm whether `no_thread_channels` is supported on the live host

--- a/docs/governance/ELIS_Advisor_Operating_Model.md
+++ b/docs/governance/ELIS_Advisor_Operating_Model.md
@@ -1,0 +1,83 @@
+# ELIS Advisor Operating Model
+
+**Status:** Draft operating model for PE-OPS-ADVISOR-01.
+
+**Version:** 1.0
+**Date:** 2026-05-09
+**Owner:** Carlos Rocha, Product Owner
+**Scope:** ELIS Advisor authority boundaries, advisory workflow, Hermes/Discord deployment prerequisites, and evidence handling.
+
+## 1. Purpose
+
+ELIS Advisor is an advisory-only agent that supports PM and Supervisor with governance advice, evidence review, risk classification, and safe draft guidance.
+
+It improves clarity and reduces mistakes, but it does not execute actions.
+
+## 2. Authority model
+
+### May do
+- review PE opening packets and governance evidence
+- summarise current PE state
+- classify risk and missing evidence
+- recommend the next safest action
+- draft messages for human review
+- reference version-controlled governance documents
+
+### May not
+- dispatch agents
+- implement files
+- issue official validation verdicts
+- modify config
+- write to GitHub
+- merge PRs
+- relay messages on behalf of Carlos/PO
+- create Discord channels
+- change Discord permissions
+- create or manage Hermes profiles autonomously
+
+## 3. Hermes pilot model
+
+Approved pilot shape:
+- runtime: Hermes
+- identity: ELIS Advisor
+- profile: existing default Hermes profile for the pilot
+- Discord target: dedicated channel `#elis-advisor`
+- threading: disable auto-threading for that channel if supported
+- secrets/tokens: no new provider/model secrets for the pilot
+- OpenClaw config: no OpenClaw config changes
+
+The dedicated Discord channel must be provisioned manually if it does not already exist.
+
+## 4. Discord behaviour
+
+- respond only in the approved channel context
+- keep replies concise and evidence-led
+- use UK English
+- do not act as a relay for Carlos/PO
+- do not create threads unless explicitly required by the approved channel policy
+
+## 5. Evidence rules
+
+Substantive advice must cite at least one high-weight source:
+- `CURRENT_PE.md`
+- `.elis/pe/*/PE_TASK.md`
+- `docs/governance/*.md`
+- `HANDOFF.md` / `REVIEW.md` when available
+
+## 6. Deployment prerequisites
+
+Before live Hermes routing:
+- confirm channel ID for `#elis-advisor`
+- confirm the proposed Hermes config patch exactly
+- confirm whether `allowed_channels` or `free_response_channels` is the right binding choice
+- confirm whether `no_thread_channels` is supported on the live host
+- confirm restart/reload procedure for `hermes-gateway.service`
+- confirm rollback steps
+
+## 7. Acceptance criteria
+
+- advisor remains advisory-only
+- no dispatch, implementation, validation, config, GitHub write, or merge authority
+- dedicated Hermes/Discord pilot model is explicit
+- live config change is proposal-only until approved
+- evidence and rollback expectations are clear

--- a/docs/hermes/ELIS_ADVISOR_CHANNEL_BINDING.md
+++ b/docs/hermes/ELIS_ADVISOR_CHANNEL_BINDING.md
@@ -1,0 +1,53 @@
+# ELIS Advisor Channel Binding
+
+## Purpose
+
+This document proposes how ELIS Advisor should be bound to Discord for the Hermes pilot.
+
+## Canonical channel
+
+- Name: `#elis-advisor`
+- Channel ID: **TBD**
+- Status: must be created manually by PO/admin if it does not already exist
+
+## Binding notes
+
+Recommended pilot binding:
+- use the existing Hermes default profile
+- bind ELIS Advisor to the dedicated `#elis-advisor` channel
+- disable auto-threading for the channel if supported via `no_thread_channels`
+- avoid a separate Discord bot for the pilot
+- do not introduce new provider/model secrets
+
+## Proposed routing intent
+
+The pilot should be constrained to the advisor channel only.
+The safest starting point is a whitelist-style binding for the dedicated channel, plus an explicit no-thread override.
+
+Likely config shape in Hermes terms:
+- `discord.allowed_channels`: include the `#elis-advisor` channel ID
+- `discord.no_thread_channels`: include the `#elis-advisor` channel ID
+- `discord.channel_prompts`: attach the ELIS Advisor system prompt to the channel ID
+
+## Channel prompt intent
+
+The channel prompt should instruct the agent to:
+- act as ELIS Advisor only
+- provide verdict, evidence, risk, next safest action, and draft message
+- avoid dispatch, validation, config changes, GitHub writes, or merges
+- use UK English
+
+## Open questions
+
+- channel ID remains unknown until the channel exists
+- whether the live host should use `allowed_channels` or `free_response_channels` for final behaviour
+- whether the channel should remain mention-gated or respond to every message in-channel
+
+## Verification
+
+Before live routing:
+- confirm the channel exists
+- confirm the channel ID
+- confirm the proposed config patch
+- confirm restart/reload requirements
+- confirm rollback steps

--- a/docs/hermes/ELIS_ADVISOR_CHANNEL_BINDING.md
+++ b/docs/hermes/ELIS_ADVISOR_CHANNEL_BINDING.md
@@ -39,7 +39,6 @@ The channel prompt should instruct the agent to:
 
 ## Open questions
 
-- channel ID is known: `1502602267931578378`
 - whether the live host should use `allowed_channels` or `free_response_channels` for final behaviour
 - whether the channel should remain mention-gated or respond to every message in-channel
 

--- a/docs/hermes/ELIS_ADVISOR_CHANNEL_BINDING.md
+++ b/docs/hermes/ELIS_ADVISOR_CHANNEL_BINDING.md
@@ -6,15 +6,15 @@ This document proposes how ELIS Advisor should be bound to Discord for the Herme
 
 ## Canonical channel
 
-- Name: `#elis-advisor`
-- Channel ID: **TBD**
-- Status: must be created manually by PO/admin if it does not already exist
+- Name: `<#1502602267931578378>`
+- Channel ID: `1502602267931578378`
+- Status: approved pilot target channel
 
 ## Binding notes
 
 Recommended pilot binding:
 - use the existing Hermes default profile
-- bind ELIS Advisor to the dedicated `#elis-advisor` channel
+- bind ELIS Advisor to the dedicated `<#1502602267931578378>` channel
 - disable auto-threading for the channel if supported via `no_thread_channels`
 - avoid a separate Discord bot for the pilot
 - do not introduce new provider/model secrets
@@ -25,9 +25,9 @@ The pilot should be constrained to the advisor channel only.
 The safest starting point is a whitelist-style binding for the dedicated channel, plus an explicit no-thread override.
 
 Likely config shape in Hermes terms:
-- `discord.allowed_channels`: include the `#elis-advisor` channel ID
-- `discord.no_thread_channels`: include the `#elis-advisor` channel ID
-- `discord.channel_prompts`: attach the ELIS Advisor system prompt to the channel ID
+- `discord.allowed_channels`: include `1502602267931578378`
+- `discord.no_thread_channels`: include `1502602267931578378`
+- `discord.channel_prompts`: attach the ELIS Advisor system prompt to `1502602267931578378`
 
 ## Channel prompt intent
 
@@ -39,7 +39,7 @@ The channel prompt should instruct the agent to:
 
 ## Open questions
 
-- channel ID remains unknown until the channel exists
+- channel ID is known: `1502602267931578378`
 - whether the live host should use `allowed_channels` or `free_response_channels` for final behaviour
 - whether the channel should remain mention-gated or respond to every message in-channel
 

--- a/docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md
+++ b/docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md
@@ -1,0 +1,79 @@
+# ELIS Advisor Hermes Runbook
+
+## Purpose
+
+Read-only preparation and later live configuration guidance for the ELIS Advisor Hermes pilot.
+
+## Current pilot decision
+
+- Canonical name: ELIS Advisor
+- Hermes profile: existing default profile for the pilot
+- Discord target: dedicated channel `#elis-advisor`
+- No separate Discord bot for the pilot
+- No new provider/model secrets for the pilot
+- No OpenClaw config changes
+- No live Hermes config edit yet
+
+## Proposed live Hermes patch
+
+This is a proposal only.
+Do not apply until PO approves the exact patch.
+
+```yaml
+discord:
+  allowed_channels:
+    - "<ELIS_ADVISOR_CHANNEL_ID>"
+  no_thread_channels:
+    - "<ELIS_ADVISOR_CHANNEL_ID>"
+  channel_prompts:
+    "<ELIS_ADVISOR_CHANNEL_ID>": |
+      You are ELIS Advisor.
+      You are advisory-only.
+      Return:
+      1. Verdict
+      2. Correct recipient
+      3. Evidence
+      4. Risk
+      5. Next safest action
+      6. Draft message
+      Use UK English.
+      Do not dispatch agents, validate, modify config, write to GitHub, or merge.
+```
+
+## Required checks before applying any live patch
+
+- confirm `#elis-advisor` exists
+- confirm the channel ID
+- confirm the patch syntax matches the live Hermes config format
+- confirm the channel prompt is correct
+- confirm whether mention gating is still desired
+- confirm rollback path
+
+## Restart / reload
+
+A Hermes gateway restart or reload is expected after any live config change.
+
+Suggested sequence:
+1. back up current Hermes config
+2. apply the exact approved patch
+3. restart `hermes-gateway.service`
+4. verify status and routing behaviour
+5. verify the advisor responds only in the intended channel
+
+## Rollback
+
+If the patch misbehaves:
+1. restore the previous config snapshot
+2. restart or reload Hermes gateway again
+3. verify the old routing state is restored
+4. record the failure and the restored state
+
+## Validation checklist
+
+- [ ] channel exists
+- [ ] channel ID recorded
+- [ ] proposed patch approved
+- [ ] no new secrets required
+- [ ] no separate bot required for the pilot
+- [ ] gateway restart plan recorded
+- [ ] rollback plan recorded

--- a/docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md
+++ b/docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md
@@ -8,7 +8,7 @@ Read-only preparation and later live configuration guidance for the ELIS Advisor
 
 - Canonical name: ELIS Advisor
 - Hermes profile: existing default profile for the pilot
-- Discord target: dedicated channel `#elis-advisor`
+- Discord target: dedicated channel `<#1502602267931578378>`
 - No separate Discord bot for the pilot
 - No new provider/model secrets for the pilot
 - No OpenClaw config changes
@@ -22,11 +22,11 @@ Do not apply until PO approves the exact patch.
 ```yaml
 discord:
   allowed_channels:
-    - "<ELIS_ADVISOR_CHANNEL_ID>"
+    - "1502602267931578378"
   no_thread_channels:
-    - "<ELIS_ADVISOR_CHANNEL_ID>"
+    - "1502602267931578378"
   channel_prompts:
-    "<ELIS_ADVISOR_CHANNEL_ID>": |
+    "1502602267931578378": |
       You are ELIS Advisor.
       You are advisory-only.
       Return:
@@ -42,8 +42,7 @@ discord:
 
 ## Required checks before applying any live patch
 
-- confirm `#elis-advisor` exists
-- confirm the channel ID
+- confirm `1502602267931578378` is the live channel ID
 - confirm the patch syntax matches the live Hermes config format
 - confirm the channel prompt is correct
 - confirm whether mention gating is still desired

--- a/docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md
+++ b/docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md
@@ -9,6 +9,7 @@ Read-only preparation and later live configuration guidance for the ELIS Advisor
 - Canonical name: ELIS Advisor
 - Hermes profile: existing default profile for the pilot
 - Discord target: dedicated channel `<#1502602267931578378>`
+- Supervisor target: dedicated channel `<#1494725349261709343>`
 - No separate Discord bot for the pilot
 - No new provider/model secrets for the pilot
 - No OpenClaw config changes
@@ -22,10 +23,17 @@ Do not apply until PO approves the exact patch.
 ```yaml
 discord:
   allowed_channels:
+    - "1494725349261709343"
     - "1502602267931578378"
   no_thread_channels:
     - "1502602267931578378"
   channel_prompts:
+    "1494725349261709343": |
+      You are ELIS Platform Monitor.
+      You are advisory and operational only.
+      Diagnose Hermes/OpenClaw gateway issues, verify auth and service health, inspect logs, verify Discord connectivity, and report operational risk.
+      Do not dispatch agents, validate PE work, modify config, write to GitHub, or merge.
+      Use UK English.
     "1502602267931578378": |
       You are ELIS Advisor.
       You are advisory-only.
@@ -42,9 +50,10 @@ discord:
 
 ## Required checks before applying any live patch
 
-- confirm `1502602267931578378` is the live channel ID
+- confirm `1494725349261709343` is the live supervisor channel ID
+- confirm `1502602267931578378` is the live advisor channel ID
 - confirm the patch syntax matches the live Hermes config format
-- confirm the channel prompt is correct
+- confirm the channel prompts are correct
 - confirm whether mention gating is still desired
 - confirm rollback path
 
@@ -69,8 +78,8 @@ If the patch misbehaves:
 
 ## Validation checklist
 
-- [ ] channel exists
-- [ ] channel ID recorded
+- [ ] channels exist
+- [ ] channel IDs recorded
 - [ ] proposed patch approved
 - [ ] no new secrets required
 - [ ] no separate bot required for the pilot

--- a/docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md
+++ b/docs/hermes/ELIS_ADVISOR_HERMES_RUNBOOK.md
@@ -29,7 +29,7 @@ discord:
     - "1502602267931578378"
   channel_prompts:
     "1494725349261709343": |
-      You are ELIS Platform Monitor.
+      You are ELIS Supervisor.
       You are advisory and operational only.
       Diagnose Hermes/OpenClaw gateway issues, verify auth and service health, inspect logs, verify Discord connectivity, and report operational risk.
       Do not dispatch agents, validate PE work, modify config, write to GitHub, or merge.
@@ -71,10 +71,21 @@ Suggested sequence:
 ## Rollback
 
 If the patch misbehaves:
-1. restore the previous config snapshot
+1. restore the specific timestamped backup taken immediately before the patch
 2. restart or reload Hermes gateway again
 3. verify the old routing state is restored
 4. record the failure and the restored state
+
+Example backup command:
+```bash
+cp ~/.hermes/config.yaml ~/.hermes/config.yaml.bak-$(date -u +%Y%m%dT%H%M%SZ)
+```
+
+Example restore command:
+```bash
+cp ~/.hermes/config.yaml.bak-<timestamp> ~/.hermes/config.yaml
+systemctl --user restart hermes-gateway.service
+```
 
 ## Validation checklist
 

--- a/docs/hermes/ELIS_SUPERVISOR_CHANNEL_BINDING.md
+++ b/docs/hermes/ELIS_SUPERVISOR_CHANNEL_BINDING.md
@@ -1,0 +1,41 @@
+# ELIS Supervisor Channel Binding
+
+## Purpose
+
+This document proposes the Discord binding for ELIS Platform Monitor / Supervisor behaviour on Hermes.
+
+## Canonical channel
+
+- Name: `<#1494725349261709343>`
+- Channel ID: `1494725349261709343`
+- Status: approved platform-monitor channel
+
+## Binding notes
+
+Recommended pilot binding:
+- use the existing Hermes default profile for the pilot
+- bind Supervisor/Platform Monitor behaviour to `<#1494725349261709343>`
+- keep the channel within the approved Hermes allowlist only
+- no separate Discord bot for the pilot
+- no new provider/model secrets
+
+## Channel prompt intent
+
+The channel prompt should instruct the agent to:
+- act as ELIS Platform Monitor / Supervisor only
+- diagnose Hermes/OpenClaw gateway issues
+- verify auth, provider, model, path, and service status
+- inspect logs
+- verify Discord connectivity
+- classify operational risk
+- avoid dispatch, validation, config changes, GitHub writes, or merges
+- use UK English
+
+## Verification
+
+Before live routing:
+- confirm the channel exists
+- confirm the channel ID
+- confirm the proposed config patch
+- confirm restart/reload requirements
+- confirm rollback steps

--- a/docs/hermes/ELIS_SUPERVISOR_CHANNEL_BINDING.md
+++ b/docs/hermes/ELIS_SUPERVISOR_CHANNEL_BINDING.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document proposes the Discord binding for ELIS Platform Monitor / Supervisor behaviour on Hermes.
+This document proposes the Discord binding for ELIS Supervisor behaviour on Hermes.
 
 ## Canonical channel
 
@@ -14,7 +14,7 @@ This document proposes the Discord binding for ELIS Platform Monitor / Superviso
 
 Recommended pilot binding:
 - use the existing Hermes default profile for the pilot
-- bind Supervisor/Platform Monitor behaviour to `<#1494725349261709343>`
+- bind ELIS Supervisor behaviour to `<#1494725349261709343>`
 - keep the channel within the approved Hermes allowlist only
 - no separate Discord bot for the pilot
 - no new provider/model secrets
@@ -22,7 +22,7 @@ Recommended pilot binding:
 ## Channel prompt intent
 
 The channel prompt should instruct the agent to:
-- act as ELIS Platform Monitor / Supervisor only
+- act as ELIS Supervisor only
 - diagnose Hermes/OpenClaw gateway issues
 - verify auth, provider, model, path, and service status
 - inspect logs


### PR DESCRIPTION
PE-OPS-ADVISOR-01 — Implement ELIS Advisor on Hermes

Summary:
- ELIS Advisor created as a separate Hermes profile and Discord bot.
- Advisor channel ID: 1502602267931578378 (`<#1502602267931578378>`).
- `elis-advisor-gateway.service` is enabled and running.
- Advisor responds in `<#1502602267931578378>`.
- Supervisor route remains separate.
- Validation: PASS with caveats.

Known non-blocking caveat:
- Slash-command sync warning / command exceeds 8000 chars.

Follow-up notes:
- `free_response_channels` is typed oddly as an empty string and should later be normalised to the preferred Hermes schema.
- Advisor profile has a duplicate `discord:` block and should later be cleaned.
- Supervisor channel had no recent activity, but validator did not classify it as a routing failure.
