### PR TITLE
PE-OPS-PM-GUARDRAILS-01: enforce PM coordination-only guardrails

### DIFF
--- a/.elis/pe/PE-OPS-PM-GUARDRAILS-01/HANDOFF.md
+++ b/.elis/pe/PE-OPS-PM-GUARDRAILS-01/HANDOFF.md
@@ -1,0 +1,31 @@
+# HANDOFF — PE-OPS-PM-GUARDRAILS-01
+
+## Summary
+This PE defines the PM coordination-only boundary so the role stays read-broad / write-narrow and cannot drift into implementation or validation.
+
+## Expected changes
+- docs/governance/ELIS_Agent_Roles_and_Boundaries.md
+- tests/test_pe_ops_pm_guardrails_01.py
+- /home/samurai/openclaw/workspace-pm/AGENTS.md
+- /home/samurai/openclaw/workspace-pm/SKILLS.md
+- /home/samurai/openclaw/workspace-pm/MEMORY.md only if needed
+- .elis/pe/PE-OPS-PM-GUARDRAILS-01/PE_TASK.md
+- .elis/pe/PE-OPS-PM-GUARDRAILS-01/REVIEW.md (validator-owned; pending)
+- .elis/pe/PE-OPS-PM-GUARDRAILS-01/validation-evidence.md
+
+## Design decisions
+- Keep the PM workspace lean: AGENTS.md remains the entry point and SKILLS.md carries the stronger coordination boundary language.
+- Record the future containerisation requirement now, but do not implement the containerisation layer in this PE.
+- Use a validator checklist that explicitly calls out PM authorship of implementation and validation artefacts.
+
+## Backup / rollback plan
+- Snapshot each live PM workspace file before editing.
+- Keep the snapshot paths in the evidence file.
+- Rollback is byte-for-byte restore from the snapshot, followed by hash re-checks.
+
+## Status packet
+- Base: `origin/main` @ `514bd9eeea9e59a181f87b62ca935df1f511844c`
+- Branch: `feature/pe-ops-pm-guardrails-01-enforce-pm-coordination-only-behaviour`
+- Implementer: `infra-impl-b`
+- Validator: `infra-val-a`
+- PM role: coordination only

--- a/.elis/pe/PE-OPS-PM-GUARDRAILS-01/PE_TASK.md
+++ b/.elis/pe/PE-OPS-PM-GUARDRAILS-01/PE_TASK.md
@@ -1,0 +1,75 @@
+# PE-OPS-PM-GUARDRAILS-01 — PE Task
+
+## PE_ID
+PE-OPS-PM-GUARDRAILS-01
+
+## Objective
+Make the PM coordination-only rule explicit, checkable, and durable before any future containerisation work.
+
+## Base
+`origin/main` @ `514bd9eeea9e59a181f87b62ca935df1f511844c`
+
+## Branch
+`feature/pe-ops-pm-guardrails-01-enforce-pm-coordination-only-behaviour`
+
+## Staffing
+- Implementer: `infra-impl-b`
+- Validator: `infra-val-a`
+
+## Working copy
+- Implementer fixed workspace: `/opt/elis/agent-worktrees/pm/.worktrees/pe-ops-pm-guardrails-01`
+- Live PM workspace: `/home/samurai/openclaw/workspace-pm`
+
+## Approved scope
+- `docs/governance/ELIS_Agent_Roles_and_Boundaries.md`
+- `.elis/pe/PE-OPS-PM-GUARDRAILS-01/PE_TASK.md`
+- `.elis/pe/PE-OPS-PM-GUARDRAILS-01/HANDOFF.md`
+- `.elis/pe/PE-OPS-PM-GUARDRAILS-01/REVIEW.md` (validator-owned; not authored by PM or implementer)
+- `.elis/pe/PE-OPS-PM-GUARDRAILS-01/validation-evidence.md`
+- `tests/test_pe_ops_pm_guardrails_01.py`
+- live PM workspace files:
+  - `/home/samurai/openclaw/workspace-pm/AGENTS.md`
+  - `/home/samurai/openclaw/workspace-pm/SKILLS.md`
+  - `/home/samurai/openclaw/workspace-pm/MEMORY.md` only if needed
+
+## Required governance content
+- PM coordinates only.
+- PM must not edit files.
+- PM must not implement.
+- PM must not validate.
+- PM must not author REVIEW.md / REVIEW_PE*.md.
+- PM needs broad read-only visibility.
+- PM must have narrow or no write authority.
+- Future containerisation must enforce read-broadly/write-narrowly with filesystem permissions and mount design.
+
+## Validator checklist language
+- Confirm the PM did not author implementation artefacts.
+- Confirm the PM did not author validation artefacts.
+- Confirm the live PM workspace updates are limited to the approved files.
+- Confirm no excluded OpenClaw runtime, auth, container, GitHub, A2A, Dash, CLAUDE.md, or CODEX.md files were changed.
+
+## Hard boundaries
+- no containerisation implementation
+- no OpenClaw runtime/config changes
+- no A2A
+- no Dash
+- no GitHub auth changes
+- no model/provider changes
+- no `CLAUDE.md` or `CODEX.md` changes
+- no `docs/openclaw/*`
+- no `openclaw/workspaces/*`
+- no PM direct file edits outside the approved live workspace files
+
+## Acceptance criteria
+- PM coordination-only language is explicit in live PM workspace docs and repo governance.
+- Read-only visibility and narrow/no-write authority are documented.
+- Future containerisation requirement is recorded.
+- Validator checklist language requires confirmation that PM did not author implementation or validation artefacts.
+- `tests/test_pe_ops_pm_guardrails_01.py` checks the new governance language.
+- live workspace edits are backed up first and evidenced.
+
+## Evidence bundle
+- `HANDOFF.md`
+- `validation-evidence.md`
+- backup paths for any live PM workspace files touched
+- before/after hashes for live PM workspace files touched

--- a/.elis/pe/PE-OPS-PM-GUARDRAILS-01/REVIEW.md
+++ b/.elis/pe/PE-OPS-PM-GUARDRAILS-01/REVIEW.md
@@ -1,0 +1,182 @@
+# REVIEW — PE-OPS-PM-GUARDRAILS-01
+
+**Validator:** `infra-val-a`
+**Date:** 2026-05-14T12:27:00+01:00
+**PE:** PE-OPS-PM-GUARDRAILS-01 — Enforce PM coordination-only behaviour
+**Branch:** `feature/pe-ops-pm-guardrails-01-enforce-pm-coordination-only-behaviour`
+**Base:** `origin/main` @ `514bd9eeea9e59a181f87b62ca935df1f511844c`
+**HEAD:** `5fb04d3fe478d1b52a8bfb3fe09e04fe2a80bcb8`
+**Review file:** `.elis/pe/PE-OPS-PM-GUARDRAILS-01/REVIEW.md` (standard path)
+**Validator worktree:** `/opt/elis/agent-worktrees/pm/.worktrees/pe-ops-pm-guardrails-01`
+
+> **Correction note (2026-05-14T12:27):** This review was originally authored at the
+> non-standard path `.elis/pe/PE-OPS-PM-GUARDRAILS-01/REVIEW_PE_OPS_PM_GUARDRAILS_01.md`
+> and has been relocated to the standard path `REVIEW.md`. The verdict, evidence, and all
+> findings are preserved verbatim from the already-approved review. The non-standard file
+> has been superseded by this one.
+
+---
+
+### Verdict
+
+**PASS**
+
+All acceptance criteria are met. No blocking findings.
+
+---
+
+### Role-boundary confirmation
+
+- **Validator** is `infra-val-a` (this review). Validator authored this REVIEW.md only.
+- **Implementer** is `infra-impl-b` — authored all implementation commits in this PE range.
+- **PM** authored no commits, no implementation files, no validation artefacts, and no REVIEW.md in this PE range.
+- PM non-authorship confirmed: `git log 514bd9e..HEAD --format="%an"` shows only `infra-impl-b`.
+
+---
+
+### Gate results
+
+| Check | Result |
+|---|---|
+| `pytest tests/test_pe_ops_pm_guardrails_01.py` | 3 passed |
+| `python scripts/check_agent_scope.py` | clean |
+| Shell script header compliance (§3.2.1) | N/A — no shell scripts in diff |
+| Variable quoting (§3.2.2) | N/A — no shell scripts in diff |
+| Port binding isolation (§3.2.3) | N/A — no compose files in diff |
+| Docker image tag policy (§3.2.4) | N/A — no Dockerfiles or compose files in diff |
+| CI secret handling (§3.2.5) | N/A — no workflow files in diff |
+| Container isolation §5.4 (ELIS mount) | N/A — no compose files in diff |
+| CI job/step naming (§3.2.7) | N/A — no workflow files in diff |
+| YAML schema / lint (§3.2.8) | N/A — no YAML files in diff |
+| PM did not author implementation artefacts | PASS |
+| PM did not author validation artefacts | PASS |
+| No excluded files changed | PASS |
+| Live workspace backup hashes match | PASS |
+| Live workspace after-hashes match evidence | PASS |
+| Governance language present (6/6 assertions) | PASS |
+| Adversarial test (negative-path) | PASS |
+
+---
+
+### Scope
+
+```
+A	.elis/pe/PE-OPS-PM-GUARDRAILS-01/HANDOFF.md
+A	.elis/pe/PE-OPS-PM-GUARDRAILS-01/PE_TASK.md
+A	.elis/pe/PE-OPS-PM-GUARDRAILS-01/validation-evidence.md
+M	docs/governance/ELIS_Agent_Roles_and_Boundaries.md
+A	tests/test_pe_ops_pm_guardrails_01.py
+```
+
+Live PM workspace files (backed up first, then edited):
+- `/home/samurai/openclaw/workspace-pm/AGENTS.md` — added Coordination boundary section
+- `/home/samurai/openclaw/workspace-pm/SKILLS.md` — added 3 PM coordination-only bullets
+- `/home/samurai/openclaw/workspace-pm/MEMORY.md` — added 3 invariant lines
+
+---
+
+### Required fixes
+
+None.
+
+---
+
+### Evidence
+
+#### Test results (independent run)
+```
+$ cd /opt/elis/agent-worktrees/pm/.worktrees/pe-ops-pm-guardrails-01 && python -m pytest -q tests/test_pe_ops_pm_guardrails_01.py -v
+test_pm_guardrails_governance_mentions_coordination_only PASSED
+test_pm_guardrails_governance_mentions_future_containerisation_boundary PASSED
+test_pe_task_requires_validator_checklist_language PASSED
+3 passed in 0.03s
+```
+
+#### Scope check
+```
+$ python scripts/check_agent_scope.py
+Agent scope clean — no secret-pattern files detected in worktree.
+```
+
+#### Commit authorship (no PM commits)
+```
+$ git log 514bd9e..HEAD --format="%h %an <%ae> %s"
+5fb04d3 infra-impl-b <infra-impl-b@users.noreply.github.com> docs(pm): record validation evidence for guardrails PE
+bf4a1e0 infra-impl-b <infra-impl-b@users.noreply.github.com> feat(pm): enforce PM coordination-only guardrails
+```
+
+#### Excluded file check (no excluded patterns in diff)
+```
+$ git diff --name-only 514bd9e..HEAD | grep -iE 'container|openclaw|claude\.md|codex\.md|a2a|dash|github.*auth|model' || echo "PASS: no excluded patterns"
+PASS: no excluded patterns
+```
+
+#### Live PM workspace backup hash verification
+```
+Before (backup file hashes):
+5af8511c  AGENTS.md.bak.20260514T110225Z
+06d9797c  SKILLS.md.bak.20260514T110225Z
+74b158a5  MEMORY.md.bak.20260514T110225Z
+
+After (live file hashes):
+5a21dc36  AGENTS.md   ← matches evidence
+1fbfe343  SKILLS.md   ← matches evidence
+b186e08a  MEMORY.md   ← matches evidence
+```
+
+#### Governance language assertions (all present, count=1 each)
+```
+$ grep -c "coordination-only" docs/governance/ELIS_Agent_Roles_and_Boundaries.md
+1
+$ grep -c "edit implementation files or validation artefacts" docs/governance/ELIS_Agent_Roles_and_Boundaries.md
+1
+$ grep -c "broad read-only visibility" docs/governance/ELIS_Agent_Roles_and_Boundaries.md
+1
+$ grep -c "Future containerisation" docs/governance/ELIS_Agent_Roles_and_Boundaries.md
+1
+$ grep -c "filesystem permissions and mount design" docs/governance/ELIS_Agent_Roles_and_Boundaries.md
+1
+$ grep -c "must explicitly confirm that PM did not author" docs/governance/ELIS_Agent_Roles_and_Boundaries.md
+1
+```
+
+#### PM workspace changes (exact diffs, minimal, approved scope only)
+
+AGENTS.md — added `## Coordination boundary` section:
+```diff
+> ## Coordination boundary
+>
+> - PM coordinates only.
+> - PM may not edit implementation files or validation artefacts.
+> - PM may not implement, validate, or author REVIEW.md / REVIEW_PE*.md.
+> - PM needs broad read-only visibility, but narrow or no write authority.
+> - Future containerisation should enforce that read access stays broad while write access remains narrowly scoped via filesystem permissions and mount design.
+```
+
+SKILLS.md — added 3 bullets:
+```diff
+> - PM coordinates only: do not edit implementation files, do not implement, do not validate, and do not author REVIEW.md / REVIEW_PE*.md.
+> - PM should maintain broad read-only visibility, with narrow or no write authority.
+> - Future containerisation must enforce the read-broadly/write-narrowly boundary with filesystem permissions and mount design.
+```
+
+MEMORY.md — added 3 invariant lines:
+```diff
+> - PM coordinates only: no file edits, no implementation, no validation, and no REVIEW.md / REVIEW_PE*.md authorship.
+> - PM needs broad read-only visibility and narrow or no write authority.
+> - Future containerisation should enforce read-broadly/write-narrowly with filesystem permissions and mount design.
+```
+
+#### Adversarial test (negative-path)
+
+Confirmed that removing `coordination-only` from the governance doc would cause `test_pm_guardrails_governance_mentions_coordination_only` to fail — the test correctly enforces the required language. All 3 tests would break if any of the mandated governance strings were absent.
+
+---
+
+### Reviewer notes
+
+- This review was originally authored at the non-standard path `REVIEW_PE_OPS_PM_GUARDRAILS_01.md` and relocated to the standard path `REVIEW.md`.
+- PM authored no commits in this PE range — all commits are `infra-impl-b`.
+- PM workspace changes are limited to the 3 approved files, with byte-for-byte backup snapshots retained.
+- No containerisation was implemented; the future requirement is documented but not actioned.
+- Worktree is clean on the feature branch.

--- a/.elis/pe/PE-OPS-PM-GUARDRAILS-01/validation-evidence.md
+++ b/.elis/pe/PE-OPS-PM-GUARDRAILS-01/validation-evidence.md
@@ -7,10 +7,29 @@
 - `pytest -q tests/test_pe_ops_pm_guardrails_01.py`
 - read-back of live PM workspace files after backup + edit
 
+## Results captured during implementation
+- `git status -sb` on the fixed worktree: clean after commit on `feature/pe-ops-pm-guardrails-01-enforce-pm-coordination-only-behaviour`
+- `git diff --name-status origin/main..HEAD`:
+  - `A .elis/pe/PE-OPS-PM-GUARDRAILS-01/HANDOFF.md`
+  - `A .elis/pe/PE-OPS-PM-GUARDRAILS-01/PE_TASK.md`
+  - `A .elis/pe/PE-OPS-PM-GUARDRAILS-01/validation-evidence.md`
+  - `M docs/governance/ELIS_Agent_Roles_and_Boundaries.md`
+  - `A tests/test_pe_ops_pm_guardrails_01.py`
+- `python scripts/check_agent_scope.py` → PASS (`Agent scope clean — no secret-pattern files detected in worktree.`)
+- `pytest -q tests/test_pe_ops_pm_guardrails_01.py` → PASS (`3 passed`)
+
 ## Backup paths
 - `/home/samurai/openclaw/workspace-pm/AGENTS.md.bak.20260514T110225Z`
 - `/home/samurai/openclaw/workspace-pm/SKILLS.md.bak.20260514T110225Z`
 - `/home/samurai/openclaw/workspace-pm/MEMORY.md.bak.20260514T110225Z`
+
+## Hashes
+- `AGENTS.md` before: `5af8511c33df5220fffcbeea18eb0ad51f9b15721159895ad70ed1adcefc708a`
+- `AGENTS.md` after:  `5a21dc36668cc06ac1b957b72af7536a4de6db1d918b95ff0054f0cbd6fe4f06`
+- `SKILLS.md` before: `06d9797c1bfab285370f3d208131c22b6e2107cc90b89e1c2db9c0547a6b9938`
+- `SKILLS.md` after:  `1fbfe343003398fdb12dd4e92cc5988667fb27cf7fcea58c5334f2970ec5368c`
+- `MEMORY.md` before: `74b158a5f27f2a859b1644e56ce112b3c72727a142df55221f9cd7bfc45abdfb`
+- `MEMORY.md` after:  `b186e08a074e4191948f1082c8efea4ecc8204b14190b1800dc8491da7f6e3b8`
 
 ## Notes
 - The validator must confirm PM did not author implementation artefacts or validation artefacts.

--- a/.elis/pe/PE-OPS-PM-GUARDRAILS-01/validation-evidence.md
+++ b/.elis/pe/PE-OPS-PM-GUARDRAILS-01/validation-evidence.md
@@ -1,0 +1,18 @@
+# Validation Evidence — PE-OPS-PM-GUARDRAILS-01
+
+## Intended checks
+- `git status -sb`
+- `git diff --name-status origin/main..HEAD`
+- `python scripts/check_agent_scope.py`
+- `pytest -q tests/test_pe_ops_pm_guardrails_01.py`
+- read-back of live PM workspace files after backup + edit
+
+## Backup paths
+- `/home/samurai/openclaw/workspace-pm/AGENTS.md.bak.20260514T110225Z`
+- `/home/samurai/openclaw/workspace-pm/SKILLS.md.bak.20260514T110225Z`
+- `/home/samurai/openclaw/workspace-pm/MEMORY.md.bak.20260514T110225Z`
+
+## Notes
+- The validator must confirm PM did not author implementation artefacts or validation artefacts.
+- `REVIEW.md` is validator-owned and should be authored independently of PM or the implementer.
+- Future containerisation remains out of scope for this PE.

--- a/docs/governance/ELIS_Agent_Roles_and_Boundaries.md
+++ b/docs/governance/ELIS_Agent_Roles_and_Boundaries.md
@@ -19,9 +19,16 @@ May:
 - update governance records
 
 May not:
+- edit implementation files or validation artefacts
+- implement the PE
+- validate the PE
+- author REVIEW.md / REVIEW_PE*.md
 - bypass validator or Gatekeeper controls
-- implement code or docs as the PE owner
 - approve merges on behalf of Carlos
+
+Operating note:
+- PM is a coordination-only role. It needs broad read-only visibility across the workspace, but narrow or no write authority.
+- Future containerisation must enforce this boundary through filesystem permissions and mount design, so read access stays broad while write access remains narrowly scoped.
 
 ### Implementer
 May:
@@ -44,6 +51,9 @@ May not:
 - modify implementation files
 - repair the implementation as part of validation
 - bypass evidence requirements
+
+Checklist note:
+- Validation must explicitly confirm that PM did not author implementation artefacts or validation artefacts for the PE under review.
 
 ### Gatekeeper
 May:
@@ -79,8 +89,13 @@ May:
 - approve or reject major governance decisions
 - authorise push, PR, merge, release, and continuation
 
+### Two-Agent Model
+- Every PE must preserve the ELIS Two-Agent Model: one implementer and one independent validator.
+- PM coordinates the workflow only; PM is not the third implementation or validation agent.
+
 ## Boundary rules
 - Implementer and validator must remain separate.
+- PM must not be substituted for either implementer or validator in the acceptance path.
 - Validators are read-only by default.
 - Recovery checks are read-only until a remediation task is explicitly assigned.
 - No external agent output is authoritative until reflected in GitHub.

--- a/tests/test_pe_ops_pm_guardrails_01.py
+++ b/tests/test_pe_ops_pm_guardrails_01.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOVERNANCE = REPO_ROOT / "docs" / "governance" / "ELIS_Agent_Roles_and_Boundaries.md"
+PE_TASK = REPO_ROOT / ".elis" / "pe" / "PE-OPS-PM-GUARDRAILS-01" / "PE_TASK.md"
+
+
+def test_pm_guardrails_governance_mentions_coordination_only() -> None:
+    text = GOVERNANCE.read_text(encoding="utf-8")
+    assert "PM" in text
+    assert "coordination-only" in text
+    assert "edit implementation files or validation artefacts" in text
+    assert "broad read-only visibility" in text
+
+
+def test_pm_guardrails_governance_mentions_future_containerisation_boundary() -> None:
+    text = GOVERNANCE.read_text(encoding="utf-8")
+    assert "Future containerisation" in text
+    assert "filesystem permissions and mount design" in text
+
+
+def test_pe_task_requires_validator_checklist_language() -> None:
+    text = PE_TASK.read_text(encoding="utf-8")
+    assert "did not author implementation artefacts" in text
+    assert "did not author validation artefacts" in text
+    assert "PM coordinates only" in text


### PR DESCRIPTION
## Summary
Enforce the PM coordination-only rule so the PM role stays read-broad / write-narrow and does not implement, validate, or author review artefacts.

## Scope
- Update governance language in `docs/governance/ELIS_Agent_Roles_and_Boundaries.md`
- Add PM guardrail checks in `tests/test_pe_ops_pm_guardrails_01.py`
- Add PE evidence bundle:
  - `.elis/pe/PE-OPS-PM-GUARDRAILS-01/PE_TASK.md`
  - `.elis/pe/PE-OPS-PM-GUARDRAILS-01/HANDOFF.md`
  - `.elis/pe/PE-OPS-PM-GUARDRAILS-01/validation-evidence.md`
  - `.elis/pe/PE-OPS-PM-GUARDRAILS-01/REVIEW.md`

## Validation
- `python -m pytest -q tests/test_pe_ops_pm_guardrails_01.py` ✅
- `python scripts/check_agent_scope.py` ✅
- Live PM workspace backups/hashes verified ✅

## Notes
- PM did not edit files.
- No runtime/config/auth/container/GitHub/A2A/Dash/model/provider changes.
- Non-standard review filename was superseded by standard `.elis/pe/PE-OPS-PM-GUARDRAILS-01/REVIEW.md`.
