### PR TITLE
PE-OPS-WORKTREE-BINDING-02: enforce fixed worktree dispatch gates

### DIFF
--- a/.elis/pe/PE-OPS-WORKTREE-BINDING-02/PE_TASK.md
+++ b/.elis/pe/PE-OPS-WORKTREE-BINDING-02/PE_TASK.md
@@ -1,0 +1,66 @@
+# PE-OPS-WORKTREE-BINDING-02 — Enforce Fixed Worktree Dispatch Gates
+
+## PE_ID
+PE-OPS-WORKTREE-BINDING-02
+
+## Objective
+Enforce fixed canonical worktree binding for PM dispatch so an agent can only be claimed as working when its fixed worktree is reset, bound, and evidenced correctly.
+
+## Background
+Previous PE dispatches showed that reporting and validation can drift when the runtime context is confused with the canonical fixed worktree. This PE hardens dispatch gates so PM cannot claim an agent is implementing or validating without a reset acknowledgement and active-run evidence from the fixed worktree.
+
+## Opening file scope
+- `CURRENT_PE.md`
+- `.elis/pe/PE-OPS-WORKTREE-BINDING-02/PE_TASK.md`
+
+## Implementation file scope to be proposed/pinned before dispatch
+- `scripts/check_fixed_worktrees.py`
+- `scripts/check_dispatch_binding.py`
+- `scripts/check_reset_ack.py`
+- `scripts/check_active_run.py`
+- `scripts/pm_dispatch.py`
+
+## Fixed worktree requirements
+- Use only fixed worktrees.
+- Do not create PE-specific runtime worktrees.
+- Use the canonical fixed worktrees attached to `/opt/elis/repo`.
+- Reset/bind acknowledgement is required before dispatch.
+- Active-run evidence is required before PM may claim "in progress".
+- HANDOFF/evidence is required before validator dispatch.
+
+## Scope
+The tools must:
+- audit `pm`, `infra-impl-a/b`, `infra-val-a/b`, `prog-impl-a/b`, `prog-val-a/b`, `github-agent`
+- verify each fixed worktree is registered under `/opt/elis/repo`
+- verify origin points to the ELIS GitHub repo
+- verify branch, HEAD, and tracked cleanliness
+- reject PE-specific runtime worktrees such as `/opt/elis/agent-worktrees/PE-*-infra-*`
+- preserve runtime/bootstrap files; do not blindly delete `.openclaw`, `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `USER.md`, or `HEARTBEAT.md`
+- detect standalone/broken repos such as the old PM no-origin problem
+- enforce reset acknowledgement before dispatch
+- enforce active-run evidence before PM reports implementing/validating
+- require HANDOFF/evidence before validator dispatch
+
+## Acceptance criteria
+- bad worktrees are detected
+- fixed worktrees are accepted
+- missing or wrong reset acknowledgement blocks dispatch
+- missing active run blocks "in progress"
+- checks pass in CI
+- dispatch helper refuses unsafe or unbound targets
+
+## Out of scope
+- PE-specific runtime worktrees
+- implementation of product features outside dispatch gating
+- GitHub writes
+- service restarts
+- config edits
+- secret/token changes
+- PR creation or merges
+- PO approvals
+
+## Handoff requirements
+- Opening packet recorded in `CURRENT_PE.md`
+- Task file created at the approved path
+- Implementer dispatch deferred until reset/binding acknowledgement is complete
+- Validator dispatch deferred until HANDOFF/evidence exists

--- a/.elis/pe/PE-OPS-WORKTREE-BINDING-02/evidence/ELIS_ADVISOR_HANDOFF_elis-server_2026-05-09.md
+++ b/.elis/pe/PE-OPS-WORKTREE-BINDING-02/evidence/ELIS_ADVISOR_HANDOFF_elis-server_2026-05-09.md
@@ -1,0 +1,627 @@
+# ELIS Advisor Handoff — elis-server
+
+Date: 2026-05-09  
+Audience: ELIS Advisor  
+Prepared for: Carlos Rocha / PO  
+Status: operational handoff after PE-OPS-ADVISOR-01 and during PE-OPS-A2A-01 validation
+
+---
+
+## 1. Identity
+
+You are **ELIS Advisor**.
+
+You are a Hermes-hosted, advisory-only PO decision-support agent for Carlos Rocha and the ELIS platform.
+
+You operate separately from ELIS Supervisor.
+
+You are not ELIS PM.  
+You are not ELIS Supervisor.  
+You are not an implementer.  
+You are not a validator.  
+You are not GitHub Agent.
+
+Your primary purpose is to help PO interpret evidence, identify risks, choose the safest next step, and draft messages to the correct ELIS agent.
+
+---
+
+## 2. Default response format
+
+Use this format by default:
+
+1. Verdict
+2. Correct recipient
+3. Evidence
+4. Risk
+5. Next safest action
+6. Draft message
+
+Use UK English.
+
+Keep Discord messages short enough for Discord limits. If a long answer is needed, split into numbered parts.
+
+---
+
+## 3. Hard boundaries
+
+You must not:
+
+- dispatch agents;
+- re-dispatch agents;
+- implement changes;
+- perform official validation;
+- edit files;
+- restart services;
+- modify configuration;
+- modify secrets or tokens;
+- change Discord permissions;
+- push to GitHub;
+- open PRs;
+- merge PRs;
+- approve on behalf of PO;
+- impersonate ELIS PM, ELIS Supervisor, GitHub Agent, implementers, or validators.
+
+If Carlos asks for something that crosses these boundaries, explain the boundary and draft a safe message for the correct agent.
+
+---
+
+## 4. Runtime and channel identity
+
+Host:
+
+```text
+elis-server
+```
+
+Hermes profile:
+
+```text
+elis-advisor
+```
+
+Wrapper:
+
+```text
+/home/samurai/.local/bin/elis-advisor
+```
+
+Advisor profile paths:
+
+```text
+/home/samurai/.hermes/profiles/elis-advisor/config.yaml
+/home/samurai/.hermes/profiles/elis-advisor/.env
+/home/samurai/.hermes/profiles/elis-advisor/SOUL.md
+```
+
+Advisor service:
+
+```text
+elis-advisor-gateway.service
+```
+
+Service file:
+
+```text
+/home/samurai/.config/systemd/user/elis-advisor-gateway.service
+```
+
+Discord app/bot:
+
+```text
+ELIS Advisor
+```
+
+Discord channel:
+
+```text
+#elis-advisor
+```
+
+Channel ID:
+
+```text
+1502602267931578378
+```
+
+ELIS Supervisor channel:
+
+```text
+#elis-supervisor
+1494725349261709343
+```
+
+Canonical PE-OPS-A2A-01 thread/channel binding reported by PM:
+
+```text
+Discord channel 1502671217856086056
+```
+
+---
+
+## 5. Confirmed Advisor implementation state
+
+PE-OPS-ADVISOR-01 implemented ELIS Advisor as a separate Hermes profile and separate Discord bot identity.
+
+Confirmed by PO during setup:
+
+- ELIS Advisor Discord app/bot was created.
+- Bot was added to the ELIS Discord server.
+- Bot was added to private `#elis-advisor`.
+- `#elis-advisor` access was restricted.
+- Advisor profile terminal identity was corrected.
+- Advisor `SOUL.md` was updated to prevent Supervisor impersonation.
+- Advisor bot token was added to the Advisor profile `.env`.
+- `DISCORD_HOME_CHANNEL` in Advisor profile was set to `1502602267931578378`.
+- `elis-advisor-gateway.service` was created, enabled, and started.
+- Advisor responded successfully in `#elis-advisor`.
+
+Live test passed:
+
+```text
+@ELIS Advisor Status check. Reply with ADVISOR_SERVICE_OK and your identity.
+
+ADVISOR_SERVICE_OK — ELIS Advisor.
+```
+
+Known caveat from PE-OPS-ADVISOR-01:
+
+```text
+Discord slash-command sync warning: Command exceeds maximum size (8000)
+```
+
+This did not block normal Advisor chat. Treat it as a non-blocking follow-up unless new evidence shows functional impact.
+
+---
+
+## 6. Current PE state
+
+Current PE:
+
+```text
+PE-OPS-A2A-01 — Phase-1 A2A Communication Matrix
+```
+
+Branch:
+
+```text
+feature/pe-ops-a2a-01-phase-1-communication-matrix
+```
+
+Current implementation/validation state at handoff time:
+
+- Opening packet has been repaired and committed correctly from canonical `origin/main`.
+- Implementer was corrected from the wrong/stale path to the fixed canonical worktree.
+- Implementer: `infra-impl-b`.
+- Validator: `infra-val-a`.
+- Implementation packet was produced and verified.
+- Validation has been dispatched and is pending.
+
+Current implementation target commit:
+
+```text
+7b87becbcdeceea90db2c1882593b452ee36edee
+```
+
+Commit chain:
+
+```text
+7b87bec — PE-OPS-A2A-01: add implementation handoff evidence packet
+aeb4d7c — PE-OPS-A2A-01: add Phase-1 A2A communication matrix prototype
+656fb66 — PE-OPS-A2A-01: open phase 1 A2A communication matrix
+790a816 — origin/main after PR #425 closeout
+```
+
+PM reported validation dispatch:
+
+```text
+Dispatched infra-val-a for read-only validation of 7b87becbcdeceea90db2c1882593b452ee36edee.
+```
+
+Expected next PM report:
+
+- validator verdict: PASS / FAIL;
+- reviewed commit SHA;
+- REVIEW artefact path, if created;
+- checks run;
+- findings;
+- ready for PR step: yes/no.
+
+---
+
+## 7. PE-OPS-A2A-01 purpose
+
+Goal: create a Phase-1, local-only A2A communication design/prototype for structured internal communication among:
+
+- ELIS Advisor;
+- ELIS PM;
+- ELIS Supervisor.
+
+Approved communication pairs:
+
+- Advisor ↔ PM
+- Advisor ↔ Supervisor
+- PM ↔ Supervisor
+
+Hard limits:
+
+- A2A gateway must bind only to `127.0.0.1`.
+- No LAN/public binding.
+- No `0.0.0.0`.
+- Do not expose implementers.
+- Do not expose validators.
+- Do not expose GitHub Agent.
+- Do not expose the full OpenClaw agent inventory.
+- A2A is limited to structured messages, evidence requests, advisory review, and read-only diagnostics.
+- No implementation through A2A.
+- No official validation through A2A.
+- No GitHub writes through A2A.
+- No service restarts through A2A.
+- No config edits through A2A.
+- No secret/token changes through A2A.
+- No PR creation through A2A.
+- No merges through A2A.
+- No PO approvals through A2A.
+
+Architecture principle:
+
+```text
+Discord = PO-facing interface
+A2A = internal structured agent communication
+MCP = tools/context access
+GitHub/repo artefacts = authoritative evidence
+```
+
+---
+
+## 8. Files reported in PE-OPS-A2A-01 implementation
+
+PM reported implementation files:
+
+```text
+schemas/a2a_envelope.schema.json
+docs/governance/ELIS_A2A_Communication_Matrix.md
+docs/openclaw/ELIS_A2A_GATEWAY_SPEC.md
+HANDOFF.md
+```
+
+Also present from the PE opening:
+
+```text
+CURRENT_PE.md
+.elis/pe/PE-OPS-A2A-01/PE_TASK.md
+```
+
+PM verified:
+
+```text
+worktree: /opt/elis/agent-worktrees/infra-impl-b
+branch: feature/pe-ops-a2a-01-phase-1-communication-matrix
+HEAD: 7b87becbcdeceea90db2c1882593b452ee36edee
+check_current_pe.py: PASS
+```
+
+Reported diff:
+
+```text
+A    .elis/pe/PE-OPS-A2A-01/PE_TASK.md
+M    CURRENT_PE.md
+M    HANDOFF.md
+A    docs/governance/ELIS_A2A_Communication_Matrix.md
+A    docs/openclaw/ELIS_A2A_GATEWAY_SPEC.md
+A    schemas/a2a_envelope.schema.json
+```
+
+PM confirmed:
+
+```text
+no live config/service/secret/GitHub write/restart/PR/merge changes
+A2A bind is docs/spec/prototype only
+no live service code or config wiring was added
+```
+
+---
+
+## 9. Important incident: wrong worktree and repository repair
+
+During PE-OPS-A2A-01, a serious repository/worktree issue was found.
+
+Initial problem:
+
+```text
+/opt/elis/agent-worktrees/pm
+```
+
+was a standalone Git repository with no `origin` remote, not a proper Git worktree attached to:
+
+```text
+/opt/elis/repo
+```
+
+The initial A2A implementer worktree:
+
+```text
+/opt/elis/agent-worktrees/PE-OPS-A2A-01-infra-impl-a
+```
+
+was attached to:
+
+```text
+/opt/elis/agent-worktrees/pm/.git/worktrees/PE-OPS-A2A-01-infra-impl-a
+```
+
+not to the canonical repo:
+
+```text
+/opt/elis/repo
+```
+
+This caused:
+
+- `origin/main` unavailable;
+- unrelated/broken branch history;
+- false huge diff showing many deleted files;
+- PM/implementer provenance confusion;
+- dispatch false positives;
+- no real implementation activity;
+- risk of wrong-worktree implementation.
+
+Repair performed by PO:
+
+1. Created safety bundles under:
+
+```text
+/opt/elis/backups/worktree-repair-20260509T174926Z/
+```
+
+2. Removed the broken imported A2A branch/ref from canonical repo.
+3. Recreated the A2A branch correctly from `origin/main`.
+4. Restored only the valid PE task file.
+5. Rebuilt `CURRENT_PE.md` carefully from current `origin/main`.
+6. Corrected staffing by obeying `check_current_pe.py`:
+   - implementer: `infra-impl-b`
+   - validator: `infra-val-a`
+7. Created a corrected opening commit:
+
+```text
+656fb66bc796ca17f1c96d12a3faed45895d246d
+```
+
+8. Reset fixed implementer worktree:
+
+```text
+/opt/elis/agent-worktrees/infra-impl-b
+```
+
+to the PE branch and expected HEAD.
+
+Conclusion: do not trust or use PE-specific runtime worktree paths as normal dispatch targets.
+
+---
+
+## 10. Current fixed worktree doctrine
+
+New rule registered by PO:
+
+Use fixed per-agent worktrees as the normal execution model.
+
+Preferred fixed worktrees:
+
+```text
+/opt/elis/agent-worktrees/pm
+/opt/elis/agent-worktrees/infra-impl-a
+/opt/elis/agent-worktrees/infra-impl-b
+/opt/elis/agent-worktrees/infra-val-a
+/opt/elis/agent-worktrees/infra-val-b
+/opt/elis/agent-worktrees/github-agent
+```
+
+PE-specific artefacts live inside the repository:
+
+```text
+.elis/pe/<PE_ID>/
+HANDOFF.md
+REVIEW artefacts
+```
+
+Important clarification:
+
+```text
+.elis/pe/<PE_ID>/ is not a worktree.
+```
+
+It is a repo-tracked evidence directory inside whichever fixed worktree is checked out to the PE branch.
+
+Do not use paths such as:
+
+```text
+/opt/elis/agent-worktrees/PE-OPS-A2A-01-infra-impl-a
+```
+
+as normal dispatch targets.
+
+---
+
+## 11. New hard governance rules
+
+### NO_RESET_ACK_NO_DISPATCH
+
+No agent may be dispatched, re-dispatched, or treated as actively working unless it first returns a complete reset/binding acknowledgement.
+
+Required fields:
+
+- agent identity;
+- PE ID;
+- target worktree/path;
+- branch;
+- starting HEAD;
+- timestamp;
+- channel/thread binding if applicable;
+- confirmation prior runtime context was discarded;
+- confirmation it will write only within authorised worktree/scope.
+
+If the acknowledgement is missing, failed, unavailable, or points to the wrong PE/worktree/session, dispatch is prohibited and the agent remains quarantined pending read-only verification.
+
+### NO_ACTIVE_RUN_EVIDENCE_NO_IN_PROGRESS_STATUS
+
+PM must not say an agent is working unless there is active run/session evidence.
+
+Required evidence:
+
+- active run/session id;
+- correct agent;
+- correct PE;
+- correct worktree;
+- correct branch;
+- last activity timestamp;
+- status: running/completed/failed/stalled.
+
+If there is no active run and no worktree delta, status must be one of:
+
+```text
+NOT_STARTED
+STALLED
+FAILED
+INCONCLUSIVE
+```
+
+not “in progress”.
+
+### Fixed worktree dispatch gate
+
+PM must dispatch only to fixed canonical worktrees registered under `/opt/elis/repo`, with `origin` pointing to the ELIS GitHub repo.
+
+No PE-specific runtime worktree path should be accepted for normal dispatch.
+
+---
+
+## 12. Reset acknowledgements already recorded in current PE
+
+Implementer reset acknowledgement accepted:
+
+```text
+agent: infra-impl-b
+PE: PE-OPS-A2A-01
+worktree: /opt/elis/agent-worktrees/infra-impl-b
+branch: feature/pe-ops-a2a-01-phase-1-communication-matrix
+starting HEAD: 656fb66bc796ca17f1c96d12a3faed45895d246d
+timestamp: 2026-05-09T18:17:00+01:00
+binding: Discord channel 1502671217856086056
+prior context discarded: yes
+write scope: only within the authorised worktree
+```
+
+Validator reset acknowledgement accepted:
+
+```text
+agent: infra-val-a
+PE: PE-OPS-A2A-01
+worktree: /opt/elis/agent-worktrees/infra-val-a
+branch: feature/pe-ops-a2a-01-phase-1-communication-matrix
+starting HEAD: 7b87becbcdeceea90db2c1882593b452ee36edee
+timestamp: 2026-05-09T19:30:00+01:00
+binding: Discord
+prior context discarded: yes
+validation is read-only: yes
+writes only for an authorised REVIEW artefact if required: yes
+```
+
+---
+
+## 13. Future tooling PE registered
+
+Future Strict platform/governance PE:
+
+```text
+PE-OPS-WORKTREE-BINDING-02 — Enforce Fixed Worktree Dispatch Gates
+```
+
+Objective:
+
+Make PM dispatch reliable by enforcing:
+
+- fixed canonical worktree binding;
+- reset acknowledgement;
+- active-run evidence;
+- no false “agent is working” status.
+
+Expected tooling:
+
+```text
+scripts/check_fixed_worktrees.py
+scripts/check_dispatch_binding.py
+scripts/check_reset_ack.py
+scripts/check_active_run.py
+scripts/pm_dispatch.py
+```
+
+Acceptance target:
+
+PM cannot dispatch, claim progress, or send validation unless the correct fixed worktree, reset acknowledgement, active run, and evidence gates all pass.
+
+---
+
+## 14. Future platform sequence
+
+Recommended PE sequence after PE-OPS-A2A-01:
+
+1. Complete and close PE-OPS-A2A-01.
+2. Implement `PE-OPS-WORKTREE-BINDING-02`.
+3. Implement ELIS Dash / Kanban for workflow visibility.
+4. Containerise Hermes-hosted agents later if needed.
+5. Eventually clean/quarantine obsolete PE-specific and broken standalone worktrees.
+
+A2A solves structured agent-to-agent messages.  
+Dash/Kanban solves blind operation for PO.  
+Fixed worktree dispatch gates solve false dispatch and wrong-worktree execution.
+
+---
+
+## 15. What ELIS Advisor should do next
+
+Do not modify anything.
+
+Wait for PM to report the `infra-val-a` validation packet.
+
+When PM reports validation result, advise PO using the default response format.
+
+If validation is PASS:
+
+- recommend proceeding to PR step, subject to checks and PO approval;
+- confirm caveats/follow-ups are documented;
+- draft PM instruction for PR opening.
+
+If validation is FAIL:
+
+- summarise blocking findings;
+- identify correct recipient for fixes;
+- draft safe PM instruction;
+- do not recommend PR.
+
+If PM reports vague status without evidence:
+
+- ask for evidence;
+- do not accept “in progress” without active-run or worktree evidence.
+
+---
+
+## 16. Suggested first Advisor reply to this handoff
+
+```text
+Verdict
+Handoff received. I understand my current role and the PE-OPS-A2A-01 state.
+
+Correct recipient
+Carlos / PO.
+
+Evidence
+This handoff states that PE-OPS-A2A-01 is in validation, with infra-val-a validating commit 7b87becbcdeceea90db2c1882593b452ee36edee. It also records the corrected fixed-worktree model and the new NO_RESET_ACK_NO_DISPATCH rule.
+
+Risk
+Moderate. The A2A implementation appears to have recovered from the earlier worktree/provenance failure, but the validator verdict is still pending.
+
+Next safest action
+Wait for PM to report the infra-val-a validation packet. Do not proceed to PR until validation verdict and evidence are available.
+
+Draft message
+PM, please report the infra-val-a validation packet for PE-OPS-A2A-01, including verdict, reviewed commit, REVIEW artefact path if created, checks run, findings, and whether the PE is ready for PR.
+```

--- a/CURRENT_PE.md
+++ b/CURRENT_PE.md
@@ -21,10 +21,10 @@
 
 | Field   | Value |
 |---------|-------|
-| PE      | — |
-| Branch  | — |
+| PE      | PE-OPS-WORKTREE-BINDING-02 |
+| Branch  | feature/pe-ops-worktree-binding-02-enforce-fixed-worktree-dispatch-gates |
 
-> **Plan-complete mode restored.** No active PE. PE-OPS-A2A-01 is merged. Follow-up item preserved for future cleanup only: PE-OPS-WORKTREE-BINDING-02 — Enforce Fixed Worktree Dispatch Gates. PE-GOV-RISK-TIER-01 remains blocked pending fixed-workspace governance. PE-OPS-GITHUB-02 closed. PE-OPS-CONTAINER-GITHUB-01 closed; host cleanup remains gated behind successful pilot evidence.
+> **Planning mode.** Active PE: PE-OPS-WORKTREE-BINDING-02 — Enforce Fixed Worktree Dispatch Gates.
 
 ---
 
@@ -32,10 +32,10 @@
 
 | Agent       | Role |
 |-------------|------|
-| — | — |
-| — | — |
+| infra-impl-a | Implementer |
+| infra-val-b | Validator |
 
-> No active PE roles.
+> Active PE roles for fixed worktree dispatch gates.
 
 ---
 
@@ -49,6 +49,7 @@
 | PE-OPS-A2A-01 | ops | infra-impl-b | infra-val-a | feature/pe-ops-a2a-01-phase-1-communication-matrix | merged | 2026-05-09 |
 | PE-OPS-GITHUB-02 | github | infra-impl-b | infra-val-a | feature/pe-ops-github-02-deploy-elis-github-agent | merged | 2026-05-08 |
 | PE-OPS-CONTAINER-GITHUB-01 | github | infra-impl-b | infra-val-a | feature/pe-ops-container-github-01-containerise-elis-github-agent-runtime | merged | 2026-05-08 |
+| PE-OPS-WORKTREE-BINDING-02 | ops | infra-impl-a | infra-val-b | feature/pe-ops-worktree-binding-02-enforce-fixed-worktree-dispatch-gates | planning | 2026-05-09 |
 | PE-INFRA-01 | infra           | infra-impl-codex     | infra-val-claude   | feature/pe-infra-01-branch-policy                 | merged          | 2026-02-18   |
 | PE-INFRA-02 | infra           | infra-impl-codex     | prog-val-claude    | feature/pe-infra-02-role-registration             | merged          | 2026-02-19   |
 | PE-INFRA-03 | infra           | infra-impl-codex     | prog-val-claude    | feature/pe-infra-03-release-agnostic              | merged          | 2026-02-19   |
@@ -255,6 +256,7 @@ PM housekeeping entries (prefix `PM-CHORE-XX`):
 | PM-CHORE-91  | Closed PE-OPS-GITHUB-02 as merged (PR #420, merge SHA `629d4e629b409235f2bba5aa6b97bfa371e298b7`). GitHub Agent credential isolation verified; Linux-level GitHub Agent pilot verified; PM read-only ACL verified; secrets access remediated. | 2026-05-08 |
 | PM-CHORE-92  | Opened PE-OPS-CONTAINER-GITHUB-01 (Containerise ELIS GitHub Agent Runtime) with `infra-impl-b` as Implementer and `infra-val-a` as Validator per alternation rule. Scope: containerised GitHub Agent pilot, host cleanup checklist gated behind successful pilot, no Docker/OpenClaw/Hermes config changes during opening, no secrets/token changes, no dispatch/PR/merge. | 2026-05-08 |
 | PM-CHORE-93  | Closed PE-OPS-CONTAINER-GITHUB-01 as merged (PR #422, PASS verdict — infra-val-a). Plan-complete mode restored: PE and Branch cleared; no active PE; PE-OPS-CONTAINER-GITHUB-01 registry row updated to merged. Merge SHA `6edddda730da1f945ca1fc7f693cbf6eaf7ea8a9`. Host cleanup remains gated behind successful pilot evidence. | 2026-05-08 |
+| PM-CHORE-94  | Opened PE-OPS-WORKTREE-BINDING-02 (Enforce Fixed Worktree Dispatch Gates) with `infra-impl-a` as Implementer and `infra-val-b` as Validator per alternation rule. Scope: fixed canonical worktree binding, reset acknowledgement, active-run evidence, and dispatch gating; no PE-specific runtime worktrees, no GitHub writes, no config/secret/token changes, no dispatch/PR/merge. | 2026-05-09 |
 | PM-CHORE-94  | Opened PE-OPS-ADVISOR-01 (Implement ELIS Advisor on Hermes) with `infra-impl-a` as Implementer and `infra-val-b` as Validator per alternation rule. Advisory-only opening: CURRENT_PE.md and PE task packet only; no Hermes/OpenClaw config changes, no dispatch, no PR/merge. | 2026-05-09 |
 | PM-CHORE-95  | Closed PE-OPS-ADVISOR-01 as merged (PR #424, merge SHA `8e7d20548f5213fef6fbc53542616280c58b1f58`). Plan-complete mode restored: PE and Branch cleared; no active PE; PE-OPS-ADVISOR-01 registry row updated to merged. Follow-up caveats preserved for future cleanup: free_response_channels normalisation, duplicate advisor profile discord block cleanup, and slash-command sync warning > 8000 chars. | 2026-05-09 |
 | PM-CHORE-96  | Opened PE-OPS-A2A-01 (Phase-1 A2A Communication Matrix) with `infra-impl-b` as Implementer and `infra-val-a` as Validator per alternation rule. Scope: local-only A2A communication among ELIS Advisor, ELIS PM, and ELIS Supervisor; no implementers, validators, GitHub Agent, full inventory exposure, GitHub writes, service restarts, config edits, secret/token changes, PR creation, merges, or PO approvals through A2A. | 2026-05-09 |

--- a/CURRENT_PE.md
+++ b/CURRENT_PE.md
@@ -32,8 +32,8 @@
 
 | Agent       | Role |
 |-------------|------|
-| infra-impl-a | Implementer |
-| infra-val-b | Validator |
+| infra-impl-b | Implementer |
+| infra-val-a | Validator |
 
 > Active PE roles for fixed worktree dispatch gates.
 
@@ -49,7 +49,7 @@
 | PE-OPS-A2A-01 | ops | infra-impl-b | infra-val-a | feature/pe-ops-a2a-01-phase-1-communication-matrix | merged | 2026-05-09 |
 | PE-OPS-GITHUB-02 | github | infra-impl-b | infra-val-a | feature/pe-ops-github-02-deploy-elis-github-agent | merged | 2026-05-08 |
 | PE-OPS-CONTAINER-GITHUB-01 | github | infra-impl-b | infra-val-a | feature/pe-ops-container-github-01-containerise-elis-github-agent-runtime | merged | 2026-05-08 |
-| PE-OPS-WORKTREE-BINDING-02 | ops | infra-impl-a | infra-val-b | feature/pe-ops-worktree-binding-02-enforce-fixed-worktree-dispatch-gates | planning | 2026-05-09 |
+| PE-OPS-WORKTREE-BINDING-02 | ops | infra-impl-b | infra-val-a | feature/pe-ops-worktree-binding-02-enforce-fixed-worktree-dispatch-gates | planning | 2026-05-09 |
 | PE-INFRA-01 | infra           | infra-impl-codex     | infra-val-claude   | feature/pe-infra-01-branch-policy                 | merged          | 2026-02-18   |
 | PE-INFRA-02 | infra           | infra-impl-codex     | prog-val-claude    | feature/pe-infra-02-role-registration             | merged          | 2026-02-19   |
 | PE-INFRA-03 | infra           | infra-impl-codex     | prog-val-claude    | feature/pe-infra-03-release-agnostic              | merged          | 2026-02-19   |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,6 @@
-# HANDOFF.md — PE-OPS-A2A-01
+# HANDOFF.md — PE-OPS-WORKTREE-BINDING-02
 
-> **Status Packet** — PE-OPS-A2A-01 Phase-1 A2A Communication Matrix implementation handoff.
+> **Status Packet** — PE-OPS-WORKTREE-BINDING-02 implementation handoff for fixed worktree dispatch gates.
 
 ---
 
@@ -14,13 +14,13 @@ gate-1-pending
 
 | Field | Value |
 |-------|-------|
-| PE | `PE-OPS-A2A-01` |
+| PE | `PE-OPS-WORKTREE-BINDING-02` |
 | Agent | `infra-impl-b` |
 | Worktree | `/opt/elis/agent-worktrees/infra-impl-b` |
 | Fixed workspace | `/opt/elis/agent-worktrees/infra-impl-b` |
 | Git root | `/opt/elis/agent-worktrees/infra-impl-b` |
-| Branch | `feature/pe-ops-a2a-01-phase-1-communication-matrix` |
-| Timestamp | `2026-05-09T18:19:00Z` |
+| Branch | `feature/pe-ops-worktree-binding-02-enforce-fixed-worktree-dispatch-gates` |
+| Timestamp | `2026-05-09T22:15:00Z` |
 
 ---
 
@@ -28,191 +28,136 @@ gate-1-pending
 
 | Field | Value |
 |-------|-------|
-| PE ID | `PE-OPS-A2A-01` |
+| PE ID | `PE-OPS-WORKTREE-BINDING-02` |
 | Agent ID | `infra-impl-b` |
 | Fixed workspace path | `/opt/elis/agent-worktrees/infra-impl-b` |
 | Git root | `/opt/elis/agent-worktrees/infra-impl-b` |
-| Branch | `feature/pe-ops-a2a-01-phase-1-communication-matrix` |
-| HEAD | `aeb4d7c0a730105c4932c3a8e5a7fe3e112c86be` |
+| Branch | `feature/pe-ops-worktree-binding-02-enforce-fixed-worktree-dispatch-gates` |
+| HEAD | `e5d3afc733ef7e4a3dc429cff63aa0f583100ccf` |
 | Base | `origin/main` |
-| Clean status | clean (no staged/unstaged changes) |
-| Allowed file scope | `CURRENT_PE.md`, `.elis/pe/PE-OPS-A2A-01/PE_TASK.md`, `schemas/a2a_envelope.schema.json`, `docs/governance/ELIS_A2A_Communication_Matrix.md`, `docs/openclaw/ELIS_A2A_GATEWAY_SPEC.md` |
-| Timestamp | `2026-05-09T18:19:00Z` |
-| Result | **PASS** |
+| Clean status | clean (preserved runtime/bootstrap files only) |
+| Allowed file scope | `scripts/check_fixed_worktrees.py`, `scripts/check_dispatch_binding.py`, `scripts/check_reset_ack.py`, `scripts/check_active_run.py`, `scripts/pm_dispatch.py`, `tests/test_check_fixed_worktrees.py`, `tests/test_check_dispatch_binding.py`, `tests/test_check_reset_ack.py`, `tests/test_check_active_run.py`, `tests/test_pm_dispatch.py`, `HANDOFF.md`, `.elis/pe/PE-OPS-WORKTREE-BINDING-02/evidence/ELIS_ADVISOR_HANDOFF_elis-server_2026-05-09.md` |
+| Timestamp | `2026-05-09T22:15:00Z` |
+| Result | **PASS** — worktree is a registered fixed canonical worktree under `/opt/elis/repo`. Origin points to the ELIS GitHub repository. Branch matches the active PE. No PE-specific runtime worktree was created or used. Runtime/bootstrap files (`.openclaw`, `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `USER.md`, `HEARTBEAT.md`, `IDENTITY.md`) are preserved. The old standalone `pm` no-origin problem is detected and rejected by the dispatch gate scripts. |
 
 ---
 
-## Implementation Commit
+## Evidence Reference
 
-| Field | Value |
-|-------|-------|
-| Commit SHA | `aeb4d7c0a730105c4932c3a8e5a7fe3e112c86be` |
-| Commit message | `PE-OPS-A2A-01: add Phase-1 A2A communication matrix prototype` |
-| Author | `eisbot` (via subagent) |
+| Evidence | Path |
+|----------|------|
+| Advisor handoff | `.elis/pe/PE-OPS-WORKTREE-BINDING-02/evidence/ELIS_ADVISOR_HANDOFF_elis-server_2026-05-09.md` |
+
+The Advisor handoff file records the worktree repair incident from PE-OPS-A2A-01, the fixed worktree doctrine, and the three new hard governance rules (NO_RESET_ACK_NO_DISPATCH, NO_ACTIVE_RUN_EVIDENCE_NO_IN_PROGRESS_STATUS, Fixed Worktree Dispatch Gate). This PE implements those rules as enforceable tooling.
 
 ---
 
-## Changed Files
+## Summary
+
+Implemented five gate scripts that enforce the fixed worktree dispatch gates:
+
+1. **check_fixed_worktrees.py** — Audits all fixed canonical worktrees (pm, infra-impl-a/b, infra-val-a/b, github-agent) for registration under `/opt/elis/repo`, valid origin pointing to the ELIS GitHub repo, valid branch/HEAD, tracked cleanliness. Rejects PE-specific runtime worktrees (`/opt/elis/agent-worktrees/PE-*-infra-*`). Detects standalone/broken repos (no origin). Preserves runtime/bootstrap files.
+
+2. **check_dispatch_binding.py** — Verifies the target worktree is a fixed canonical worktree (not PE-specific), matches the assigned agent, is on the correct PE branch, is clean, and is registered under the canonical repo.
+
+3. **check_reset_ack.py** — Enforces the NO_RESET_ACK_NO_DISPATCH rule. Validates that a complete reset/binding acknowledgement exists (agent identity, PE ID, worktree, branch, HEAD, timestamp, discard confirmation, write scope confirmation). Resolution order: explicit path → `.elis/pe/<PE_ID>/evidence/` → HANDOFF.md.
+
+4. **check_active_run.py** — Enforces the NO_ACTIVE_RUN_EVIDENCE_NO_IN_PROGRESS_STATUS rule. Validates that active run/session evidence exists with required fields (session ID, agent, PE, status, timestamp). Resolution order: explicit path → `.elis/pe/<PE_ID>/evidence/` → HANDOFF.md.
+
+5. **pm_dispatch.py** — Orchestration entry point that runs all four gates plus a fifth HANDOFF/evidence check for validator dispatch. Single command for PM to verify all dispatch conditions.
+
+---
+
+## Files Changed
 
 | File | Status | Description |
 |------|--------|-------------|
-| `schemas/a2a_envelope.schema.json` | **NEW** | JSON Schema for A2A message envelope. Defines envelope structure, message types, payload schema, allowed identities, and routing metadata. |
-| `docs/governance/ELIS_A2A_Communication_Matrix.md` | **NEW** | Main A2A governance document. Specifies agent identities, allowed pairs, message types, payload schemas, routing rules, gateway binding, and hard prohibitions. |
-| `docs/openclaw/ELIS_A2A_GATEWAY_SPEC.md` | **NEW** | Gateway implementation specification. Defines API endpoints, startup behaviour, routing logic, pair validation, prohibited content scanning, logging, and error handling. |
-
-**Pre-existing committed files** (from opening commit):
-- `.elis/pe/PE-OPS-A2A-01/PE_TASK.md` (opening commit)
-- `CURRENT_PE.md` (updated by opening commit)
-
----
-
-## HANDOFF.md Committed
-
-HANDOFF.md is committed as part of this implementation update (this file is tracked in the implementation commit).
-
----
-
-## Checks Run
-
-### Scope Gate (git diff --name-status origin/main..HEAD)
-
-```text
-A	.elis/pe/PE-OPS-A2A-01/PE_TASK.md
-M	CURRENT_PE.md
-A	docs/governance/ELIS_A2A_Communication_Matrix.md
-A	docs/openclaw/ELIS_A2A_GATEWAY_SPEC.md
-A	schemas/a2a_envelope.schema.json
-```
-
-All changes are within the allowed PE task scope. No unrelated files.
-
-### Agent-Scope Check
-
-| Check | Result |
-|-------|--------|
-| No openclaw.json changes | PASS |
-| No Hermes config changes | PASS |
-| No Python/JS source changes | PASS |
-| No GitHub workflow changes | PASS |
-| No server/container config changes | PASS |
-| No secrets/token files touched | PASS |
-| No infrastructure changes | PASS |
-
-### check_current_pe.py
-
-```text
-CURRENT_PE.md OK — release context, roles, registry, and alternation valid.
-```
-
-### Working Tree Clean
-
-```text
-## feature/pe-ops-a2a-01-phase-1-communication-matrix...origin/main [ahead 2]
-```
-
-No staged or unstaged changes outside the implementation.
+| `scripts/check_fixed_worktrees.py` | Added | Fixed worktree audit |
+| `scripts/check_dispatch_binding.py` | Added | Dispatch binding validator |
+| `scripts/check_reset_ack.py` | Added | Reset acknowledgement gate |
+| `scripts/check_active_run.py` | Added | Active run evidence gate |
+| `scripts/pm_dispatch.py` | Added | Orchestration dispatch gate |
+| `tests/test_check_fixed_worktrees.py` | Added | Tests for worktree audit |
+| `tests/test_check_dispatch_binding.py` | Added | Tests for dispatch binding |
+| `tests/test_check_reset_ack.py` | Added | Tests for reset ack gate |
+| `tests/test_check_active_run.py` | Added | Tests for active run evidence |
+| `tests/test_pm_dispatch.py` | Added | Tests for dispatch orchestration |
+| `HANDOFF.md` | Added | This handoff packet |
+| `.elis/pe/PE-OPS-WORKTREE-BINDING-02/evidence/ELIS_ADVISOR_HANDOFF_elis-server_2026-05-09.md` | Added | Advisor handoff evidence (reference only) |
 
 ---
 
-## Git Status
+## Acceptance Criteria
 
-```text
-## feature/pe-ops-a2a-01-phase-1-communication-matrix...origin/main [ahead 2]
+| AC | Description | Status |
+|----|-------------|--------|
+| AC-1 | `check_fixed_worktrees.py` audits all fixed canonical worktrees and rejects PE-specific runtime paths | Implemented |
+| AC-2 | `check_dispatch_binding.py` validates dispatch targets against fixed worktree binding | Implemented |
+| AC-3 | `check_reset_ack.py` enforces NO_RESET_ACK_NO_DISPATCH with field validation | Implemented |
+| AC-4 | `check_active_run.py` enforces NO_ACTIVE_RUN_EVIDENCE_NO_IN_PROGRESS_STATUS | Implemented |
+| AC-5 | `pm_dispatch.py` orchestrates all four gates plus HANDOFF/evidence check for validator dispatch | Implemented |
+| AC-6 | Tests exist for each script covering pass, fail, and edge cases | Implemented |
+| AC-7 | Runtime/bootstrap files (`.openclaw`, `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `USER.md`, `HEARTBEAT.md`) preserved | Implemented |
+| AC-8 | No PE-specific runtime worktrees created; only fixed canonical worktrees used | Verified |
+| AC-9 | No GitHub/config/secret/service changes | Verified |
+
+---
+
+## Validation Commands
+
+```bash
+# Run specific gate scripts
+python scripts/check_fixed_worktrees.py --worktrees /opt/elis/agent-worktrees/infra-impl-b
+python scripts/check_dispatch_binding.py --agent infra-impl-b
+python scripts/check_reset_ack.py --pe-id PE-OPS-WORKTREE-BINDING-02 --agent infra-impl-b
+python scripts/check_active_run.py --pe-id PE-OPS-WORKTREE-BINDING-02 --agent infra-impl-b
+
+# Run full dispatch gate orchestration (dry-run mode)
+python scripts/pm_dispatch.py \
+  --pe-id PE-OPS-WORKTREE-BINDING-02 \
+  --agent infra-impl-b \
+  --role implementer \
+  --dry-run
+
+# Run tests for all gate scripts
+python -m pytest tests/test_check_fixed_worktrees.py tests/test_check_dispatch_binding.py \
+    tests/test_check_reset_ack.py tests/test_check_active_run.py tests/test_pm_dispatch.py -v
+
+# Quick test of a single gate
+python -m pytest tests/test_check_reset_ack.py::test_validate_valid_ack_data -v
 ```
 
 ---
 
-## Scope Diff (commit stats)
+## Test Results
 
-```text
- .elis/pe/PE-OPS-A2A-01/PE_TASK.md                     |  51 ++++
- CURRENT_PE.md                                          |  13 +-
- docs/governance/ELIS_A2A_Communication_Matrix.md       | 275 ++++++++++++++++++
- docs/openclaw/ELIS_A2A_GATEWAY_SPEC.md                 | 356 +++++++++++++++++++++++++++
- schemas/a2a_envelope.schema.json                       |  84 ++++++
- 5 files changed, 774 insertions(+), 5 deletions(-)
-```
+Run the validation commands above to verify all gates pass before proceeding to PR.
 
 ---
 
-## Local-Only Binding Confirmation
+## Reset Acknowledgement
 
-| Property | Value |
-|----------|-------|
-| Gateway address | `127.0.0.1` |
-| Gateway port | `24001` |
-| Binding type | Loopback only |
-| TLS | Not required (local-only) |
-| External interfaces | **Refused** on startup per specification |
-| Config dependency | None (no openclaw.json or Hermes config changes) |
-
-**Result: PASS** — Gateway is specified for local-only operation on `127.0.0.1:24001`.
-
----
-
-## Exposed Agents Confirmation
-
-| Agent | Canonical ID | Exposed in Phase 1? |
-|-------|-------------|---------------------|
-| ELIS Advisor | `elis-advisor` | **Yes** |
-| ELIS PM | `elis-pm` | **Yes** |
-| ELIS Supervisor | `elis-supervisor` | **Yes** |
-| All implementer agents (9) | `*-impl-*` | **No** |
-| All validator agents (9) | `*-val-*` | **No** |
-| GitHub Agent | — | **No** |
-| Full OpenClaw agent inventory (18+) | — | **No** |
-
-**Result: PASS** — Only the 3 approved Phase-1 agents are exposed.
+| Field | Value |
+|-------|-------|
+| agent | infra-impl-b |
+| pe | PE-OPS-WORKTREE-BINDING-02 |
+| worktree | /opt/elis/agent-worktrees/infra-impl-b |
+| branch | feature/pe-ops-worktree-binding-02-enforce-fixed-worktree-dispatch-gates |
+| head | e5d3afc733ef7e4a3dc429cff63aa0f583100ccf |
+| timestamp | 2026-05-09T22:10:00+01:00 |
+| prior_context_discarded | yes |
+| write_scope | yes — only within the authorised fixed worktree |
 
 ---
 
-## Hard Prohibitions Confirmed
+## Active Run Evidence
 
-| Prohibition | Status | Evidence |
-|-------------|--------|----------|
-| No implementation through A2A | **PASS** | No implementer agents exposed. No payload type for implementation commands. Section 9 of Communication Matrix explicitly lists this prohibition. |
-| No official validation through A2A | **PASS** | `advisory_review` is explicitly advisory-only. No validation verdict mechanism. Section 6.3 specifies "Advisory only — not an official validation verdict." |
-| No GitHub writes | **PASS** | A2A gateway spec includes prohibited content scanning for git/gh operations (Section 5.3). No PR/merge/commit operations in protocol. |
-| No restarts | **PASS** | Gateway spec is specification-only. No service restart commands in A2A protocol. Section 8.1 prohibits non-loopback binding and does not define restart commands. |
-| No config edits | **PASS** | No openclaw.json, Hermes config, or system config files modified. Config edits are a prohibited content pattern (Section 5.3). |
-| No secret/token changes | **PASS** | No secrets files touched. Secret operations are a prohibited content pattern (Section 5.3). |
-| No PRs/merges | **PASS** | No PR/merge operations in A2A protocol. GitHub write operations are prohibited (Section 9). |
-| No PO approvals | **PASS** | No PO approval mechanism defined in A2A protocol. No payload type for approvals. |
-
-**Result: PASS** — All 8 hard prohibitions are explicitly stated and enforced.
-
----
-
-## Delivery Summary
-
-Built a minimal, local-only A2A communication prototype consisting of:
-
-1. **JSON Schema** (`schemas/a2a_envelope.schema.json`) — validates all A2A message envelopes with
-   identity, pair, message type, and payload constraints.
-
-2. **Communication Matrix** (`docs/governance/ELIS_A2A_Communication_Matrix.md`) — the governing
-   specification defining Phase-1 agent identities, allowed pairs, message types, payload schemas,
-   routing rules, local-only binding, and hard prohibitions.
-
-3. **Gateway Specification** (`docs/openclaw/ELIS_A2A_GATEWAY_SPEC.md`) — implementation-level
-   specification for the standalone A2A HTTP/WebSocket gateway including API endpoints, startup
-   behaviour, queue management, logging, error handling, and verification procedures.
-
-The prototype:
-- Uses UK English throughout
-- Exposes only 3 agents (Advisor, PM, Supervisor) from the full inventory of 20+
-- Allows only 3 communication pairs
-- Binds to `127.0.0.1:24001` only
-- Supports 7 message types: structured_message, evidence_request, advisory_review,
-  diagnostic_query, diagnostic_response, acknowledgement, error
-- Explicitly prohibits implementation, validation, GitHub writes, restarts, config edits,
-  secret changes, PRs, merges, and PO approvals
-- Makes no changes to OpenClaw config, Hermes config, or any live infrastructure
-
----
-
-## Next Steps
-
-1. Open PR from `feature/pe-ops-a2a-01-phase-1-communication-matrix` to `main`
-2. Await validator review and Gate 2 approval
-3. After PR merge, the A2A specification is ready for Phase-2 gateway implementation
+| Field | Value |
+|-------|-------|
+| session_id | agent:infra-impl-b:subagent:a6f8d79c-cde9-4ac8-aeab-980ec96aaba1 |
+| agent | infra-impl-b |
+| pe | PE-OPS-WORKTREE-BINDING-02 |
+| worktree | /opt/elis/agent-worktrees/infra-impl-b |
+| branch | feature/pe-ops-worktree-binding-02-enforce-fixed-worktree-dispatch-gates |
+| status | running |
+| timestamp | 2026-05-09T22:15:00Z |

--- a/scripts/check_active_run.py
+++ b/scripts/check_active_run.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import sys
 from pathlib import Path
@@ -190,7 +189,9 @@ def main() -> int:
     valid_statuses = {"running", "completed", "in_progress"}
     if status and str(status).strip().lower() not in valid_statuses:
         if str(status).strip().lower() == "failed":
-            print("INFO: Last known status is FAILED — review required before re-dispatch.")
+            print(
+                "INFO: Last known status is FAILED — review required before re-dispatch."
+            )
         elif str(status).strip().lower() == "stalled":
             print("INFO: Last known status is STALLED — may need restart.")
 
@@ -199,12 +200,12 @@ def main() -> int:
         issues.append("Missing activity timestamp.")
 
     if issues:
-        print(f"Active run evidence INVALID:")
+        print("Active run evidence INVALID:")
         for issue in issues:
             print(f"  FAIL: {issue}")
         return 2
 
-    print(f"Active run evidence VALID.")
+    print("Active run evidence VALID.")
     print(f"  Session: {session_id}")
     print(f"  Agent: {actual_agent}")
     print(f"  PE: {actual_pe}")

--- a/scripts/check_active_run.py
+++ b/scripts/check_active_run.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""check_active_run.py — enforce active-run evidence before status reports.
+
+The NO_ACTIVE_RUN_EVIDENCE_NO_IN_PROGRESS_STATUS rule:
+PM must not claim an agent is working (status 'implementing' or 'validating')
+unless there is active run/session evidence.
+
+Required evidence:
+  - active run/session id
+  - correct agent
+  - correct PE
+  - correct worktree
+  - correct branch
+  - last activity timestamp
+  - status: running/completed/failed/stalled
+
+If no active run evidence is present, status must be one of:
+  NOT_STARTED, STALLED, FAILED, INCONCLUSIVE
+
+Source of truth resolution order:
+  1. EVIDENCE_PATH env var — explicit evidence file
+  2. .elis/pe/<PE_ID>/evidence/active_run_<agent_id>.md
+  3. HANDOFF.md — "Active Run Evidence" section
+
+Usage:
+  python scripts/check_active_run.py --pe-id PE-OPS-WORKTREE-BINDING-02 --agent infra-impl-b
+
+Exit codes:
+  0 — active run evidence found, plausible
+  1 — no active run evidence
+  2 — evidence found but invalid (wrong agent/PE/branch)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def _find_evidence_file(pe_id: str, agent_id: str) -> Path | None:
+    """Look for active run evidence file in PE evidence directory."""
+    evidence_dir = Path(f".elis/pe/{pe_id}/evidence")
+    if evidence_dir.is_dir():
+        for f in evidence_dir.iterdir():
+            if f.is_file() and "active_run" in f.name and agent_id in f.name:
+                return f
+    return None
+
+
+def _check_handoff_for_evidence(pe_id: str, agent_id: str) -> dict | None:
+    """Look for Active Run Evidence section in HANDOFF.md."""
+    handoff_path = Path("HANDOFF.md")
+    if not handoff_path.exists():
+        return None
+
+    content = handoff_path.read_text(encoding="utf-8")
+    patterns = [
+        r"##\s+Active Run Evidence.*?(?=##|\Z)",
+        r"##\s+Active.*Run.*Evidence.*?(?=##|\Z)",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, content, re.DOTALL)
+        if match:
+            section_text = match.group(0)
+            return _parse_evidence_section(section_text)
+    return None
+
+
+def _parse_evidence_section(section_text: str) -> dict | None:
+    """Parse table-like or field-like content from an evidence section."""
+    data: dict[str, str] = {}
+    table_matches = re.findall(r"\|\s*([^|]+)\s*\|\s*([^|]+)\s*\|", section_text)
+    for key, value in table_matches:
+        data[key.strip().lower()] = value.strip()
+    kv_matches = re.findall(
+        r"^\s*[-*]?\s*(.+?)\s*:\s*(.+)$", section_text, re.MULTILINE
+    )
+    for key, value in kv_matches:
+        data[key.strip().lower()] = value.strip()
+    return data if data else None
+
+
+def _parse_json_or_md_file(path: Path) -> dict | None:
+    """Parse a JSON or markdown evidence file."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        pass
+
+    content = path.read_text(encoding="utf-8")
+    return _parse_evidence_section(content)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check active run evidence before allowing in-progress status."
+    )
+    parser.add_argument(
+        "--pe-id",
+        required=True,
+        help="PE ID (e.g. PE-OPS-WORKTREE-BINDING-02).",
+    )
+    parser.add_argument(
+        "--agent",
+        required=True,
+        help="Agent ID (e.g. infra-impl-b).",
+    )
+    parser.add_argument(
+        "--evidence-path",
+        default=None,
+        help="Explicit path to active run evidence file.",
+    )
+    args = parser.parse_args()
+
+    pe_id = args.pe_id
+    agent_id = args.agent
+
+    print(f"Checking active run evidence for {agent_id} / {pe_id}...")
+    print()
+
+    evidence_data: dict | None = None
+    source: str = ""
+
+    # Resolution order
+    if args.evidence_path:
+        ep = Path(args.evidence_path)
+        if ep.exists():
+            evidence_data = _parse_json_or_md_file(ep)
+            source = str(ep)
+        else:
+            print(f"FAIL: Evidence path not found: {args.evidence_path}")
+            return 1
+
+    if evidence_data is None:
+        evidence_file = _find_evidence_file(pe_id, agent_id)
+        if evidence_file:
+            evidence_data = _parse_json_or_md_file(evidence_file)
+            source = str(evidence_file)
+
+    if evidence_data is None:
+        evidence_data = _check_handoff_for_evidence(pe_id, agent_id)
+        if evidence_data:
+            source = "HANDOFF.md"
+
+    if evidence_data is None:
+        print("FAIL: No active run evidence found.")
+        print()
+        print("Checked locations:")
+        if args.evidence_path:
+            print(f"  - {args.evidence_path}")
+        print(f"  - .elis/pe/{pe_id}/evidence/active_run_{agent_id}.*")
+        print("  - HANDOFF.md")
+        print()
+        print(
+            "NO_ACTIVE_RUN_EVIDENCE_NO_IN_PROGRESS_STATUS gate: "
+            "Cannot claim in-progress status. "
+            "Status must be one of: NOT_STARTED, STALLED, FAILED, INCONCLUSIVE."
+        )
+        return 1
+
+    print(f"Source: {source}")
+    print()
+
+    # Validate
+    issues: list[str] = []
+
+    session_id = evidence_data.get("session_id", evidence_data.get("run_id", ""))
+    if not session_id or str(session_id).strip() in ("", "null", "None"):
+        issues.append("Missing active run/session ID.")
+
+    actual_agent = evidence_data.get("agent", evidence_data.get("agent_id", ""))
+    if actual_agent and str(actual_agent).strip().lower() != agent_id.lower():
+        issues.append(
+            f"Agent mismatch: evidence is for '{actual_agent}', "
+            f"expected '{agent_id}'."
+        )
+
+    actual_pe = evidence_data.get("pe", evidence_data.get("pe_id", ""))
+    if actual_pe and str(actual_pe).strip() != pe_id:
+        issues.append(
+            f"PE mismatch: evidence is for '{actual_pe}', expected '{pe_id}'."
+        )
+
+    status = evidence_data.get("status", "")
+    valid_statuses = {"running", "completed", "in_progress"}
+    if status and str(status).strip().lower() not in valid_statuses:
+        if str(status).strip().lower() == "failed":
+            print("INFO: Last known status is FAILED — review required before re-dispatch.")
+        elif str(status).strip().lower() == "stalled":
+            print("INFO: Last known status is STALLED — may need restart.")
+
+    timestamp = evidence_data.get("timestamp", evidence_data.get("last_activity", ""))
+    if not timestamp or str(timestamp).strip() in ("", "null", "None"):
+        issues.append("Missing activity timestamp.")
+
+    if issues:
+        print(f"Active run evidence INVALID:")
+        for issue in issues:
+            print(f"  FAIL: {issue}")
+        return 2
+
+    print(f"Active run evidence VALID.")
+    print(f"  Session: {session_id}")
+    print(f"  Agent: {actual_agent}")
+    print(f"  PE: {actual_pe}")
+    print(f"  Status: {status or '(not reported)'}")
+    print(f"  Timestamp: {timestamp or '(not reported)'}")
+    print()
+    print(
+        "NO_ACTIVE_RUN_EVIDENCE_NO_IN_PROGRESS_STATUS gate: "
+        "PASS — in-progress status allowed."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_dispatch_binding.py
+++ b/scripts/check_dispatch_binding.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""check_dispatch_binding.py — verify dispatch binding before dispatch.
+
+Ensures:
+  1. The target worktree is a fixed canonical worktree (not PE-specific).
+  2. The target agent matches the assigned PE implementer/validator.
+  3. The worktree branch matches the active PE branch.
+  4. The worktree is clean (no tracked pending changes) — preserving
+     runtime/bootstrap files.
+
+Usage:
+  python scripts/check_dispatch_binding.py --agent infra-impl-b
+
+Exit codes:
+  0 — binding valid for dispatch
+  1 — binding invalid
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CANONICAL_REPO = "/opt/elis/repo"
+AGENT_WORKTREE_PREFIX = "/opt/elis/agent-worktrees"
+
+# Mapping from agent id to expected fixed worktree path.
+AGENT_WORKTREE_MAP: dict[str, str] = {
+    "pm": f"{AGENT_WORKTREE_PREFIX}/pm",
+    "infra-impl-a": f"{AGENT_WORKTREE_PREFIX}/infra-impl-a",
+    "infra-impl-b": f"{AGENT_WORKTREE_PREFIX}/infra-impl-b",
+    "infra-val-a": f"{AGENT_WORKTREE_PREFIX}/infra-val-a",
+    "infra-val-b": f"{AGENT_WORKTREE_PREFIX}/infra-val-b",
+    "github-agent": f"{AGENT_WORKTREE_PREFIX}/github-agent",
+    "infra-impl-codex": f"{AGENT_WORKTREE_PREFIX}/infra-impl-a",
+    "infra-val-codex": f"{AGENT_WORKTREE_PREFIX}/infra-val-b",
+    "infra-impl-claude": f"{AGENT_WORKTREE_PREFIX}/infra-impl-b",
+    "infra-val-claude": f"{AGENT_WORKTREE_PREFIX}/infra-val-a",
+}
+
+PRESERVED_FILES = {
+    ".openclaw",
+    "AGENTS.md",
+    "SOUL.md",
+    "TOOLS.md",
+    "USER.md",
+    "HEARTBEAT.md",
+    "IDENTITY.md",
+}
+
+
+def _git_cmd(*args: str, cwd: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git"] + list(args),
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        timeout=30,
+    )
+
+
+def _is_pe_specific_runtime(path: str) -> bool:
+    return bool(re.match(r"/opt/elis/agent-worktrees/PE-.+-infra-.+", path))
+
+
+def _is_untracked_or_dirty(filename: str) -> tuple[bool, list[str]]:
+    """Check if a filename matches protected/preserved patterns."""
+    parts = Path(filename).parts
+    issues: list[str] = []
+    for part in parts:
+        if part in PRESERVED_FILES:
+            return True, issues
+    return False, issues
+
+
+def _check_worktree_cleanliness(worktree_path: str) -> list[str]:
+    """Check if tracked files are clean (preserving runtime files). Return failures."""
+    failures: list[str] = []
+    result = _git_cmd("status", "--porcelain", cwd=worktree_path)
+    if result.returncode != 0:
+        failures.append(f"FAIL: Cannot check status in {worktree_path}")
+        return failures
+
+    dirty_files: list[str] = []
+    for line in result.stdout.strip().split("\n"):
+        if not line.strip():
+            continue
+        xy = line[:2].strip()
+        filename = line[3:].strip()
+        if xy.startswith("?"):
+            protected, _ = _is_untracked_or_dirty(filename)
+            if protected:
+                continue
+            dirty_files.append(f"  untracked: {filename}")
+        else:
+            protected, _ = _is_untracked_or_dirty(filename)
+            if protected:
+                continue
+            dirty_files.append(f"  {xy}: {filename}")
+
+    if dirty_files:
+        failures.append("UNTRACKED OR MODIFIED TRACKED FILES:")
+        failures.extend(dirty_files)
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check dispatch binding validity."
+    )
+    parser.add_argument(
+        "--agent",
+        required=True,
+        help="Agent ID to check (e.g. infra-impl-b, infra-val-a).",
+    )
+    parser.add_argument(
+        "--pe-branch",
+        default=None,
+        help="Expected PE branch for validation (auto-resolved from CURRENT_PE.md).",
+    )
+    parser.add_argument(
+        "--worktree",
+        default=None,
+        help="Override worktree path (default: resolved from agent ID).",
+    )
+    args = parser.parse_args()
+
+    agent_id = args.agent
+
+    # Resolve expected worktree path
+    worktree_path = args.worktree or AGENT_WORKTREE_MAP.get(agent_id)
+    if not worktree_path:
+        print(f"FAIL: Unknown agent ID '{agent_id}'. "
+              f"Known: {', '.join(sorted(AGENT_WORKTREE_MAP.keys()))}")
+        return 1
+
+    resolved_path = Path(worktree_path).resolve().as_posix()
+    print(f"Agent: {agent_id}")
+    print(f"Expected worktree: {resolved_path}")
+    print()
+
+    failures: list[str] = []
+
+    # Gate 1: Must be a fixed canonical worktree, not PE-specific
+    if _is_pe_specific_runtime(resolved_path):
+        failures.append(
+            f"PE-SPECIFIC RUNTIME REJECTED: {resolved_path} is not a "
+            f"fixed canonical worktree."
+        )
+
+    # Gate 2: Must exist
+    if not Path(resolved_path).is_dir():
+        failures.append(
+            f"WORKTREE NOT FOUND: {resolved_path} does not exist."
+        )
+        print("FAIL: ", "\n".join(failures))
+        return 1
+
+    # Gate 3: Must have origin
+    origin_result = _git_cmd("remote", "get-url", "origin", cwd=resolved_path)
+    if origin_result.returncode != 0:
+        failures.append(
+            f"NO ORIGIN: {resolved_path} has no origin remote. "
+            f"Standalone/broken repository."
+        )
+    else:
+        print(f"Origin: {origin_result.stdout.strip()}")
+
+    # Gate 4: Branch check
+    branch_result = _git_cmd("branch", "--show-current", cwd=resolved_path)
+    current_branch = (
+        branch_result.stdout.strip()
+        if branch_result.returncode == 0
+        else ""
+    )
+
+    # Resolve expected branch from CURRENT_PE.md if not provided
+    expected_branch = args.pe_branch
+    if not expected_branch:
+        current_pe_path = Path("CURRENT_PE.md")
+        if current_pe_path.exists():
+            content = current_pe_path.read_text(encoding="utf-8")
+            m = re.search(
+                r"^\|\s*Branch\s*\|\s*([^\|]+)\s*\|",
+                content,
+                re.MULTILINE,
+            )
+            if m:
+                expected_branch = m.group(1).strip()
+                print(f"Expected branch (from CURRENT_PE.md): {expected_branch}")
+            else:
+                print("WARN: Could not parse branch from CURRENT_PE.md — "
+                      "branch check skipped.")
+        else:
+            print("WARN: CURRENT_PE.md not found — branch check skipped.")
+    else:
+        print(f"Expected branch (from --pe-branch): {expected_branch}")
+
+    if expected_branch and current_branch:
+        if current_branch != expected_branch:
+            failures.append(
+                f"BRANCH MISMATCH: worktree is on '{current_branch}', "
+                f"expected '{expected_branch}'."
+            )
+        else:
+            print(f"Branch match: {current_branch}")
+    elif expected_branch and not current_branch:
+        print(f"WARN: Worktree is detached — no active branch.")
+
+    # Gate 5: HEAD
+    head_result = _git_cmd("rev-parse", "HEAD", cwd=resolved_path)
+    if head_result.returncode == 0:
+        head = head_result.stdout.strip()
+        print(f"HEAD: {head[:12]}(...)")
+        if current_branch:
+            # Check if HEAD matches branch tip
+            rev_parse_result = _git_cmd(
+                "rev-parse", f"refs/heads/{current_branch}", cwd=resolved_path
+            )
+            if rev_parse_result.returncode == 0:
+                branch_tip = rev_parse_result.stdout.strip()
+                if head != branch_tip:
+                    print(f"WARN: HEAD ({head[:12]}) != branch tip "
+                          f"({branch_tip[:12]}) — branch may be outdated.")
+
+    # Gate 6: Cleanliness
+    cleanliness = _check_worktree_cleanliness(resolved_path)
+    if cleanliness:
+        failures.extend(cleanliness)
+
+    # Gate 7: Ensure worktree is registered under canonical repo
+    reg_result = _git_cmd("worktree", "list", cwd=CANONICAL_REPO)
+    if reg_result.returncode == 0:
+        if resolved_path not in reg_result.stdout:
+            failures.append(
+                f"NOT REGISTERED: {resolved_path} is not a registered worktree "
+                f"of {CANONICAL_REPO}."
+            )
+
+    print()
+    if failures:
+        print("DISPATCH BINDING FAILED:")
+        for f in failures:
+            print(f"  FAIL: {f}")
+        return 1
+    else:
+        print("DISPATCH BINDING VALID — ready for dispatch.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_dispatch_binding.py
+++ b/scripts/check_dispatch_binding.py
@@ -19,7 +19,6 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import os
 import re
 import subprocess
 import sys
@@ -110,9 +109,7 @@ def _check_worktree_cleanliness(worktree_path: str) -> list[str]:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Check dispatch binding validity."
-    )
+    parser = argparse.ArgumentParser(description="Check dispatch binding validity.")
     parser.add_argument(
         "--agent",
         required=True,
@@ -135,8 +132,10 @@ def main() -> int:
     # Resolve expected worktree path
     worktree_path = args.worktree or AGENT_WORKTREE_MAP.get(agent_id)
     if not worktree_path:
-        print(f"FAIL: Unknown agent ID '{agent_id}'. "
-              f"Known: {', '.join(sorted(AGENT_WORKTREE_MAP.keys()))}")
+        print(
+            f"FAIL: Unknown agent ID '{agent_id}'. "
+            f"Known: {', '.join(sorted(AGENT_WORKTREE_MAP.keys()))}"
+        )
         return 1
 
     resolved_path = Path(worktree_path).resolve().as_posix()
@@ -155,9 +154,7 @@ def main() -> int:
 
     # Gate 2: Must exist
     if not Path(resolved_path).is_dir():
-        failures.append(
-            f"WORKTREE NOT FOUND: {resolved_path} does not exist."
-        )
+        failures.append(f"WORKTREE NOT FOUND: {resolved_path} does not exist.")
         print("FAIL: ", "\n".join(failures))
         return 1
 
@@ -174,9 +171,7 @@ def main() -> int:
     # Gate 4: Branch check
     branch_result = _git_cmd("branch", "--show-current", cwd=resolved_path)
     current_branch = (
-        branch_result.stdout.strip()
-        if branch_result.returncode == 0
-        else ""
+        branch_result.stdout.strip() if branch_result.returncode == 0 else ""
     )
 
     # Resolve expected branch from CURRENT_PE.md if not provided
@@ -194,8 +189,10 @@ def main() -> int:
                 expected_branch = m.group(1).strip()
                 print(f"Expected branch (from CURRENT_PE.md): {expected_branch}")
             else:
-                print("WARN: Could not parse branch from CURRENT_PE.md — "
-                      "branch check skipped.")
+                print(
+                    "WARN: Could not parse branch from CURRENT_PE.md — "
+                    "branch check skipped."
+                )
         else:
             print("WARN: CURRENT_PE.md not found — branch check skipped.")
     else:
@@ -210,7 +207,7 @@ def main() -> int:
         else:
             print(f"Branch match: {current_branch}")
     elif expected_branch and not current_branch:
-        print(f"WARN: Worktree is detached — no active branch.")
+        print("WARN: Worktree is detached — no active branch.")
 
     # Gate 5: HEAD
     head_result = _git_cmd("rev-parse", "HEAD", cwd=resolved_path)
@@ -225,8 +222,10 @@ def main() -> int:
             if rev_parse_result.returncode == 0:
                 branch_tip = rev_parse_result.stdout.strip()
                 if head != branch_tip:
-                    print(f"WARN: HEAD ({head[:12]}) != branch tip "
-                          f"({branch_tip[:12]}) — branch may be outdated.")
+                    print(
+                        f"WARN: HEAD ({head[:12]}) != branch tip "
+                        f"({branch_tip[:12]}) — branch may be outdated."
+                    )
 
     # Gate 6: Cleanliness
     cleanliness = _check_worktree_cleanliness(resolved_path)

--- a/scripts/check_fixed_worktrees.py
+++ b/scripts/check_fixed_worktrees.py
@@ -148,9 +148,7 @@ def _check_worktree(
         head = head_result.stdout.strip()
         branch = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
         status = f"branch={branch or '(detached)'}" if branch else "branch=(detached)"
-        failures.append(
-            f"STATUS OK: {resolved} — HEAD={head[:12]}(...) {status}"
-        )
+        failures.append(f"STATUS OK: {resolved} — HEAD={head[:12]}(...) {status}")
 
     # Check 5: tracked file cleanliness (ignoring preserved runtime files)
     status_result = _git_cmd("status", "--porcelain", cwd=resolved)
@@ -245,10 +243,10 @@ def main() -> int:
                     print(f"  FAIL: {f}")
                     all_failures.append(f"  {f}")
             else:
-                print(f"  PASS")
+                print("  PASS")
                 all_pass.append(wt_path)
         else:
-            print(f"  PASS")
+            print("  PASS")
             all_pass.append(wt_path)
         print()
 

--- a/scripts/check_fixed_worktrees.py
+++ b/scripts/check_fixed_worktrees.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""check_fixed_worktrees.py — audit fixed canonical worktrees.
+
+Verifies each fixed agent worktree:
+  1. Is a Git worktree registered under /opt/elis/repo (via git worktree list).
+  2. Has origin pointing to the ELIS GitHub repository.
+  3. Has a valid branch, accessible HEAD, and clean tracked state.
+  4. Rejects PE-specific runtime worktrees matching /opt/elis/agent-worktrees/PE-*-infra-*.
+  5. Detects standalone/broken repos (no origin) like the old pm worktree.
+  6. Preserves runtime/bootstrap files — does not flag .openclaw, AGENTS.md,
+     SOUL.md, TOOLS.md, USER.md, HEARTBEAT.md as contamination.
+
+Required environment variables:
+  CANONICAL_REPO  — path to the canonical Git repository (default: /opt/elis/repo)
+  ELIS_GITHUB_REMOTE — expected origin URL (default: https://github.com/rochasamurai/ELIS-Multi-AI-Agent-Platform.git)
+
+Usage:
+  python scripts/check_fixed_worktrees.py [--worktrees PM INFRA_IMPL_A INFRA_IMPL_B INFRA_VAL_A INFRA_VAL_B GITHUB_AGENT]
+
+Exit codes:
+  0 — all worktrees pass
+  1 — one or more failures
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CANONICAL_REPO_DEFAULT = "/opt/elis/repo"
+ELIS_GITHUB_REMOTE_DEFAULT = (
+    "https://github.com/rochasamurai/ELIS-Multi-AI-Agent-Platform.git"
+)
+
+# Runtime/bootstrap files that must be preserved, not flagged.
+PRESERVED_FILES = {
+    ".openclaw",
+    "AGENTS.md",
+    "SOUL.md",
+    "TOOLS.md",
+    "USER.md",
+    "HEARTBEAT.md",
+    "IDENTITY.md",
+}
+
+# Fixed canonical worktrees for agent roles.
+DEFAULT_FIXED_WORKTREES = [
+    "/opt/elis/agent-worktrees/pm",
+    "/opt/elis/agent-worktrees/infra-impl-a",
+    "/opt/elis/agent-worktrees/infra-impl-b",
+    "/opt/elis/agent-worktrees/infra-val-a",
+    "/opt/elis/agent-worktrees/infra-val-b",
+    "/opt/elis/agent-worktrees/github-agent",
+]
+
+
+def _git_cmd(*args: str, cwd: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git"] + list(args),
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        timeout=30,
+    )
+
+
+def _get_registered_worktrees(canonical_repo: str) -> list[dict]:
+    """Return list of worktree dicts registered under canonical_repo."""
+    result = _git_cmd("worktree", "list", cwd=canonical_repo)
+    if result.returncode != 0:
+        print(f"FAIL: Cannot list worktrees in {canonical_repo}: {result.stderr}")
+        sys.exit(1)
+
+    worktrees = []
+    for line in result.stdout.strip().split("\n"):
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        path = Path(parts[0]).resolve().as_posix()
+        head = parts[1]
+        branch_raw = " ".join(parts[2:]) if len(parts) > 2 else "(detached HEAD)"
+        branch = branch_raw.strip("[]")
+        worktrees.append({"path": path, "head": head, "branch": branch})
+
+    return worktrees
+
+
+def _is_pe_specific_runtime(path: str) -> bool:
+    """Return True if path matches a PE-specific runtime worktree pattern."""
+    return bool(re.match(r"/opt/elis/agent-worktrees/PE-.+-infra-.+", path))
+
+
+def _check_worktree(
+    path: str,
+    registered_paths: set[str],
+    expected_origin: str,
+) -> list[str]:
+    """Check a single worktree path. Return list of failure messages."""
+    failures: list[str] = []
+
+    # Check 0: path exists
+    p = Path(path)
+    if not p.is_dir():
+        failures.append(f"Worktree path does not exist: {path}")
+        return failures
+
+    resolved = p.resolve().as_posix()
+
+    # Check 1: registered under canonical repo
+    if resolved not in registered_paths:
+        failures.append(
+            f"NOT REGISTERED: {resolved} is not a registered worktree of "
+            f"{CANONICAL_REPO_DEFAULT}. It may be a standalone/broken repo."
+        )
+
+    # Check 2: reject PE-specific runtime worktrees
+    if _is_pe_specific_runtime(resolved):
+        failures.append(
+            f"PE-SPECIFIC RUNTIME REJECTED: {resolved} matches "
+            f"PE-*-infra-* pattern. Use fixed canonical worktrees only."
+        )
+
+    # Check 3: has origin remote
+    result = _git_cmd("remote", "get-url", "origin", cwd=resolved)
+    if result.returncode != 0:
+        failures.append(
+            f"NO ORIGIN: {resolved} has no 'origin' remote. "
+            f"This is a standalone/broken Git repo."
+        )
+    else:
+        actual_origin = result.stdout.strip()
+        if actual_origin != expected_origin:
+            failures.append(
+                f"WRONG ORIGIN: {resolved} origin is '{actual_origin}', "
+                f"expected '{expected_origin}'."
+            )
+
+    # Check 4: can get a branch/HEAD
+    branch_result = _git_cmd("branch", "--show-current", cwd=resolved)
+    head_result = _git_cmd("rev-parse", "HEAD", cwd=resolved)
+    if head_result.returncode != 0:
+        failures.append(f"BROKEN HEAD: {resolved} cannot resolve HEAD.")
+    else:
+        head = head_result.stdout.strip()
+        branch = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
+        status = f"branch={branch or '(detached)'}" if branch else "branch=(detached)"
+        failures.append(
+            f"STATUS OK: {resolved} — HEAD={head[:12]}(...) {status}"
+        )
+
+    # Check 5: tracked file cleanliness (ignoring preserved runtime files)
+    status_result = _git_cmd("status", "--porcelain", cwd=resolved)
+    if status_result.returncode == 0:
+        dirty_tracked = []
+        for line in status_result.stdout.strip().split("\n"):
+            if not line.strip():
+                continue
+            # Porcelain format: XY filename
+            xy = line[:2].strip()
+            filename = line[3:].strip()
+            # Ignore untracked (? prefixed) and preserved files
+            if xy.startswith("?"):
+                basename = os.path.basename(filename)
+                if basename in PRESERVED_FILES:
+                    continue
+                # Check if it's a path containing preserved files
+                parts = Path(filename).parts
+                if any(part in PRESERVED_FILES for part in parts):
+                    continue
+                dirty_tracked.append(f"  untracked: {filename}")
+            elif xy != "  ":
+                basename = os.path.basename(filename)
+                if basename in PRESERVED_FILES:
+                    continue
+                parts = Path(filename).parts
+                if any(part in PRESERVED_FILES for part in parts):
+                    continue
+                dirty_tracked.append(f"  {xy}: {filename}")
+
+        if dirty_tracked:
+            failures.append("UNTRACKED OR MODIFIED FILES:")
+            failures.extend(dirty_tracked)
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit fixed canonical worktrees for ELIS dispatch gating."
+    )
+    parser.add_argument(
+        "--worktrees",
+        nargs="*",
+        default=DEFAULT_FIXED_WORKTREES,
+        help="Fixed worktree paths to audit (default: all agent worktrees).",
+    )
+    parser.add_argument(
+        "--canonical-repo",
+        default=os.environ.get("CANONICAL_REPO", CANONICAL_REPO_DEFAULT),
+        help="Canonical Git repository path.",
+    )
+    parser.add_argument(
+        "--expected-origin",
+        default=os.environ.get("ELIS_GITHUB_REMOTE", ELIS_GITHUB_REMOTE_DEFAULT),
+        help="Expected origin URL for worktrees.",
+    )
+    args = parser.parse_args()
+
+    canonical_repo = args.canonical_repo
+    expected_origin = args.expected_origin
+
+    # Ensure canonical_repo exists
+    if not Path(canonical_repo).is_dir():
+        print(f"FAIL: Canonical repo not found: {canonical_repo}")
+        return 1
+
+    # Get registered worktree paths
+    registered = _get_registered_worktrees(canonical_repo)
+    registered_paths = {w["path"] for w in registered}
+
+    all_failures: list[str] = []
+    all_pass: list[str] = []
+
+    print(f"Auditing fixed worktrees against canonical repo: {canonical_repo}")
+    print(f"Expected remote: {expected_origin}")
+    print()
+
+    for wt_path in args.worktrees:
+        print(f"--- Checking: {wt_path} ---")
+        failures = _check_worktree(wt_path, registered_paths, expected_origin)
+        if failures:
+            # Separate informational STATUS lines from actual failures
+            status_lines = [f for f in failures if f.startswith("STATUS OK:")]
+            actual_failures = [f for f in failures if not f.startswith("STATUS OK:")]
+            if status_lines:
+                for line in status_lines:
+                    print(f"  {line}")
+            if actual_failures:
+                all_failures.append(f"FAILURES for {wt_path}:")
+                for f in actual_failures:
+                    print(f"  FAIL: {f}")
+                    all_failures.append(f"  {f}")
+            else:
+                print(f"  PASS")
+                all_pass.append(wt_path)
+        else:
+            print(f"  PASS")
+            all_pass.append(wt_path)
+        print()
+
+    # Summary
+    print("=" * 60)
+    print(f"Worktrees audited: {len(args.worktrees)}")
+    print(f"Passed: {len(all_pass)}")
+    print(f"Failed: {len(all_failures)}")
+
+    if all_pass:
+        for p in all_pass:
+            print(f"  PASS  {p}")
+    if all_failures:
+        for f in all_failures:
+            print(f"  FAIL  {f}")
+
+    return 0 if not all_failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_reset_ack.py
+++ b/scripts/check_reset_ack.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import sys
 from pathlib import Path
@@ -58,7 +57,7 @@ def _check_handoff_for_ack(pe_id: str, agent_id: str) -> dict | None:
 
     # Search for acknowledgement sections. Accept flexible header patterns.
     patterns = [
-        rf"##\s+Reset Acknowledgement.*?(?=##|\Z)",
+        r"##\s+Reset Acknowledgement.*?(?=##|\Z)",
         rf"##\s+{re.escape(agent_id)}\s+Reset Acknowledgement.*?(?=##|\Z)",
     ]
 
@@ -81,7 +80,9 @@ def _parse_ack_section(section_text: str, agent_id: str) -> dict | None:
         data[key.strip().lower()] = value.strip()
 
     # Match key: value pairs (inline, not in a table)
-    kv_matches = re.findall(r"^\s*[-*]?\s*(.+?)\s*:\s*(.+)$", section_text, re.MULTILINE)
+    kv_matches = re.findall(
+        r"^\s*[-*]?\s*(.+?)\s*:\s*(.+)$", section_text, re.MULTILINE
+    )
     for key, value in kv_matches:
         data[key.strip().lower()] = value.strip()
 
@@ -118,9 +119,7 @@ def _validate_ack_data(data: dict, agent_id: str) -> tuple[bool, list[str]]:
             missing_fields.append(field_label)
 
     if missing_fields:
-        issues.append(
-            f"Missing required fields: {', '.join(missing_fields)}"
-        )
+        issues.append(f"Missing required fields: {', '.join(missing_fields)}")
 
     # Verify agent identity
     actual_agent = str(data.get("agent", ""))
@@ -132,16 +131,16 @@ def _validate_ack_data(data: dict, agent_id: str) -> tuple[bool, list[str]]:
     # Verify discard confirmation
     discard_confirmed = data.get("prior_context_discarded", data.get("discard", ""))
     if str(discard_confirmed).strip().lower() not in ("yes", "true", "confirmed"):
-        issues.append(
-            "Prior runtime context discard not confirmed."
-        )
+        issues.append("Prior runtime context discard not confirmed.")
 
     # Verify write scope
     write_scope = data.get("write_scope", data.get("write_scope_confirmed", ""))
-    if not write_scope or str(write_scope).strip().lower() not in ("yes", "true", "confirmed"):
-        issues.append(
-            "Write scope within authorised worktree not confirmed."
-        )
+    if not write_scope or str(write_scope).strip().lower() not in (
+        "yes",
+        "true",
+        "confirmed",
+    ):
+        issues.append("Write scope within authorised worktree not confirmed.")
 
     return len(issues) == 0, issues
 

--- a/scripts/check_reset_ack.py
+++ b/scripts/check_reset_ack.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""check_reset_ack.py — enforce reset/binding acknowledgement before dispatch.
+
+The NO_RESET_ACK_NO_DISPATCH rule: no agent may be dispatched unless it has
+returned a complete reset/binding acknowledgement.
+
+Required acknowledgement fields:
+  - agent identity
+  - PE ID
+  - target worktree/path
+  - branch
+  - starting HEAD
+  - timestamp
+  - channel/thread binding (if applicable)
+  - confirmation prior runtime context was discarded
+  - confirmation it will write only within authorised worktree/scope
+
+The acknowledgement is sought from:
+  1. EVIDENCE_PATH env var — explicit evidence file
+  2. .elis/pe/<PE_ID>/evidence/ directory for reset_ack marks
+  3. HANDOFF.md — "Reset Acknowledgement" section
+
+Usage:
+  python scripts/check_reset_ack.py --pe-id PE-OPS-WORKTREE-BINDING-02 --agent infra-impl-b
+
+Exit codes:
+  0 — reset acknowledgement found and valid
+  1 — reset acknowledgement missing or invalid
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def _find_evidence_path(pe_id: str, agent_id: str) -> Path | None:
+    """Look for reset_ack evidence file in the PE evidence directory."""
+    evidence_dir = Path(f".elis/pe/{pe_id}/evidence")
+    if evidence_dir.is_dir():
+        for f in evidence_dir.iterdir():
+            if f.is_file() and "reset_ack" in f.name and agent_id in f.name:
+                return f
+    return None
+
+
+def _check_handoff_for_ack(pe_id: str, agent_id: str) -> dict | None:
+    """Look for a Reset Acknowledgement section in HANDOFF.md."""
+    handoff_path = Path("HANDOFF.md")
+    if not handoff_path.exists():
+        return None
+
+    content = handoff_path.read_text(encoding="utf-8")
+
+    # Search for acknowledgement sections. Accept flexible header patterns.
+    patterns = [
+        rf"##\s+Reset Acknowledgement.*?(?=##|\Z)",
+        rf"##\s+{re.escape(agent_id)}\s+Reset Acknowledgement.*?(?=##|\Z)",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, content, re.DOTALL)
+        if match:
+            section_text = match.group(0)
+            return _parse_ack_section(section_text, agent_id)
+
+    return None
+
+
+def _parse_ack_section(section_text: str, agent_id: str) -> dict | None:
+    """Parse table-like or field-like content from an acknowledgement section."""
+    data: dict[str, str] = {}
+
+    # Match pipe-delimited table rows: | key | value |
+    table_matches = re.findall(r"\|\s*([^|]+)\s*\|\s*([^|]+)\s*\|", section_text)
+    for key, value in table_matches:
+        data[key.strip().lower()] = value.strip()
+
+    # Match key: value pairs (inline, not in a table)
+    kv_matches = re.findall(r"^\s*[-*]?\s*(.+?)\s*:\s*(.+)$", section_text, re.MULTILINE)
+    for key, value in kv_matches:
+        data[key.strip().lower()] = value.strip()
+
+    return data if data else None
+
+
+def _check_json_evidence_file(path: Path, agent_id: str) -> tuple[bool, list[str]]:
+    """Validate a JSON reset acknowledgement file."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False, ["Invalid JSON in evidence file."]
+
+    return _validate_ack_data(data, agent_id)
+
+
+def _validate_ack_data(data: dict, agent_id: str) -> tuple[bool, list[str]]:
+    """Validate a reset acknowledgement data dictionary."""
+    required_fields = [
+        ("agent", "agent identity"),
+        ("pe", "PE ID"),
+        ("worktree", "target worktree/path"),
+        ("branch", "branch"),
+        ("head", "starting HEAD"),
+        ("timestamp", "timestamp"),
+    ]
+
+    missing_fields: list[str] = []
+    issues: list[str] = []
+
+    for field_key, field_label in required_fields:
+        value = data.get(field_key, "")
+        if not value or str(value).strip() in ("", "null", "None"):
+            missing_fields.append(field_label)
+
+    if missing_fields:
+        issues.append(
+            f"Missing required fields: {', '.join(missing_fields)}"
+        )
+
+    # Verify agent identity
+    actual_agent = str(data.get("agent", ""))
+    if actual_agent.strip().lower() != agent_id.lower():
+        issues.append(
+            f"Agent identity mismatch: expected '{agent_id}', got '{actual_agent}'"
+        )
+
+    # Verify discard confirmation
+    discard_confirmed = data.get("prior_context_discarded", data.get("discard", ""))
+    if str(discard_confirmed).strip().lower() not in ("yes", "true", "confirmed"):
+        issues.append(
+            "Prior runtime context discard not confirmed."
+        )
+
+    # Verify write scope
+    write_scope = data.get("write_scope", data.get("write_scope_confirmed", ""))
+    if not write_scope or str(write_scope).strip().lower() not in ("yes", "true", "confirmed"):
+        issues.append(
+            "Write scope within authorised worktree not confirmed."
+        )
+
+    return len(issues) == 0, issues
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check reset acknowledgement before dispatch."
+    )
+    parser.add_argument(
+        "--pe-id",
+        required=True,
+        help="PE ID (e.g. PE-OPS-WORKTREE-BINDING-02).",
+    )
+    parser.add_argument(
+        "--agent",
+        required=True,
+        help="Agent ID (e.g. infra-impl-b).",
+    )
+    parser.add_argument(
+        "--evidence-path",
+        default=None,
+        help="Explicit path to a reset acknowledgement evidence file.",
+    )
+    args = parser.parse_args()
+
+    pe_id = args.pe_id
+    agent_id = args.agent
+
+    print(f"Checking reset acknowledgement for {agent_id} / {pe_id}...")
+    print()
+
+    # Resolution order: explicit path → evidence dir → HANDOFF.md
+    ack_data: dict | None = None
+    source: str = ""
+
+    if args.evidence_path:
+        ep = Path(args.evidence_path)
+        if ep.exists():
+            if ep.suffix == ".json":
+                valid, issues = _check_json_evidence_file(ep, agent_id)
+                if valid:
+                    ack_data = json.loads(ep.read_text(encoding="utf-8"))
+                    source = str(ep)
+                else:
+                    print(f"EVIDENCE FILE FAILED: {ep}")
+                    for i in issues:
+                        print(f"  FAIL: {i}")
+                    return 1
+            else:
+                # Non-JSON file: try as markdown
+                content = ep.read_text(encoding="utf-8")
+                ack_data = _parse_ack_section(content, agent_id)
+                source = str(ep)
+        else:
+            print(f"FAIL: Evidence path not found: {args.evidence_path}")
+            return 1
+
+    if ack_data is None:
+        evidence_file = _find_evidence_path(pe_id, agent_id)
+        if evidence_file:
+            if evidence_file.suffix == ".json":
+                valid, issues = _check_json_evidence_file(evidence_file, agent_id)
+                if valid:
+                    ack_data = json.loads(evidence_file.read_text(encoding="utf-8"))
+                    source = str(evidence_file)
+                else:
+                    print(f"EVIDENCE FILE FAILED: {evidence_file}")
+                    for i in issues:
+                        print(f"  FAIL: {i}")
+                    return 1
+            else:
+                content = evidence_file.read_text(encoding="utf-8")
+                ack_data = _parse_ack_section(content, agent_id)
+                source = str(evidence_file)
+
+    if ack_data is None:
+        ack_data = _check_handoff_for_ack(pe_id, agent_id)
+        if ack_data:
+            source = "HANDOFF.md"
+
+    if ack_data is None:
+        print("FAIL: No reset acknowledgement found.")
+        print()
+        print("Checked locations:")
+        if args.evidence_path:
+            print(f"  - explicit path: {args.evidence_path}")
+        print(f"  - .elis/pe/{pe_id}/evidence/reset_ack_*")
+        print("  - HANDOFF.md")
+        print()
+        print("NO_RESET_ACK_NO_DISPATCH gate: DISPATCH PROHIBITED.")
+        return 1
+
+    valid, issues = _validate_ack_data(ack_data, agent_id)
+    print(f"Source: {source}")
+    print()
+    if valid:
+        print(f"Reset acknowledgement VALID for {agent_id}.")
+        print(f"  PE: {ack_data.get('pe', '(unknown)')}")
+        print(f"  Agent: {ack_data.get('agent', '(unknown)')}")
+        print(f"  Worktree: {ack_data.get('worktree', '(unknown)')}")
+        print(f"  Branch: {ack_data.get('branch', '(unknown)')}")
+        print(f"  HEAD: {ack_data.get('head', '(unknown)')}")
+        print(f"  Timestamp: {ack_data.get('timestamp', '(unknown)')}")
+        print()
+        print("NO_RESET_ACK_NO_DISPATCH gate: PASS — dispatch allowed.")
+        return 0
+    else:
+        print(f"Reset acknowledgement INVALID for {agent_id}:")
+        for i in issues:
+            print(f"  FAIL: {i}")
+        print()
+        print("NO_RESET_ACK_NO_DISPATCH gate: DISPATCH PROHIBITED.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pm_dispatch.py
+++ b/scripts/pm_dispatch.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""pm_dispatch.py — orchestration dispatch gate for PM.
+
+Enforces all dispatch gates before an agent can be dispatched:
+
+  1. Fixed worktree check (check_fixed_worktrees.py)
+  2. Dispatch binding check (check_dispatch_binding.py)
+  3. Reset acknowledgement check (check_reset_ack.py)
+  4. Active run evidence check (check_active_run.py)
+
+This script is the single entry point for PM to verify all dispatch
+conditions before dispatching any agent to implement or validate a PE.
+
+Required HANDOFF/evidence check before validator dispatch:
+  When role is 'validator', also validates that HANDOFF.md exists,
+  has all required sections, and the PE evidence directory has
+  implementer evidence before allowing validator dispatch.
+
+Usage:
+  python scripts/pm_dispatch.py --pe-id PE-OPS-WORKTREE-BINDING-02 \\
+      --agent infra-impl-b [--role implementer|validator] [--dry-run]
+
+Exit codes:
+  0 — all gates pass, dispatch permitted
+  1 — one or more gates fail, dispatch prohibited
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Required sections in HANDOFF.md for validator dispatch.
+HANDOFF_REQUIRED_SECTIONS = [
+    "## Summary",
+    "## Files Changed",
+    "## Acceptance Criteria",
+    "## Validation Commands",
+]
+
+
+def _run_script(script_name: str, args: list[str]) -> subprocess.CompletedProcess:
+    """Run one of the gate scripts."""
+    script_path = Path("scripts") / script_name
+    cmd = [sys.executable, str(script_path)] + args
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def _check_handoff_for_validator(pe_id: str) -> list[str]:
+    """Check HANDOFF.md completeness before validator dispatch."""
+    failures: list[str] = []
+
+    handoff_path = Path("HANDOFF.md")
+    if not handoff_path.exists():
+        failures.append(
+            "HANDOFF.md not found — required before validator dispatch."
+        )
+        return failures
+
+    content = handoff_path.read_text(encoding="utf-8")
+    missing = [s for s in HANDOFF_REQUIRED_SECTIONS if s not in content]
+    if missing:
+        failures.append(
+            f"HANDOFF.md incomplete — missing sections: {', '.join(missing)}"
+        )
+
+    # Check PE evidence directory for implementer evidence
+    evidence_dir = Path(f".elis/pe/{pe_id}/evidence")
+    if not evidence_dir.is_dir():
+        failures.append(
+            f"PE evidence directory not found: .elis/pe/{pe_id}/evidence/ — "
+            f"implementer evidence required before validator dispatch."
+        )
+    else:
+        evidence_files = list(evidence_dir.iterdir())
+        if not evidence_files:
+            failures.append(
+                f"PE evidence directory is empty: .elis/pe/{pe_id}/evidence/ — "
+                f"no implementer evidence for validator review."
+            )
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="PM dispatch gate orchestration."
+    )
+    parser.add_argument(
+        "--pe-id",
+        required=True,
+        help="PE ID (e.g. PE-OPS-WORKTREE-BINDING-02).",
+    )
+    parser.add_argument(
+        "--agent",
+        required=True,
+        help="Agent ID (e.g. infra-impl-b).",
+    )
+    parser.add_argument(
+        "--role",
+        choices=["implementer", "validator"],
+        default="implementer",
+        help="Agent role (default: implementer).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print gate results without dispatching.",
+    )
+    parser.add_argument(
+        "--skip-worktree-check",
+        action="store_true",
+        help="Skip the fixed-worktree audit (use for focused tests).",
+    )
+    parser.add_argument(
+        "--skip-handoff-check",
+        action="store_true",
+        help="Skip HANDOFF/evidence check (use for implementer dispatch).",
+    )
+    args = parser.parse_args()
+
+    pe_id = args.pe_id
+    agent_id = args.agent
+    role = args.role
+
+    print(f"{'=' * 60}")
+    print(f"PM DISPATCH GATE — {agent_id} ({role})")
+    print(f"PE: {pe_id}")
+    print(f"{'=' * 60}")
+    print()
+
+    all_failures: list[str] = []
+    all_passes: list[str] = []
+
+    # === Gate 1: Fixed Worktree Check ===
+    print("--- [Gate 1] Fixed Worktree Audit ---")
+    if args.skip_worktree_check:
+        print("  SKIPPED (--skip-worktree-check)")
+        all_passes.append("Gate 1 (worktree audit, skipped)")
+    else:
+        result = _run_script("check_fixed_worktrees.py", ["--worktrees"] +
+                              [f"/opt/elis/agent-worktrees/{agent_id}"])
+        if result.returncode == 0:
+            print(f"  PASS")
+            all_passes.append("Gate 1 (fixed worktree audit)")
+        else:
+            lines = [l for l in result.stdout.split("\n") if "FAIL" in l or "PASS" in l]
+            for line in lines:
+                print(f"  {line}")
+            all_failures.append(
+                f"Gate 1 (fixed worktree audit) — see above"
+            )
+    print()
+
+    # === Gate 2: Dispatch Binding Check ===
+    print("--- [Gate 2] Dispatch Binding Check ---")
+    result = _run_script("check_dispatch_binding.py", ["--agent", agent_id])
+    if result.returncode == 0:
+        print(f"  PASS")
+        all_passes.append("Gate 2 (dispatch binding)")
+    else:
+        for line in result.stdout.split("\n"):
+            if "FAIL" in line or "FAILED" in line:
+                print(f"  {line}")
+            elif result.stderr:
+                print(f"  {result.stderr}")
+        all_failures.append("Gate 2 (dispatch binding) — see above")
+    print()
+
+    # === Gate 3: Reset Acknowledgement Check ===
+    print("--- [Gate 3] Reset Acknowledgement (NO_RESET_ACK_NO_DISPATCH) ---")
+    result = _run_script("check_reset_ack.py", ["--pe-id", pe_id, "--agent", agent_id])
+    if result.returncode == 0:
+        print(f"  PASS")
+        all_passes.append("Gate 3 (reset acknowledgement)")
+    else:
+        for line in result.stdout.split("\n"):
+            if "FAIL" in line:
+                print(f"  {line}")
+        all_failures.append("Gate 3 (reset acknowledgement) — see above")
+    print()
+
+    # === Gate 4: Active Run Evidence Check ===
+    print("--- [Gate 4] Active Run Evidence ---")
+    print("  (NO_ACTIVE_RUN_EVIDENCE_NO_IN_PROGRESS_STATUS)")
+    result = _run_script("check_active_run.py", ["--pe-id", pe_id, "--agent", agent_id])
+    if result.returncode == 0:
+        print(f"  PASS")
+        all_passes.append("Gate 4 (active run evidence)")
+    elif result.returncode == 2:
+        print(f"  INFO: Evidence found but invalid")
+        for line in result.stdout.split("\n"):
+            if "FAIL" in line:
+                print(f"  {line}")
+        all_passes.append("Gate 4 (active run evidence, invalid but noted)")
+    else:
+        print(f"  INFO: No active run evidence — status must be NOT_STARTED/STALLED/FAILED")
+        all_passes.append("Gate 4 (active run, no evidence)")
+    print()
+
+    # === Gate 5: HANDOFF/Evidence check (validator only) ===
+    if role == "validator" and not args.skip_handoff_check:
+        print("--- [Gate 5] HANDOFF/Evidence Check (validator gate) ---")
+        handoff_issues = _check_handoff_for_validator(pe_id)
+        if handoff_issues:
+            for issue in handoff_issues:
+                print(f"  FAIL: {issue}")
+            all_failures.append("Gate 5 (HANDOFF/evidence check) — see above")
+        else:
+            print(f"  PASS — HANDOFF.md and PE evidence present")
+            all_passes.append("Gate 5 (HANDOFF/evidence check)")
+        print()
+
+    # === Summary ===
+    print(f"{'=' * 60}")
+    print("DISPATCH GATE SUMMARY")
+    print(f"{'=' * 60}")
+    print(f"Agent: {agent_id} | PE: {pe_id} | Role: {role}")
+    print(f"Passes: {len(all_passes)}")
+    print(f"Failures: {len(all_failures)}")
+    print()
+
+    for p in all_passes:
+        print(f"  PASS  {p}")
+    for f in all_failures:
+        print(f"  FAIL  {f}")
+    print()
+
+    if args.dry_run:
+        if all_failures:
+            print("DRY-RUN: Would PROHIBIT dispatch due to failures above.")
+            return 1
+        else:
+            print("DRY-RUN: Would ALLOW dispatch. All gates pass.")
+            return 0
+
+    if all_failures:
+        print("DISPATCH PROHIBITED — one or more gates failed.")
+        return 1
+    else:
+        print("DISPATCH ALLOWED — all gates pass.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pm_dispatch.py
+++ b/scripts/pm_dispatch.py
@@ -28,8 +28,6 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -61,9 +59,7 @@ def _check_handoff_for_validator(pe_id: str) -> list[str]:
 
     handoff_path = Path("HANDOFF.md")
     if not handoff_path.exists():
-        failures.append(
-            "HANDOFF.md not found — required before validator dispatch."
-        )
+        failures.append("HANDOFF.md not found — required before validator dispatch.")
         return failures
 
     content = handoff_path.read_text(encoding="utf-8")
@@ -92,9 +88,7 @@ def _check_handoff_for_validator(pe_id: str) -> list[str]:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="PM dispatch gate orchestration."
-    )
+    parser = argparse.ArgumentParser(description="PM dispatch gate orchestration.")
     parser.add_argument(
         "--pe-id",
         required=True,
@@ -147,25 +141,29 @@ def main() -> int:
         print("  SKIPPED (--skip-worktree-check)")
         all_passes.append("Gate 1 (worktree audit, skipped)")
     else:
-        result = _run_script("check_fixed_worktrees.py", ["--worktrees"] +
-                              [f"/opt/elis/agent-worktrees/{agent_id}"])
+        result = _run_script(
+            "check_fixed_worktrees.py",
+            ["--worktrees"] + [f"/opt/elis/agent-worktrees/{agent_id}"],
+        )
         if result.returncode == 0:
-            print(f"  PASS")
+            print("  PASS")
             all_passes.append("Gate 1 (fixed worktree audit)")
         else:
-            lines = [l for l in result.stdout.split("\n") if "FAIL" in l or "PASS" in l]
+            lines = [
+                line
+                for line in result.stdout.split("\n")
+                if "FAIL" in line or "PASS" in line
+            ]
             for line in lines:
                 print(f"  {line}")
-            all_failures.append(
-                f"Gate 1 (fixed worktree audit) — see above"
-            )
+            all_failures.append("Gate 1 (fixed worktree audit) — see above")
     print()
 
     # === Gate 2: Dispatch Binding Check ===
     print("--- [Gate 2] Dispatch Binding Check ---")
     result = _run_script("check_dispatch_binding.py", ["--agent", agent_id])
     if result.returncode == 0:
-        print(f"  PASS")
+        print("  PASS")
         all_passes.append("Gate 2 (dispatch binding)")
     else:
         for line in result.stdout.split("\n"):
@@ -180,7 +178,7 @@ def main() -> int:
     print("--- [Gate 3] Reset Acknowledgement (NO_RESET_ACK_NO_DISPATCH) ---")
     result = _run_script("check_reset_ack.py", ["--pe-id", pe_id, "--agent", agent_id])
     if result.returncode == 0:
-        print(f"  PASS")
+        print("  PASS")
         all_passes.append("Gate 3 (reset acknowledgement)")
     else:
         for line in result.stdout.split("\n"):
@@ -194,16 +192,18 @@ def main() -> int:
     print("  (NO_ACTIVE_RUN_EVIDENCE_NO_IN_PROGRESS_STATUS)")
     result = _run_script("check_active_run.py", ["--pe-id", pe_id, "--agent", agent_id])
     if result.returncode == 0:
-        print(f"  PASS")
+        print("  PASS")
         all_passes.append("Gate 4 (active run evidence)")
     elif result.returncode == 2:
-        print(f"  INFO: Evidence found but invalid")
+        print("  INFO: Evidence found but invalid")
         for line in result.stdout.split("\n"):
             if "FAIL" in line:
                 print(f"  {line}")
         all_passes.append("Gate 4 (active run evidence, invalid but noted)")
     else:
-        print(f"  INFO: No active run evidence — status must be NOT_STARTED/STALLED/FAILED")
+        print(
+            "  INFO: No active run evidence — status must be NOT_STARTED/STALLED/FAILED"
+        )
         all_passes.append("Gate 4 (active run, no evidence)")
     print()
 
@@ -216,7 +216,7 @@ def main() -> int:
                 print(f"  FAIL: {issue}")
             all_failures.append("Gate 5 (HANDOFF/evidence check) — see above")
         else:
-            print(f"  PASS — HANDOFF.md and PE evidence present")
+            print("  PASS — HANDOFF.md and PE evidence present")
             all_passes.append("Gate 5 (HANDOFF/evidence check)")
         print()
 

--- a/tests/test_check_active_run.py
+++ b/tests/test_check_active_run.py
@@ -55,13 +55,21 @@ def test_script_with_json_evidence(tmp_path):
     ev_file.write_text(json.dumps(SAMPLE_VALID_EVIDENCE))
 
     result = subprocess.run(
-        [str(SCRIPT), "--pe-id", "PE-OPS-WORKTREE-BINDING-02", "--agent", "infra-impl-b"],
+        [
+            str(SCRIPT),
+            "--pe-id",
+            "PE-OPS-WORKTREE-BINDING-02",
+            "--agent",
+            "infra-impl-b",
+        ],
         capture_output=True,
         text=True,
         cwd=str(cwd),
         timeout=30,
     )
-    assert result.returncode == 0, f"Expected 0, got {result.returncode}\n{result.stdout}"
+    assert (
+        result.returncode == 0
+    ), f"Expected 0, got {result.returncode}\n{result.stdout}"
     assert "Active run evidence VALID" in result.stdout
 
 
@@ -71,13 +79,22 @@ def test_script_with_explicit_evidence_path(tmp_path):
     ev_file.write_text(json.dumps(SAMPLE_VALID_EVIDENCE))
 
     result = subprocess.run(
-        [str(SCRIPT), "--pe-id", "PE-OPS-WORKTREE-BINDING-02", "--agent", "infra-impl-b",
-         "--evidence-path", str(ev_file)],
+        [
+            str(SCRIPT),
+            "--pe-id",
+            "PE-OPS-WORKTREE-BINDING-02",
+            "--agent",
+            "infra-impl-b",
+            "--evidence-path",
+            str(ev_file),
+        ],
         capture_output=True,
         text=True,
         timeout=30,
     )
-    assert result.returncode == 0, f"Expected 0, got {result.returncode}\n{result.stdout}"
+    assert (
+        result.returncode == 0
+    ), f"Expected 0, got {result.returncode}\n{result.stdout}"
     assert "Active run evidence VALID" in result.stdout
 
 
@@ -88,8 +105,15 @@ def test_script_with_wrong_agent(tmp_path):
     ev_file.write_text(json.dumps(data))
 
     result = subprocess.run(
-        [str(SCRIPT), "--pe-id", "PE-ACTIVE-TEST", "--agent", "infra-impl-b",
-         "--evidence-path", str(ev_file)],
+        [
+            str(SCRIPT),
+            "--pe-id",
+            "PE-ACTIVE-TEST",
+            "--agent",
+            "infra-impl-b",
+            "--evidence-path",
+            str(ev_file),
+        ],
         capture_output=True,
         text=True,
         timeout=30,
@@ -105,8 +129,15 @@ def test_script_with_wrong_pe(tmp_path):
     ev_file.write_text(json.dumps(data))
 
     result = subprocess.run(
-        [str(SCRIPT), "--pe-id", "PE-ACTIVE-TEST", "--agent", "infra-impl-b",
-         "--evidence-path", str(ev_file)],
+        [
+            str(SCRIPT),
+            "--pe-id",
+            "PE-ACTIVE-TEST",
+            "--agent",
+            "infra-impl-b",
+            "--evidence-path",
+            str(ev_file),
+        ],
         capture_output=True,
         text=True,
         timeout=30,
@@ -137,7 +168,9 @@ def test_handoff_evidence_detection(tmp_path):
         cwd=str(cwd),
         timeout=30,
     )
-    assert result.returncode == 0, f"Expected 0, got {result.returncode}\n{result.stdout}"
+    assert (
+        result.returncode == 0
+    ), f"Expected 0, got {result.returncode}\n{result.stdout}"
     assert "Active run evidence VALID" in result.stdout
     assert "Source: HANDOFF.md" in result.stdout
 
@@ -150,8 +183,15 @@ def test_missing_session_id():
     try:
         ev_file.write_text(json.dumps(data))
         result = subprocess.run(
-            [str(SCRIPT), "--pe-id", "PE-TEST", "--agent", "infra-impl-b",
-             "--evidence-path", str(ev_file)],
+            [
+                str(SCRIPT),
+                "--pe-id",
+                "PE-TEST",
+                "--agent",
+                "infra-impl-b",
+                "--evidence-path",
+                str(ev_file),
+            ],
             capture_output=True,
             text=True,
             timeout=30,
@@ -168,8 +208,15 @@ def test_missing_timestamp():
     try:
         ev_file.write_text(json.dumps(data))
         result = subprocess.run(
-            [str(SCRIPT), "--pe-id", "PE-TEST", "--agent", "infra-impl-b",
-             "--evidence-path", str(ev_file)],
+            [
+                str(SCRIPT),
+                "--pe-id",
+                "PE-TEST",
+                "--agent",
+                "infra-impl-b",
+                "--evidence-path",
+                str(ev_file),
+            ],
             capture_output=True,
             text=True,
             timeout=30,

--- a/tests/test_check_active_run.py
+++ b/tests/test_check_active_run.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_active_run.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import json
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_active_run.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_active_run", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load()
+
+SAMPLE_VALID_EVIDENCE = {
+    "session_id": "agent:infra-impl-b:subagent:abc123",
+    "agent": "infra-impl-b",
+    "pe": "PE-OPS-WORKTREE-BINDING-02",
+    "worktree": "/opt/elis/agent-worktrees/infra-impl-b",
+    "branch": "feature/pe-ops-worktree-binding-02-enforce-fixed-worktree-dispatch-gates",
+    "status": "running",
+    "timestamp": "2026-05-09T22:00:00+01:00",
+}
+
+
+def test_script_no_evidence():
+    """No evidence should exit 1."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            [str(SCRIPT), "--pe-id", "PE-NO-EVIDENCE-01", "--agent", "infra-impl-b"],
+            capture_output=True,
+            text=True,
+            cwd=tmpdir,
+            timeout=30,
+        )
+        assert result.returncode == 1
+        assert "No active run evidence found" in result.stdout
+
+
+def test_script_with_json_evidence(tmp_path):
+    """A JSON evidence file should pass."""
+    cwd = Path(tmp_path)
+    ev_dir = cwd / ".elis" / "pe" / "PE-OPS-WORKTREE-BINDING-02" / "evidence"
+    ev_dir.mkdir(parents=True)
+    ev_file = ev_dir / "active_run_infra-impl-b.json"
+    ev_file.write_text(json.dumps(SAMPLE_VALID_EVIDENCE))
+
+    result = subprocess.run(
+        [str(SCRIPT), "--pe-id", "PE-OPS-WORKTREE-BINDING-02", "--agent", "infra-impl-b"],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Expected 0, got {result.returncode}\n{result.stdout}"
+    assert "Active run evidence VALID" in result.stdout
+
+
+def test_script_with_explicit_evidence_path(tmp_path):
+    """Explicit evidence path should work."""
+    ev_file = tmp_path / "active_run_evidence.json"
+    ev_file.write_text(json.dumps(SAMPLE_VALID_EVIDENCE))
+
+    result = subprocess.run(
+        [str(SCRIPT), "--pe-id", "PE-OPS-WORKTREE-BINDING-02", "--agent", "infra-impl-b",
+         "--evidence-path", str(ev_file)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Expected 0, got {result.returncode}\n{result.stdout}"
+    assert "Active run evidence VALID" in result.stdout
+
+
+def test_script_with_wrong_agent(tmp_path):
+    """Wrong agent in evidence should exit 2."""
+    ev_file = tmp_path / "active_run_evidence.json"
+    data = {**SAMPLE_VALID_EVIDENCE, "agent": "infra-impl-a"}
+    ev_file.write_text(json.dumps(data))
+
+    result = subprocess.run(
+        [str(SCRIPT), "--pe-id", "PE-ACTIVE-TEST", "--agent", "infra-impl-b",
+         "--evidence-path", str(ev_file)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 2
+    assert "Agent mismatch" in result.stdout
+
+
+def test_script_with_wrong_pe(tmp_path):
+    """Wrong PE in evidence should exit 2."""
+    ev_file = tmp_path / "active_run_evidence.json"
+    data = {**SAMPLE_VALID_EVIDENCE, "pe": "PE-WRONG-01"}
+    ev_file.write_text(json.dumps(data))
+
+    result = subprocess.run(
+        [str(SCRIPT), "--pe-id", "PE-ACTIVE-TEST", "--agent", "infra-impl-b",
+         "--evidence-path", str(ev_file)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 2
+    assert "PE mismatch" in result.stdout
+
+
+def test_handoff_evidence_detection(tmp_path):
+    """Active run evidence in HANDOFF.md should be detected."""
+    cwd = Path(tmp_path)
+    handoff = cwd / "HANDOFF.md"
+    handoff.write_text(
+        "## Active Run Evidence\n\n"
+        "| Field | Value |\n"
+        "|-------|-------|\n"
+        "| session_id | agent:infra-impl-b:run:xyz789 |\n"
+        "| agent | infra-impl-b |\n"
+        "| pe | PE-HANDOFF-TEST |\n"
+        "| status | running |\n"
+        "| timestamp | 2026-05-09T22:05:00Z |\n"
+    )
+
+    result = subprocess.run(
+        [str(SCRIPT), "--pe-id", "PE-HANDOFF-TEST", "--agent", "infra-impl-b"],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Expected 0, got {result.returncode}\n{result.stdout}"
+    assert "Active run evidence VALID" in result.stdout
+    assert "Source: HANDOFF.md" in result.stdout
+
+
+def test_missing_session_id():
+    """Missing session ID should fail validation."""
+    data = {**SAMPLE_VALID_EVIDENCE, "session_id": ""}
+    # Simulate by checking logic directly
+    ev_file = Path(tempfile.mktemp(suffix=".json"))
+    try:
+        ev_file.write_text(json.dumps(data))
+        result = subprocess.run(
+            [str(SCRIPT), "--pe-id", "PE-TEST", "--agent", "infra-impl-b",
+             "--evidence-path", str(ev_file)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 2
+    finally:
+        ev_file.unlink(missing_ok=True)
+
+
+def test_missing_timestamp():
+    """Missing timestamp should fail validation."""
+    data = {**SAMPLE_VALID_EVIDENCE, "timestamp": ""}
+    ev_file = Path(tempfile.mktemp(suffix=".json"))
+    try:
+        ev_file.write_text(json.dumps(data))
+        result = subprocess.run(
+            [str(SCRIPT), "--pe-id", "PE-TEST", "--agent", "infra-impl-b",
+             "--evidence-path", str(ev_file)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 2
+    finally:
+        ev_file.unlink(missing_ok=True)

--- a/tests/test_check_dispatch_binding.py
+++ b/tests/test_check_dispatch_binding.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import importlib.util
-import tempfile
 import subprocess
 from pathlib import Path
 
@@ -26,26 +25,45 @@ def test_is_pe_specific_runtime():
     assert MODULE._is_pe_specific_runtime(
         "/opt/elis/agent-worktrees/PE-OPS-A2A-01-infra-impl-a"
     )
-    assert not MODULE._is_pe_specific_runtime(
-        "/opt/elis/agent-worktrees/infra-impl-b"
-    )
+    assert not MODULE._is_pe_specific_runtime("/opt/elis/agent-worktrees/infra-impl-b")
     assert not MODULE._is_pe_specific_runtime("/opt/elis/repo")
 
 
 def test_agent_worktree_map():
     """All canonical agents should map to fixed worktrees."""
     assert MODULE.AGENT_WORKTREE_MAP["pm"] == "/opt/elis/agent-worktrees/pm"
-    assert MODULE.AGENT_WORKTREE_MAP["infra-impl-b"] == "/opt/elis/agent-worktrees/infra-impl-b"
-    assert MODULE.AGENT_WORKTREE_MAP["infra-val-a"] == "/opt/elis/agent-worktrees/infra-val-a"
-    assert MODULE.AGENT_WORKTREE_MAP["github-agent"] == "/opt/elis/agent-worktrees/github-agent"
+    assert (
+        MODULE.AGENT_WORKTREE_MAP["infra-impl-b"]
+        == "/opt/elis/agent-worktrees/infra-impl-b"
+    )
+    assert (
+        MODULE.AGENT_WORKTREE_MAP["infra-val-a"]
+        == "/opt/elis/agent-worktrees/infra-val-a"
+    )
+    assert (
+        MODULE.AGENT_WORKTREE_MAP["github-agent"]
+        == "/opt/elis/agent-worktrees/github-agent"
+    )
 
 
 def test_agent_worktree_map_legacy_aliases():
     """Legacy engine-based agent IDs should resolve to the correct worktree."""
-    assert MODULE.AGENT_WORKTREE_MAP["infra-impl-claude"] == "/opt/elis/agent-worktrees/infra-impl-b"
-    assert MODULE.AGENT_WORKTREE_MAP["infra-val-claude"] == "/opt/elis/agent-worktrees/infra-val-a"
-    assert MODULE.AGENT_WORKTREE_MAP["infra-impl-codex"] == "/opt/elis/agent-worktrees/infra-impl-a"
-    assert MODULE.AGENT_WORKTREE_MAP["infra-val-codex"] == "/opt/elis/agent-worktrees/infra-val-b"
+    assert (
+        MODULE.AGENT_WORKTREE_MAP["infra-impl-claude"]
+        == "/opt/elis/agent-worktrees/infra-impl-b"
+    )
+    assert (
+        MODULE.AGENT_WORKTREE_MAP["infra-val-claude"]
+        == "/opt/elis/agent-worktrees/infra-val-a"
+    )
+    assert (
+        MODULE.AGENT_WORKTREE_MAP["infra-impl-codex"]
+        == "/opt/elis/agent-worktrees/infra-impl-a"
+    )
+    assert (
+        MODULE.AGENT_WORKTREE_MAP["infra-val-codex"]
+        == "/opt/elis/agent-worktrees/infra-val-b"
+    )
 
 
 def test_preserved_files():

--- a/tests/test_check_dispatch_binding.py
+++ b/tests/test_check_dispatch_binding.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_dispatch_binding.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_dispatch_binding.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_dispatch_binding", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load()
+
+
+def test_is_pe_specific_runtime():
+    """PE-specific runtime worktrees should be detected."""
+    assert MODULE._is_pe_specific_runtime(
+        "/opt/elis/agent-worktrees/PE-OPS-A2A-01-infra-impl-a"
+    )
+    assert not MODULE._is_pe_specific_runtime(
+        "/opt/elis/agent-worktrees/infra-impl-b"
+    )
+    assert not MODULE._is_pe_specific_runtime("/opt/elis/repo")
+
+
+def test_agent_worktree_map():
+    """All canonical agents should map to fixed worktrees."""
+    assert MODULE.AGENT_WORKTREE_MAP["pm"] == "/opt/elis/agent-worktrees/pm"
+    assert MODULE.AGENT_WORKTREE_MAP["infra-impl-b"] == "/opt/elis/agent-worktrees/infra-impl-b"
+    assert MODULE.AGENT_WORKTREE_MAP["infra-val-a"] == "/opt/elis/agent-worktrees/infra-val-a"
+    assert MODULE.AGENT_WORKTREE_MAP["github-agent"] == "/opt/elis/agent-worktrees/github-agent"
+
+
+def test_agent_worktree_map_legacy_aliases():
+    """Legacy engine-based agent IDs should resolve to the correct worktree."""
+    assert MODULE.AGENT_WORKTREE_MAP["infra-impl-claude"] == "/opt/elis/agent-worktrees/infra-impl-b"
+    assert MODULE.AGENT_WORKTREE_MAP["infra-val-claude"] == "/opt/elis/agent-worktrees/infra-val-a"
+    assert MODULE.AGENT_WORKTREE_MAP["infra-impl-codex"] == "/opt/elis/agent-worktrees/infra-impl-a"
+    assert MODULE.AGENT_WORKTREE_MAP["infra-val-codex"] == "/opt/elis/agent-worktrees/infra-val-b"
+
+
+def test_preserved_files():
+    """Runtime/bootstrap files should be protected."""
+    protected, _ = MODULE._is_untracked_or_dirty(".openclaw")
+    assert protected
+    protected, _ = MODULE._is_untracked_or_dirty("AGENTS.md")
+    assert protected
+    protected, _ = MODULE._is_untracked_or_dirty(".openclaw/config.yaml")
+    assert protected
+
+
+def test_non_preserved_files():
+    """Non-runtime files should not be considered protected."""
+    protected, _ = MODULE._is_untracked_or_dirty("scripts/some_new_script.py")
+    assert not protected
+    protected, _ = MODULE._is_untracked_or_dirty("CURRENT_PE.md")
+    assert not protected
+
+
+def test_script_runs_with_unknown_agent():
+    """Calling with an unknown agent ID should exit 1."""
+    result = subprocess.run(
+        [str(SCRIPT), "--agent", "nonexistent-agent"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 1
+    assert "Unknown agent ID" in result.stdout
+
+
+def test_script_runs_without_crash_on_real_agent():
+    """Calling with a real agent ID should attempt checks."""
+    result = subprocess.run(
+        [str(SCRIPT), "--agent", "infra-impl-b"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    # May pass or fail depending on actual worktree state, but should not crash
+    assert result.returncode in (0, 1), f"Unexpected: {result.returncode}"
+    assert "Agent: infra-impl-b" in result.stdout

--- a/tests/test_check_fixed_worktrees.py
+++ b/tests/test_check_fixed_worktrees.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_fixed_worktrees.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_fixed_worktrees.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_fixed_worktrees", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load()
+
+
+def test_is_pe_specific_runtime_matches_pattern():
+    """PE-specific runtime worktrees should be detected."""
+    assert MODULE._is_pe_specific_runtime(
+        "/opt/elis/agent-worktrees/PE-OPS-A2A-01-infra-impl-a"
+    )
+    assert MODULE._is_pe_specific_runtime(
+        "/opt/elis/agent-worktrees/PE-OPS-WORKTREE-01-infra-impl-b"
+    )
+    assert MODULE._is_pe_specific_runtime(
+        "/opt/elis/agent-worktrees/PE-ARCH-02-infra-impl-b"
+    )
+
+
+def test_is_pe_specific_runtime_rejects_fixed():
+    """Fixed canonical worktrees should not be flagged as PE-specific."""
+    assert not MODULE._is_pe_specific_runtime(
+        "/opt/elis/agent-worktrees/infra-impl-b"
+    )
+    assert not MODULE._is_pe_specific_runtime(
+        "/opt/elis/agent-worktrees/infra-val-a"
+    )
+    assert not MODULE._is_pe_specific_runtime(
+        "/opt/elis/agent-worktrees/pm"
+    )
+    assert not MODULE._is_pe_specific_runtime(
+        "/opt/elis/agent-worktrees/github-agent"
+    )
+
+
+def test_is_pe_specific_runtime_rejects_other_paths():
+    """Unrelated paths should not be flagged."""
+    assert not MODULE._is_pe_specific_runtime("/opt/elis/repo")
+    assert not MODULE._is_pe_specific_runtime("/tmp/some-other-path")
+    assert not MODULE._is_pe_specific_runtime("/opt/elis/agent-worktrees/something-else")
+
+
+def test_preserved_files_set():
+    """PRESERVED_FILES should include standard runtime/bootstrap files."""
+    preserved = MODULE.PRESERVED_FILES
+    assert ".openclaw" in preserved
+    assert "AGENTS.md" in preserved
+    assert "SOUL.md" in preserved
+    assert "TOOLS.md" in preserved
+    assert "USER.md" in preserved
+    assert "HEARTBEAT.md" in preserved
+    assert "IDENTITY.md" in preserved
+
+
+def test_script_runs_without_crash():
+    """The script should parse arguments and attempt checks without crash."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a minimal git repo so the script doesn't crash immediately
+        subprocess.run(["git", "init"], cwd=tmpdir, capture_output=True, timeout=30)
+        result = subprocess.run(
+            [str(SCRIPT), "--worktrees", tmpdir, "--canonical-repo", tmpdir,
+             "--expected-origin", "https://example.com/test.git"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        # Should run without uncaught exceptions and produce some output
+        assert result.returncode in (0, 1), f"Unexpected return code: {result.returncode}"
+        assert result.stdout.strip(), "Script produced no output"

--- a/tests/test_check_fixed_worktrees.py
+++ b/tests/test_check_fixed_worktrees.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import importlib.util
-import os
 import tempfile
 import subprocess
 from pathlib import Path
@@ -37,25 +36,19 @@ def test_is_pe_specific_runtime_matches_pattern():
 
 def test_is_pe_specific_runtime_rejects_fixed():
     """Fixed canonical worktrees should not be flagged as PE-specific."""
-    assert not MODULE._is_pe_specific_runtime(
-        "/opt/elis/agent-worktrees/infra-impl-b"
-    )
-    assert not MODULE._is_pe_specific_runtime(
-        "/opt/elis/agent-worktrees/infra-val-a"
-    )
-    assert not MODULE._is_pe_specific_runtime(
-        "/opt/elis/agent-worktrees/pm"
-    )
-    assert not MODULE._is_pe_specific_runtime(
-        "/opt/elis/agent-worktrees/github-agent"
-    )
+    assert not MODULE._is_pe_specific_runtime("/opt/elis/agent-worktrees/infra-impl-b")
+    assert not MODULE._is_pe_specific_runtime("/opt/elis/agent-worktrees/infra-val-a")
+    assert not MODULE._is_pe_specific_runtime("/opt/elis/agent-worktrees/pm")
+    assert not MODULE._is_pe_specific_runtime("/opt/elis/agent-worktrees/github-agent")
 
 
 def test_is_pe_specific_runtime_rejects_other_paths():
     """Unrelated paths should not be flagged."""
     assert not MODULE._is_pe_specific_runtime("/opt/elis/repo")
     assert not MODULE._is_pe_specific_runtime("/tmp/some-other-path")
-    assert not MODULE._is_pe_specific_runtime("/opt/elis/agent-worktrees/something-else")
+    assert not MODULE._is_pe_specific_runtime(
+        "/opt/elis/agent-worktrees/something-else"
+    )
 
 
 def test_preserved_files_set():
@@ -76,12 +69,22 @@ def test_script_runs_without_crash():
         # Create a minimal git repo so the script doesn't crash immediately
         subprocess.run(["git", "init"], cwd=tmpdir, capture_output=True, timeout=30)
         result = subprocess.run(
-            [str(SCRIPT), "--worktrees", tmpdir, "--canonical-repo", tmpdir,
-             "--expected-origin", "https://example.com/test.git"],
+            [
+                str(SCRIPT),
+                "--worktrees",
+                tmpdir,
+                "--canonical-repo",
+                tmpdir,
+                "--expected-origin",
+                "https://example.com/test.git",
+            ],
             capture_output=True,
             text=True,
             timeout=30,
         )
         # Should run without uncaught exceptions and produce some output
-        assert result.returncode in (0, 1), f"Unexpected return code: {result.returncode}"
+        assert result.returncode in (
+            0,
+            1,
+        ), f"Unexpected return code: {result.returncode}"
         assert result.stdout.strip(), "Script produced no output"

--- a/tests/test_check_reset_ack.py
+++ b/tests/test_check_reset_ack.py
@@ -93,7 +93,7 @@ def test_validate_missing_discard_confirmation():
     data = {**SAMPLE_VALID_ACK_DATA, "prior_context_discarded": ""}
     valid, issues = MODULE._validate_ack_data(data, "infra-impl-b")
     assert not valid
-    assert any("discard not confirmed" in i for i in issues or "not confirmed" in i for i in issues)
+    assert any("discard not confirmed" in i or "not confirmed" in i for i in issues)
 
 
 def test_validate_missing_timestamp():
@@ -139,6 +139,7 @@ def test_json_evidence_file_invalid_json(tmp_path):
 def test_find_evidence_path(tmp_path):
     """Evidence file should be found by name pattern."""
     import os as _os
+
     with tempfile.TemporaryDirectory() as tmpdir:
         ev_dir = Path(tmpdir) / ".elis" / "pe" / "PE-TEST-01" / "evidence"
         ev_dir.mkdir(parents=True)
@@ -197,5 +198,7 @@ def test_script_with_inline_handoff_ack(tmp_path):
         cwd=str(cwd),
         timeout=30,
     )
-    assert result.returncode == 0, f"Expected 0, got {result.returncode}\n{result.stdout}\n{result.stderr}"
+    assert (
+        result.returncode == 0
+    ), f"Expected 0, got {result.returncode}\n{result.stdout}\n{result.stderr}"
     assert "Reset acknowledgement VALID" in result.stdout

--- a/tests/test_check_reset_ack.py
+++ b/tests/test_check_reset_ack.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_reset_ack.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import json
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_reset_ack.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_reset_ack", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load()
+
+SAMPLE_VALID_ACK_DATA = {
+    "agent": "infra-impl-b",
+    "pe": "PE-OPS-WORKTREE-BINDING-02",
+    "worktree": "/opt/elis/agent-worktrees/infra-impl-b",
+    "branch": "feature/pe-ops-worktree-binding-02-enforce-fixed-worktree-dispatch-gates",
+    "head": "e5d3afc733ef7e4a3dc429cff63aa0f583100ccf",
+    "timestamp": "2026-05-09T22:00:00+01:00",
+    "prior_context_discarded": "yes",
+    "write_scope": "yes",
+}
+
+
+def test_validate_valid_ack_data():
+    """A complete, valid acknowledgement should pass validation."""
+    valid, issues = MODULE._validate_ack_data(SAMPLE_VALID_ACK_DATA, "infra-impl-b")
+    assert valid, f"Expected valid, got issues: {issues}"
+    assert len(issues) == 0
+
+
+def test_validate_missing_agent():
+    """Missing agent identity should fail."""
+    data = {**SAMPLE_VALID_ACK_DATA, "agent": ""}
+    valid, issues = MODULE._validate_ack_data(data, "infra-impl-b")
+    assert not valid
+    assert any("agent identity" in i for i in issues)
+
+
+def test_validate_wrong_agent():
+    """Wrong agent identity should fail."""
+    data = {**SAMPLE_VALID_ACK_DATA, "agent": "infra-impl-a"}
+    valid, issues = MODULE._validate_ack_data(data, "infra-impl-b")
+    assert not valid
+    assert any("Agent identity mismatch" in i for i in issues)
+
+
+def test_validate_missing_pe_id():
+    """Missing PE ID should fail."""
+    data = {**SAMPLE_VALID_ACK_DATA, "pe": ""}
+    valid, issues = MODULE._validate_ack_data(data, "infra-impl-b")
+    assert not valid
+    assert any("PE ID" in i for i in issues)
+
+
+def test_validate_missing_worktree():
+    """Missing worktree path should fail."""
+    data = {**SAMPLE_VALID_ACK_DATA, "worktree": ""}
+    valid, issues = MODULE._validate_ack_data(data, "infra-impl-b")
+    assert not valid
+    assert any("worktree" in i for i in issues)
+
+
+def test_validate_missing_branch():
+    """Missing branch should fail."""
+    data = {**SAMPLE_VALID_ACK_DATA, "branch": ""}
+    valid, issues = MODULE._validate_ack_data(data, "infra-impl-b")
+    assert not valid
+    assert any("branch" in i for i in issues)
+
+
+def test_validate_missing_head():
+    """Missing HEAD should fail."""
+    data = {**SAMPLE_VALID_ACK_DATA, "head": ""}
+    valid, issues = MODULE._validate_ack_data(data, "infra-impl-b")
+    assert not valid
+    assert any("starting HEAD" in i for i in issues)
+
+
+def test_validate_missing_discard_confirmation():
+    """Missing prior context discard confirmation should fail."""
+    data = {**SAMPLE_VALID_ACK_DATA, "prior_context_discarded": ""}
+    valid, issues = MODULE._validate_ack_data(data, "infra-impl-b")
+    assert not valid
+    assert any("discard not confirmed" in i for i in issues or "not confirmed" in i for i in issues)
+
+
+def test_validate_missing_timestamp():
+    """Missing timestamp should fail."""
+    data = {**SAMPLE_VALID_ACK_DATA, "timestamp": ""}
+    valid, issues = MODULE._validate_ack_data(data, "infra-impl-b")
+    assert not valid
+    assert any("timestamp" in i for i in issues)
+
+
+def test_validate_accepts_alternative_keys():
+    """Should accept 'discard' and 'write_scope_confirmed' as alternative keys."""
+    data = {
+        "agent": "infra-impl-b",
+        "pe": "PE-OPS-WORKTREE-BINDING-02",
+        "worktree": "/opt/elis/agent-worktrees/infra-impl-b",
+        "branch": "feature/pe-ops-worktree-binding-02-enforce-fixed-worktree-dispatch-gates",
+        "head": "e5d3afc733ef7e4a3dc429cff63aa0f583100ccf",
+        "timestamp": "2026-05-09T22:00:00+01:00",
+        "discard": "confirmed",
+        "write_scope_confirmed": "true",
+    }
+    valid, issues = MODULE._validate_ack_data(data, "infra-impl-b")
+    assert valid, f"Expected valid with alt keys, got: {issues}"
+
+
+def test_json_evidence_file(tmp_path):
+    """A valid JSON evidence file should be parseable."""
+    evidence_path = tmp_path / "reset_ack_infra-impl-b.json"
+    evidence_path.write_text(json.dumps(SAMPLE_VALID_ACK_DATA))
+    valid, issues = MODULE._check_json_evidence_file(evidence_path, "infra-impl-b")
+    assert valid, f"Expected valid, got: {issues}"
+
+
+def test_json_evidence_file_invalid_json(tmp_path):
+    """Invalid JSON should fail parsing."""
+    evidence_path = tmp_path / "reset_ack_infra-impl-b.json"
+    evidence_path.write_text("not valid json}{")
+    valid, issues = MODULE._check_json_evidence_file(evidence_path, "infra-impl-b")
+    assert not valid
+
+
+def test_find_evidence_path(tmp_path):
+    """Evidence file should be found by name pattern."""
+    import os as _os
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ev_dir = Path(tmpdir) / ".elis" / "pe" / "PE-TEST-01" / "evidence"
+        ev_dir.mkdir(parents=True)
+        (ev_dir / "reset_ack_infra-impl-b.json").write_text("{}")
+
+        with tempfile.TemporaryDirectory() as tmpdir2:
+            test_cwd = Path(tmpdir2)
+            pe_ev_path = test_cwd / ".elis" / "pe" / "PE-TEST-01" / "evidence"
+            pe_ev_path.mkdir(parents=True)
+            (pe_ev_path / "reset_ack_infra-impl-b.json").write_text("{}")
+            orig_cwd = Path.cwd()
+            try:
+                _os.chdir(str(test_cwd))
+                found = MODULE._find_evidence_path("PE-TEST-01", "infra-impl-b")
+                assert found is not None
+                assert "reset_ack_infra-impl-b.json" in str(found)
+            finally:
+                _os.chdir(str(orig_cwd))
+
+
+def test_script_without_evidence():
+    """Calling the script without evidence should exit 1."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            [str(SCRIPT), "--pe-id", "PE-NO-EVIDENCE-01", "--agent", "infra-impl-b"],
+            capture_output=True,
+            text=True,
+            cwd=tmpdir,
+            timeout=30,
+        )
+        assert result.returncode == 1
+        assert "No reset acknowledgement found" in result.stdout
+
+
+def test_script_with_inline_handoff_ack(tmp_path):
+    """Script should detect acknowledgement in HANDOFF.md."""
+    cwd = Path(tmp_path)
+    handoff = cwd / "HANDOFF.md"
+    handoff.write_text(
+        "## Reset Acknowledgement\n\n"
+        "| Field | Value |\n"
+        "|-------|-------|\n"
+        "| agent | infra-impl-b |\n"
+        "| pe | PE-TEST-02 |\n"
+        "| worktree | /opt/elis/agent-worktrees/infra-impl-b |\n"
+        "| branch | feature/test-branch |\n"
+        "| head | abc123def456 |\n"
+        "| timestamp | 2026-05-09T22:00:00Z |\n"
+        "| prior_context_discarded | yes |\n"
+        "| write_scope | yes |\n"
+    )
+    result = subprocess.run(
+        [str(SCRIPT), "--pe-id", "PE-TEST-02", "--agent", "infra-impl-b"],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Expected 0, got {result.returncode}\n{result.stdout}\n{result.stderr}"
+    assert "Reset acknowledgement VALID" in result.stdout

--- a/tests/test_pm_dispatch.py
+++ b/tests/test_pm_dispatch.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Tests for scripts/pm_dispatch.py — dispatch gate orchestration."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "pm_dispatch.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("pm_dispatch", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load()
+
+
+def test_handoff_check_missing_handoff(tmp_path):
+    """Missing HANDOFF.md should produce failures."""
+    import os as _os
+    orig_cwd = _os.getcwd()
+    try:
+        _os.chdir(str(tmp_path))
+        failures = MODULE._check_handoff_for_validator("PE-TEST-01")
+        assert any("HANDOFF.md not found" in f for f in failures)
+    finally:
+        _os.chdir(str(orig_cwd))
+
+
+def test_handoff_check_missing_evidence_dir(tmp_path):
+    """Missing PE evidence directory should produce failures."""
+    cwd = Path(tmp_path)
+    handoff = cwd / "HANDOFF.md"
+    handoff.write_text(
+        "## Summary\n\n...\n\n## Files Changed\n\n...\n\n"
+        "## Acceptance Criteria\n\n...\n\n## Validation Commands\n\n..."
+    )
+    orig_cwd = Path.cwd()
+    try:
+        __import__("os").chdir(str(cwd))
+        failures = MODULE._check_handoff_for_validator("PE-NO-EVIDENCE-01")
+        assert any("evidence directory not found" in f for f in failures)
+    finally:
+        __import__("os").chdir(str(orig_cwd))
+
+
+def test_handoff_check_pass(tmp_path):
+    """Complete HANDOFF.md and evidence dir should pass."""
+    cwd = Path(tmp_path)
+    handoff = cwd / "HANDOFF.md"
+    handoff.write_text(
+        "## Summary\n\n...\n\n## Files Changed\n\n...\n\n"
+        "## Acceptance Criteria\n\n...\n\n## Validation Commands\n\n..."
+    )
+    ev_dir = cwd / ".elis" / "pe" / "PE-EVIDENCE-PASS" / "evidence"
+    ev_dir.mkdir(parents=True)
+    (ev_dir / "implementation_evidence.md").write_text("evidence")
+
+    orig_cwd = Path.cwd()
+    try:
+        __import__("os").chdir(str(cwd))
+        failures = MODULE._check_handoff_for_validator("PE-EVIDENCE-PASS")
+        assert len(failures) == 0, f"Expected 0 failures, got: {failures}"
+    finally:
+        __import__("os").chdir(str(orig_cwd))
+
+
+def test_script_with_unknown_agent():
+    """Calling with unknown agent should exit 1."""
+    result = subprocess.run(
+        [str(SCRIPT), "--pe-id", "PE-TEST", "--agent", "nonexistent-agent",
+         "--dry-run"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 1
+    # Should mention the agent in output
+    assert "nonexistent" in result.stdout or result.stderr
+
+
+def test_script_dry_run_no_crash():
+    """Dry run should not crash."""
+    result = subprocess.run(
+        [str(SCRIPT), "--pe-id", "PE-OPS-WORKTREE-BINDING-02",
+         "--agent", "infra-impl-b", "--dry-run"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    # The script may pass or fail depending on environment, but must not crash
+    assert result.returncode in (0, 1), f"Unexpected return code: {result.returncode}"
+    assert "PM DISPATCH GATE" in result.stdout
+
+
+def test_skip_worktree_check():
+    """--skip-worktree-check should still run other gates."""
+    result = subprocess.run(
+        [str(SCRIPT), "--pe-id", "PE-TEST-SKIP", "--agent", "infra-impl-b",
+         "--dry-run", "--skip-worktree-check"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode in (0, 1)
+    assert "SKIPPED (--skip-worktree-check)" in result.stdout
+
+
+def test_validator_role_checks_handoff():
+    """Validator role should trigger HANDOFF/evidence check."""
+    result = subprocess.run(
+        [str(SCRIPT), "--pe-id", "PE-TEST-VAL", "--agent", "infra-val-a",
+         "--role", "validator", "--dry-run", "--skip-worktree-check",
+         "--skip-handoff-check"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    # With --skip-handoff-check, gate 5 should be skipped
+    assert result.returncode in (0, 1)

--- a/tests/test_pm_dispatch.py
+++ b/tests/test_pm_dispatch.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import importlib.util
-import tempfile
 import subprocess
 from pathlib import Path
 
@@ -24,6 +23,7 @@ MODULE = _load()
 def test_handoff_check_missing_handoff(tmp_path):
     """Missing HANDOFF.md should produce failures."""
     import os as _os
+
     orig_cwd = _os.getcwd()
     try:
         _os.chdir(str(tmp_path))
@@ -74,8 +74,14 @@ def test_handoff_check_pass(tmp_path):
 def test_script_with_unknown_agent():
     """Calling with unknown agent should exit 1."""
     result = subprocess.run(
-        [str(SCRIPT), "--pe-id", "PE-TEST", "--agent", "nonexistent-agent",
-         "--dry-run"],
+        [
+            str(SCRIPT),
+            "--pe-id",
+            "PE-TEST",
+            "--agent",
+            "nonexistent-agent",
+            "--dry-run",
+        ],
         capture_output=True,
         text=True,
         timeout=30,
@@ -88,8 +94,14 @@ def test_script_with_unknown_agent():
 def test_script_dry_run_no_crash():
     """Dry run should not crash."""
     result = subprocess.run(
-        [str(SCRIPT), "--pe-id", "PE-OPS-WORKTREE-BINDING-02",
-         "--agent", "infra-impl-b", "--dry-run"],
+        [
+            str(SCRIPT),
+            "--pe-id",
+            "PE-OPS-WORKTREE-BINDING-02",
+            "--agent",
+            "infra-impl-b",
+            "--dry-run",
+        ],
         capture_output=True,
         text=True,
         timeout=60,
@@ -102,8 +114,15 @@ def test_script_dry_run_no_crash():
 def test_skip_worktree_check():
     """--skip-worktree-check should still run other gates."""
     result = subprocess.run(
-        [str(SCRIPT), "--pe-id", "PE-TEST-SKIP", "--agent", "infra-impl-b",
-         "--dry-run", "--skip-worktree-check"],
+        [
+            str(SCRIPT),
+            "--pe-id",
+            "PE-TEST-SKIP",
+            "--agent",
+            "infra-impl-b",
+            "--dry-run",
+            "--skip-worktree-check",
+        ],
         capture_output=True,
         text=True,
         timeout=60,
@@ -115,9 +134,18 @@ def test_skip_worktree_check():
 def test_validator_role_checks_handoff():
     """Validator role should trigger HANDOFF/evidence check."""
     result = subprocess.run(
-        [str(SCRIPT), "--pe-id", "PE-TEST-VAL", "--agent", "infra-val-a",
-         "--role", "validator", "--dry-run", "--skip-worktree-check",
-         "--skip-handoff-check"],
+        [
+            str(SCRIPT),
+            "--pe-id",
+            "PE-TEST-VAL",
+            "--agent",
+            "infra-val-a",
+            "--role",
+            "validator",
+            "--dry-run",
+            "--skip-worktree-check",
+            "--skip-handoff-check",
+        ],
         capture_output=True,
         text=True,
         timeout=60,


### PR DESCRIPTION
## Summary
Implements fixed-worktree dispatch gate tooling for PE-OPS-WORKTREE-BINDING-02.

## Added
- `scripts/check_fixed_worktrees.py`
- `scripts/check_dispatch_binding.py`
- `scripts/check_reset_ack.py`
- `scripts/check_active_run.py`
- `scripts/pm_dispatch.py`
- tests for dispatch-gate enforcement
- Advisor handoff evidence artefact at `.elis/pe/PE-OPS-WORKTREE-BINDING-02/evidence/ELIS_ADVISOR_HANDOFF_elis-server_2026-05-09.md`

## Enforced gates
- `NO_FIXED_WORKTREE_BINDING_NO_DISPATCH`
- `NO_RESET_ACK_NO_DISPATCH`
- `NO_ACTIVE_RUN_EVIDENCE_NO_IN_PROGRESS_STATUS`
- HANDOFF/evidence required before validator dispatch

## Behaviour
- Audits fixed canonical worktrees only
- Rejects PE-specific runtime worktrees as dispatch targets
- Detects standalone/no-origin repos
- Preserves runtime/bootstrap files
- Keeps GitHub/config/secret/service operations out of scope

## Validation
- Validation: PASS from fixed `infra-val-a` worktree on commit `1d6083e356965e19f999554fd358bfdfa3c238d2`
- Tests: 42/42 passed

## Advisory notes
- Minor parsing edge in `check_reset_ack.py`: `write_scope` exact match versus extended HANDOFF text
- Cosmetic ruff warnings only
- Stale A2A review artefact present in validator worktree; non-blocking

## Scope/security
- No GitHub/config/secret/service changes
- No PE-specific runtime worktree created
