### PR TITLE
test: accept canonical CURRENT_PE table closeout format

### DIFF
--- a/tests/test_pm_dispatch_contract.py
+++ b/tests/test_pm_dispatch_contract.py
@@ -22,8 +22,8 @@ def test_current_pe_marks_the_active_pe_and_roles() -> None:
     closeout_state = all(
         marker in text
         for marker in (
-            "PE: —",
-            "Branch: —",
+            "| PE      | — |",
+            "| Branch  | — |",
             "plan-complete / no active PE",
             "no active PE roles",
             "PE-OPS-DISPATCH-WRAPPER-HARDENING-01",


### PR DESCRIPTION
## Summary
This narrow test-hardening PR updates the dispatch contract test so it accepts the canonical table-based CURRENT_PE.md closeout format.

## Scope
- `tests/test_pm_dispatch_contract.py` only

## Expected closeout markers
- `| PE      | — |`
- `| Branch  | — |`
- `plan-complete / no active PE`
- `no active PE roles`
- `PE-OPS-DISPATCH-WRAPPER-HARDENING-01`
- `merged`

## Verification
- `python -m pytest -q tests/test_pm_dispatch_contract.py`
- `python -m black --check tests/test_pm_dispatch_contract.py`
- `python scripts/check_current_pe.py`

## Confirmations
- PR #449 untouched
- CURRENT_PE.md untouched
- No runtime/config/auth/service changes
- No service restart