### PR TITLE
PE-OPS-A2A-01: add Phase 1 A2A communication spec

### DIFF
--- a/.elis/pe/PE-OPS-A2A-01/PE_TASK.md
+++ b/.elis/pe/PE-OPS-A2A-01/PE_TASK.md
@@ -13,6 +13,43 @@ This PE defines the initial A2A operating surface for structured messages, evide
 - `CURRENT_PE.md`
 - `.elis/pe/PE-OPS-A2A-01/PE_TASK.md`
 
+## Opening packet
+- Lane: Strict
+- Baseline HEAD: `20070320566b9c587eb6842598da74d74836e744`
+- Branch: `feature/pe-ops-a2a-01-phase-1-communication-matrix-clean-opening`
+- Implementer: `infra-impl-b`
+- Validator: `infra-val-a`
+
+### Approved first-pass files
+- `CURRENT_PE.md`
+- `.elis/pe/PE-OPS-A2A-01/PE_TASK.md`
+- `docs/governance/ELIS_A2A_Communication_Matrix.md`
+- `docs/openclaw/ELIS_A2A_GATEWAY_SPEC.md`
+
+### Explicit exclusions
+- `schemas/a2a_envelope.schema.json`
+- runtime code
+- service units
+- OpenClaw config
+- Hermes config
+- credentials/secrets/auth
+- live routing changes
+
+### Evidence requirements
+- baseline HEAD on `origin/main`
+- clean PM worktree before opening
+- plan-complete `CURRENT_PE.md` before opening
+- commit SHA, branch, diff summary, and clean status after opening
+
+### Hard stops
+- no A2A runtime deployment
+- no service restart
+- no OpenClaw/Hermes config mutation
+- no credentials/secrets/auth changes
+- no live inter-agent routing change
+- no branch creation before PO approval
+- no implementer/validator dispatch before PO approval
+
 ## Core constraints
 - A2A gateway remains local-only on `127.0.0.1`
 - Phase-1 agents are only:

--- a/.elis/pe/PE-OPS-A2A-01/REVIEW.md
+++ b/.elis/pe/PE-OPS-A2A-01/REVIEW.md
@@ -1,0 +1,52 @@
+# REVIEW.md — PE-OPS-A2A-01
+
+## Metadata
+- PE: `PE-OPS-A2A-01`
+- Branch: `feature/pe-ops-a2a-01-phase-1-communication-matrix-clean-opening`
+- Validated commit: `bc1ebf02c1367d9af2bc918f796c3029ee98cb11`
+- Validator: `infra-val-a`
+- Scope: Phase 1 protocol/spec only
+
+## Evidence
+```text
+$ git show --format=fuller --no-patch bc1ebf02c1367d9af2bc918f796c3029ee98cb11
+commit bc1ebf02c1367d9af2bc918f796c3029ee98cb11
+Author:     infra-impl-b <infra-impl-b@openclaw.local>
+AuthorDate: Sun May 17 22:31:41 2026 +0100
+Commit:     infra-impl-b <infra-impl-b@openclaw.local>
+CommitDate: Sun May 17 22:31:41 2026 +0100
+
+    docs(a2a): add phase 1 governance and gateway spec
+
+$ git status -sb
+## feature/pe-ops-a2a-01-phase-1-communication-matrix-clean-opening
+
+$ git status --porcelain=v1
+<empty>
+```
+
+## Checks performed
+- Reviewed `docs/governance/ELIS_A2A_Communication_Matrix.md`.
+- Reviewed `docs/openclaw/ELIS_A2A_GATEWAY_SPEC.md`.
+- Confirmed Phase 1 is limited to `elis-advisor`, `elis-pm`, and `elis-supervisor`.
+- Confirmed only the three allowed communication pairs are defined.
+- Confirmed A2A is local-only on `127.0.0.1:24001`.
+- Confirmed the docs keep the surface read-only / governance-safe for Phase 1.
+- Confirmed Discord remains the PO-facing interface.
+- Confirmed prohibited actions remain prohibited: implementation, official validation, GitHub writes, service restarts, config edits, secrets, PR/merge, PO approvals, and agent inventory exposure.
+- Confirmed future runtime gates are explicitly deferred out of Phase 1.
+- Confirmed no schema/runtime/config/auth/service/live-routing files were changed in the implementation commit.
+- Confirmed no runtime deployment, service restart, or live routing change occurred.
+
+## Findings
+The Phase 1 docs are internally consistent and adequate for a governed specification/readiness pass.
+
+The only caveat is intentional: the documents define the future runtime gates separately and do not attempt to implement them in this phase, which is correct for the approved scope.
+
+## Verdict
+PASS_WITH_NOTES
+
+## Notes
+- Implementation was correctly confined to the two approved docs.
+- The temporary validation worktree was clean and correctly bound to the approved branch/HEAD.
+- Original dirty validator worktree remained untouched.

--- a/CURRENT_PE.md
+++ b/CURRENT_PE.md
@@ -46,7 +46,7 @@
 | PE-GOV-01   | governance      | infra-impl-b         | infra-val-a        | feature/pe-gov-01-operating-protocol-templates    | merged          | 2026-05-03   |
 | PE-GOV-RISK-TIER-01 | governance | infra-impl-a         | infra-val-b        | feature/pe-gov-risk-tier-01-add-risk-tiered-pe-protocol | blocked         | 2026-05-06   |
 | PE-OPS-FIXED-WORKSPACES-01 | fixed-workspaces | infra-impl-b | infra-val-a | feature/pe-ops-fixed-workspaces-01-adopt-fixed-agent-workspace-and-github-write-boundary-model | merged | 2026-05-07 |
-| PE-OPS-A2A-01 | ops | infra-impl-b | infra-val-a | feature/pe-ops-a2a-01-phase-1-communication-matrix | planning | 2026-05-17 |
+| PE-OPS-A2A-01 | ops | infra-impl-b | infra-val-a | feature/pe-ops-a2a-01-phase-1-communication-matrix-clean-opening | planning | 2026-05-17 |
 | PE-OPS-GITHUB-01 | github          | infra-impl-a         | infra-val-b        | feature/pe-ops-github-01-elis-github-agent-role-and-permission-model | merged          | 2026-05-06   |
 | PE-OPS-GITHUB-02 | github | infra-impl-b | infra-val-a | feature/pe-ops-github-02-deploy-elis-github-agent | merged | 2026-05-08 |
 | PE-OPS-GITHUB-AGENT-ENFORCEMENT-01 | github | infra-impl-a | infra-val-b | feature/pe-ops-github-agent-enforcement-01-deterministic-github-agent-source-path | planning | 2026-05-10 |

--- a/CURRENT_PE.md
+++ b/CURRENT_PE.md
@@ -21,10 +21,10 @@
 
 | Field   | Value |
 |---------|-------|
-| PE      | — |
-| Branch  | — |
+| PE      | PE-OPS-A2A-01 |
+| Branch  | feature/pe-ops-a2a-01-phase-1-communication-matrix-clean-opening |
 
-> **Plan-complete mode.** No active PE.
+> **Strict mode.** Active PE: PE-OPS-A2A-01 — Phase-1 A2A Communication Matrix.
 
 ---
 
@@ -32,10 +32,10 @@
 
 | Agent       | Role |
 |-------------|------|
-| infra-impl-b | — |
-| infra-val-a | — |
+| infra-impl-b | Implementer |
+| infra-val-a | Validator |
 
-> No active PE roles.
+> Active PE roles assigned for PE-OPS-A2A-01.
 
 ---
 
@@ -46,7 +46,7 @@
 | PE-GOV-01   | governance      | infra-impl-b         | infra-val-a        | feature/pe-gov-01-operating-protocol-templates    | merged          | 2026-05-03   |
 | PE-GOV-RISK-TIER-01 | governance | infra-impl-a         | infra-val-b        | feature/pe-gov-risk-tier-01-add-risk-tiered-pe-protocol | blocked         | 2026-05-06   |
 | PE-OPS-FIXED-WORKSPACES-01 | fixed-workspaces | infra-impl-b | infra-val-a | feature/pe-ops-fixed-workspaces-01-adopt-fixed-agent-workspace-and-github-write-boundary-model | merged | 2026-05-07 |
-| PE-OPS-A2A-01 | ops | infra-impl-b | infra-val-a | feature/pe-ops-a2a-01-phase-1-communication-matrix | merged | 2026-05-09 |
+| PE-OPS-A2A-01 | ops | infra-impl-b | infra-val-a | feature/pe-ops-a2a-01-phase-1-communication-matrix | planning | 2026-05-17 |
 | PE-OPS-GITHUB-01 | github          | infra-impl-a         | infra-val-b        | feature/pe-ops-github-01-elis-github-agent-role-and-permission-model | merged          | 2026-05-06   |
 | PE-OPS-GITHUB-02 | github | infra-impl-b | infra-val-a | feature/pe-ops-github-02-deploy-elis-github-agent | merged | 2026-05-08 |
 | PE-OPS-GITHUB-AGENT-ENFORCEMENT-01 | github | infra-impl-a | infra-val-b | feature/pe-ops-github-agent-enforcement-01-deterministic-github-agent-source-path | planning | 2026-05-10 |
@@ -269,6 +269,7 @@ PM housekeeping entries (prefix `PM-CHORE-XX`):
 | PM-CHORE-99  | Closed PE-OPS-ADVISOR-HANDOFF-01 as merged (PR #430, merge SHA `21e348d87c8e8874a5b3201307c3c7a2e1e0d190`). Plan-complete mode restored: PE and Branch cleared; no active PE; PE-OPS-ADVISOR-HANDOFF-01 registry row updated to merged. One-time PO-approved fallback used after closing wrong-path PR #429; wrong source-path evidence preserved. Follow-up defects preserved: PE-OPS-GITHUB-AGENT-ENFORCEMENT-01 must implement RULE_DEFINED_PR_SOURCE_PATH; GitHub Agent must not default to its runtime workspace as PR source; GitHub Agent must use GITHUB_AGENT_READS_SOURCE_WRITES_REMOTE; GitHub Agent identity must be corrected away from rochasamurai in a future credentials/security PE; OpenClaw agent workspace readiness must include .openclaw creation checks. | 2026-05-10 |
 | PM-CHORE-100 | Closed PE-OPS-GITHUB-AGENT-ENFORCEMENT-01 as merged (PR #431, final PR head `01cb8d6fdad7ec83f46811bb1b9972d3cd3f5ebd`, merge SHA `b9126c4f3f9361ddc549b2733789599be383caf3`). Plan-complete mode restored: PE and Branch cleared; no active PE; PE-OPS-GITHUB-AGENT-ENFORCEMENT-01 registry row updated to merged. TEMPORARY_HUMAN_GITHUB_AUTH_RISK was recorded for this PR; follow-up credentials/security PE remains required to replace `rochasamurai` with the proper GitHub Agent service identity. | 2026-05-10 |
 | PM-CHORE-100 | Opened PE-OPS-GITHUB-AGENT-ENFORCEMENT-01 (Enforce GitHub Agent Path for GitHub Operations) with `infra-impl-a` as Implementer and `infra-val-b` as Validator per alternation rule. Opening packet only: CURRENT_PE.md and PE task packet updated; no registry/status corrections beyond the opening row; no secret/token/permission/config changes, no PM direct GitHub writes, no PE-specific runtime worktrees. | 2026-05-10 |
+| PM-CHORE-101 | Opened PE-OPS-A2A-01 (Phase-1 A2A Communication Matrix) on clean baseline branch `feature/pe-ops-a2a-01-phase-1-communication-matrix-clean-opening` from `origin/main` at `20070320566b9c587eb6842598da74d74836e744`. Scope: Strict lane, Phase 1 protocol/spec metadata only, local-only A2A communication boundaries, and read-only governance/evidence rules; no runtime deployment, no config/auth/service changes, and no live routing changes. | 2026-05-17 |
 
 
 Alternation rule:

--- a/docs/governance/ELIS_A2A_Communication_Matrix.md
+++ b/docs/governance/ELIS_A2A_Communication_Matrix.md
@@ -275,3 +275,35 @@ The following actions are **strictly prohibited** through the A2A channel:
 - **ELIS Supervisor** is also deployed on Hermes
   (`docs/hermes/ELIS_SUPERVISOR_CHANNEL_BINDING.md`). Its A2A identity is `elis-supervisor`.
 - The A2A gateway runs independently of both Hermes and OpenClaw, on `127.0.0.1:24001`.
+
+---
+
+## 13. Phase 1 Blocker Classifications
+
+When Phase 1 evidence is incomplete or a boundary is violated, classify the blocker explicitly:
+
+- `A2A_IDENTITY_UNAUTHORISED`
+- `A2A_PAIR_DISALLOWED`
+- `A2A_LOOPBACK_VIOLATION`
+- `A2A_READ_ONLY_BOUNDARY_BROKEN`
+- `A2A_SCHEMA_OR_ENVELOPE_MISMATCH`
+- `A2A_FUTURE_RUNTIME_GATED`
+- `A2A_DISPATCH_BLOCKED`
+
+These classifications are advisory/governance labels only. They do not authorise runtime execution, implementation dispatch, or live routing.
+
+---
+
+## 14. Future Runtime Gates (Not in Phase 1)
+
+Any live A2A implementation requires separate approval and must satisfy all of the following before deployment:
+
+1. approved schema artefact and validation tests;
+2. runtime code review and commit evidence;
+3. service-unit or launch-wrapper review;
+4. OpenClaw/Hermes config review if any runtime binding is introduced;
+5. explicit no-secrets/no-auth-change check;
+6. live routing change approval;
+7. rollback plan and verification evidence.
+
+Phase 1 does not satisfy these gates; it only defines the governed protocol/spec boundary.

--- a/docs/openclaw/ELIS_A2A_GATEWAY_SPEC.md
+++ b/docs/openclaw/ELIS_A2A_GATEWAY_SPEC.md
@@ -299,3 +299,19 @@ kill -TERM <PID>
 - Message encryption
 - Authentication/authorisation beyond identity validation
 - Full A2A agent discovery
+
+---
+
+## 12. Future Runtime Gates
+
+Before any live A2A implementation is allowed, the following gates must be approved and evidenced separately:
+
+1. schema artefact exists and validates;
+2. runtime code is reviewed and committed;
+3. launch mechanism / service unit is reviewed;
+4. OpenClaw/Hermes config impact is reviewed (if any);
+5. no credentials/secrets/auth changes are required;
+6. live routing change is explicitly approved;
+7. rollback/verification evidence is captured.
+
+Phase 1 does not include these gates; it only defines the specification for later controlled implementation.


### PR DESCRIPTION
PE ID: PE-OPS-A2A-01

Source branch: feature/pe-ops-a2a-01-phase-1-communication-matrix-clean-opening
Source worktree: /opt/elis/agent-worktrees/infra-val-a-a2a-01
Target branch: main
Origin/main baseline: 20070320566b9c587eb6842598da74d74836e744
Final validated HEAD: 892e85b99b15e9f52b2591d44ab4c10c21f640fb
Opening commit: 99d29c8c05dbac4fca1a2623c622b2162faec01c
Implementation commit: bc1ebf02c1367d9af2bc918f796c3029ee98cb11
Validation/review commit: 892e85b99b15e9f52b2591d44ab4c10c21f640fb
Metadata-correction commit: 83a0fa2d7562121aa2c6fe2f00a911343ad5b1f2
Verdict: PASS_WITH_NOTES accepted by PO

Changed files:
- CURRENT_PE.md
- .elis/pe/PE-OPS-A2A-01/PE_TASK.md
- .elis/pe/PE-OPS-A2A-01/REVIEW.md
- docs/governance/ELIS_A2A_Communication_Matrix.md
- docs/openclaw/ELIS_A2A_GATEWAY_SPEC.md

Checks performed:
- branch/HEAD check
- file scope check
- prohibited-file check
- runtime/config/auth/service boundary check
- schema/runtime/live-routing exclusion check
- author/identity check
- current-main pre-PR diff verification
- CURRENT_PE.md branch metadata correction verified

Notes:
- Phase 1 protocol/spec only
- Discord remains PO-facing
- no schema/runtime/config/auth/service changes
- no runtime deployment, service restart, or live routing change
- future runtime gates are deferred

/opt/elis/repo is not used as the handoff source while it remains dirty/on the containers branch.