### PR TITLE
Test-hardening: accept closeout current PE state

### DIFF
--- a/tests/test_pm_dispatch.py
+++ b/tests/test_pm_dispatch.py
@@ -122,7 +122,10 @@ CLOSEOUT_STATE = {
     ],
     "required_rules": [],
     "phase_1_gates": [],
-    "tests": ["tests/test_check_current_pe.py", "tests/test_check_pe_opening_context.py"],
+    "tests": [
+        "tests/test_check_current_pe.py",
+        "tests/test_check_pe_opening_context.py",
+    ],
     "rollback": "Restore CURRENT_PE.md and .elis/state/current_pe.json to the merged closeout snapshot if needed.",
     "hard_stops": [
         "do not change runtime/config/auth/service files",
@@ -233,7 +236,9 @@ def _make_scoped_files(
     include_runtime_noise: bool = True,
 ) -> None:
     _write_scope_file(root, "CURRENT_PE.md", _state_markdown(state))
-    _write_scope_file(root, ".elis/state/current_pe.json", json.dumps(state, indent=2) + "\n")
+    _write_scope_file(
+        root, ".elis/state/current_pe.json", json.dumps(state, indent=2) + "\n"
+    )
     _write_scope_file(
         root,
         ".elis/pe/PE-OPS-CURRENT-PE-STATE-01/PE_TASK.md",

--- a/tests/test_pm_dispatch.py
+++ b/tests/test_pm_dispatch.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "pm_dispatch.py"
 STATE_PATH = Path(__file__).resolve().parents[1] / ".elis" / "state" / "current_pe.json"
 
@@ -24,18 +26,119 @@ def _load():
 MODULE = _load()
 CURRENT_STATE = json.loads(STATE_PATH.read_text(encoding="utf-8"))
 
-
-def _write_scope_file(root: Path, rel: str, content: str = "placeholder\n") -> None:
-    path = root / rel
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
-
-
-def _make_scoped_files(root: Path, include_runtime_noise: bool = True) -> None:
-    _write_scope_file(
-        root,
+ACTIVE_STATE = {
+    "pe_id": "PE-OPS-CURRENT-PE-STATE-01",
+    "objective": "Move canonical PE machine state out of CURRENT_PE.md into structured state. CURRENT_PE.md becomes a validated human-readable summary only.",
+    "branch": "feature/pe-ops-current-pe-state-01",
+    "baseline": "origin/main @ f686e92ac64f9d174d2cf64b781ce95312d7a090",
+    "lane": "Strict",
+    "implementer": "infra-impl-b",
+    "validator": "infra-val-a",
+    "current_state": "planning",
+    "file_scope": [
         "CURRENT_PE.md",
-        """# Current PE Assignment
+        ".elis/state/current_pe.json",
+        "schemas/current_pe.schema.json",
+        "scripts/check_current_pe.py",
+        "scripts/check_pe_opening_context.py",
+        "scripts/pm_dispatch.py",
+        "tests/test_check_current_pe.py",
+        "tests/test_check_pe_opening_context.py",
+        "tests/test_pm_dispatch.py",
+        "tests/test_pm_dispatch_contract.py",
+        "docs/governance/ELIS_Current_PE_State_Model.md",
+        ".elis/pe/PE-OPS-CURRENT-PE-STATE-01/PE_TASK.md",
+        ".elis/pe/PE-OPS-CURRENT-PE-STATE-01/HANDOFF.md",
+    ],
+    "runtime_bootstrap_allowlist": [
+        "AGENTS.md",
+        "TOOLS.md",
+        "USER.md",
+        "HEARTBEAT.md",
+        "SOUL.md",
+        "IDENTITY.md",
+        ".openclaw/",
+        "memory/",
+        "skills/",
+        "canvas/",
+    ],
+    "required_rules": [
+        "PRESERVED_RUNTIME_BOOTSTRAP_FILES_ARE_NOT_DISPATCH_BLOCKERS_RULE",
+        "NEW_PE_REQUIRES_FRESH_THREAD_AND_RESET_ACK_RULE",
+        "DISPATCH_CONTRACT_MUST_USE_TARGET_AGENT_WORKSPACE_RULE",
+        "FRESH_VALIDATOR_SUBAGENT_DISPATCH_RULE",
+        "VALIDATOR_MUST_NOT_USE_PM_WORKTREE_RULE",
+        "VALIDATION_PASS_REQUIRES_PRIOR_RESET_ACK_RULE",
+        "TARGET_REF_AVAILABLE_BEFORE_AGENT_BINDING_RULE",
+        "FIXED_AGENT_WORKTREE_READINESS_BEFORE_DISPATCH_RULE",
+        "ROLE_CORRECT_GIT_AUTHOR_IDENTITY_RULE",
+        "COMPLETE_BRANCH_FILE_SCOPE_EVIDENCE_RULE",
+    ],
+    "phase_1_gates": ["dry-run", "check", "generate"],
+    "tests": [
+        "tests/test_pm_dispatch.py",
+        "tests/test_pm_dispatch_contract.py",
+        "tests/test_po_dispatch.py",
+    ],
+    "rollback": "Revert only the approved scoped files to the accepted origin/main baseline and keep OpenClaw/Hermes configuration unchanged.",
+    "hard_stops": [
+        "do not create the branch here",
+        "do not call Discord APIs",
+        "do not send live messages",
+        "do not call OpenClaw live dispatch actions",
+        "do not mutate repo state outside approved scope",
+        "do not alter CURRENT_PE.md outside approved scope",
+        "do not change OpenClaw/Hermes config",
+        "do not change auth or secret state",
+        "do not restart services",
+        "do not replace live dispatch behaviour",
+        "do not push, open PRs, or merge without PO approval",
+    ],
+    "live_dispatch_statement": "Phase 1 only generates and checks dispatch contracts; it does not call live dispatch APIs or Discord APIs.",
+    "runtime_bootstrap_policy": "Approved OpenClaw runtime/bootstrap files are non-blocking only when they are untracked or workspace-local, not staged, not part of the PE-approved file scope, not secret-bearing, not modified tracked repository files, not being committed, and not masking unsafe PE residue.",
+}
+
+CLOSEOUT_STATE = {
+    "pe_id": "—",
+    "objective": "PE-OPS-CURRENT-PE-STATE-01 is merged; no active PE remains.",
+    "branch": "—",
+    "baseline": "origin/main @ 26254d3556526ef9ef59f399f51d5a7c0e837c6a",
+    "lane": "—",
+    "implementer": "—",
+    "validator": "—",
+    "current_state": "plan-complete",
+    "file_scope": ["CURRENT_PE.md", ".elis/state/current_pe.json"],
+    "runtime_bootstrap_allowlist": [
+        "AGENTS.md",
+        "TOOLS.md",
+        "USER.md",
+        "HEARTBEAT.md",
+        "SOUL.md",
+        "IDENTITY.md",
+        ".openclaw/",
+        "memory/",
+        "skills/",
+        "canvas/",
+    ],
+    "required_rules": [],
+    "phase_1_gates": [],
+    "tests": ["tests/test_check_current_pe.py", "tests/test_check_pe_opening_context.py"],
+    "rollback": "Restore CURRENT_PE.md and .elis/state/current_pe.json to the merged closeout snapshot if needed.",
+    "hard_stops": [
+        "do not change runtime/config/auth/service files",
+        "do not restart services",
+        "do not resume PE-OPS-A2A-RUNTIME-01 yet",
+    ],
+    "live_dispatch_statement": "No active PE remains; the structured state is now a closeout snapshot.",
+    "runtime_bootstrap_policy": "Approved OpenClaw runtime/bootstrap files remain non-blocking only when they are untracked or workspace-local, not staged, not part of the closeout scope, not secret-bearing, not modified tracked repository files, not being committed, and not masking unsafe residue.",
+}
+
+STATE_CASES = [ACTIVE_STATE, CLOSEOUT_STATE]
+
+
+def _state_markdown(state: dict[str, object]) -> str:
+    if state["current_state"] == "planning":
+        return """# Current PE Assignment
 
 ## Release context
 
@@ -67,13 +170,70 @@ def _make_scoped_files(root: Path, include_runtime_noise: bool = True) -> None:
 | PE-ID       | Domain          | Implementer-agentId  | Validator-agentId  | Branch                                            | Status          | Last-updated |
 |-------------|-----------------|----------------------|--------------------|---------------------------------------------------|-----------------|--------------|
 | PE-OPS-CURRENT-PE-STATE-01 | ops | infra-impl-b | infra-val-a | feature/pe-ops-current-pe-state-01 | planning | 2026-05-19 |
-""",
-    )
-    _write_scope_file(
-        root,
-        ".elis/state/current_pe.json",
-        json.dumps(CURRENT_STATE, indent=2) + "\n",
-    )
+"""
+
+    return """# Current PE Assignment
+
+> Maintained by PM. Update ALL fields at the start of every new PE or release.
+> Both agents read this file as Step 0. It is the only file that needs editing
+> when switching release lines.
+
+---
+
+## Release context
+
+| Field          | Value                                                          |
+|----------------|----------------------------------------------------------------|
+| Release        | ELIS SLR Agent — Multi-Agent Implementation Plan · v2.0.1     |
+| Base branch    | main                                                           |
+| Plan file      | ELIS_MultiAgent_Implementation_Plan_v2_0.md                   |
+| Plan location  | repo root                                                      |
+
+---
+
+## Current PE
+
+| Field   | Value |
+|---------|-------|
+| PE      | — |
+| Branch  | — |
+
+> **plan-complete / no active PE. `PE-OPS-CURRENT-PE-STATE-01` merged on `origin/main`.**
+
+## Agent roles
+
+| Agent | Role |
+|-------|------|
+| — | — |
+| — | — |
+
+> no active PE roles.
+
+
+---
+
+## Active PE Registry
+
+| PE-ID       | Domain          | Implementer-agentId  | Validator-agentId  | Branch                                            | Status          | Last-updated |
+|-------------|-----------------|----------------------|--------------------|---------------------------------------------------|-----------------|--------------|
+| PE-OPS-CURRENT-PE-STATE-01 | ops | infra-impl-b | infra-val-a | feature/pe-ops-current-pe-state-01 | merged | 2026-05-20 |
+"""
+
+
+def _write_scope_file(root: Path, rel: str, content: str = "placeholder\n") -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_scoped_files(
+    root: Path,
+    *,
+    state: dict[str, object],
+    include_runtime_noise: bool = True,
+) -> None:
+    _write_scope_file(root, "CURRENT_PE.md", _state_markdown(state))
+    _write_scope_file(root, ".elis/state/current_pe.json", json.dumps(state, indent=2) + "\n")
     _write_scope_file(
         root,
         ".elis/pe/PE-OPS-CURRENT-PE-STATE-01/PE_TASK.md",
@@ -108,51 +268,53 @@ def _init_git_repo(root: Path) -> None:
     subprocess.run(["git", "init", "-q"], cwd=root, check=True)
 
 
-def test_build_packet_uses_the_current_pe_state() -> None:
+@pytest.mark.parametrize("state", STATE_CASES)
+def test_build_packet_uses_the_current_pe_state(state: dict[str, object]) -> None:
     packet = MODULE.build_packet(
-        state=CURRENT_STATE,
-        pe_id="PE-OPS-CURRENT-PE-STATE-01",
-        branch="feature/pe-ops-current-pe-state-01",
-        baseline="origin/main @ f686e92ac64f9d174d2cf64b781ce95312d7a090",
-        lane="Strict",
-        implementer="infra-impl-b",
-        validator="infra-val-a",
+        state=state,
+        pe_id=str(state["pe_id"]),
+        branch=str(state["branch"]),
+        baseline=str(state["baseline"]),
+        lane=str(state["lane"]),
+        implementer=str(state["implementer"]),
+        validator=str(state["validator"]),
     )
 
-    assert packet.phase == "planning"
+    assert packet.phase == str(state["current_state"])
     assert packet.mode == "dry-run"
-    assert packet.objective == CURRENT_STATE["objective"]
-    assert packet.file_scope == tuple(CURRENT_STATE["file_scope"])
+    assert packet.objective == state["objective"]
+    assert packet.file_scope == tuple(state["file_scope"])
     assert packet.runtime_bootstrap_allowlist == tuple(
-        CURRENT_STATE["runtime_bootstrap_allowlist"]
+        state["runtime_bootstrap_allowlist"]
     )
-    assert packet.required_rules == tuple(CURRENT_STATE["required_rules"])
-    assert packet.phase_1_gates == tuple(CURRENT_STATE["phase_1_gates"])
-    assert packet.tests == tuple(CURRENT_STATE["tests"])
-    assert packet.live_dispatch_statement == CURRENT_STATE["live_dispatch_statement"]
-    assert packet.runtime_bootstrap_policy == CURRENT_STATE["runtime_bootstrap_policy"]
+    assert packet.required_rules == tuple(state["required_rules"])
+    assert packet.phase_1_gates == tuple(state["phase_1_gates"])
+    assert packet.tests == tuple(state["tests"])
+    assert packet.live_dispatch_statement == state["live_dispatch_statement"]
+    assert packet.runtime_bootstrap_policy == state["runtime_bootstrap_policy"]
 
 
-def test_render_contract_json_includes_current_state() -> None:
+@pytest.mark.parametrize("state", STATE_CASES)
+def test_render_contract_json_includes_current_state(state: dict[str, object]) -> None:
     packet = MODULE.build_packet(
-        state=CURRENT_STATE,
-        pe_id="PE-OPS-CURRENT-PE-STATE-01",
-        branch="feature/pe-ops-current-pe-state-01",
-        baseline="origin/main @ f686e92ac64f9d174d2cf64b781ce95312d7a090",
-        lane="Strict",
-        implementer="infra-impl-b",
-        validator="infra-val-a",
+        state=state,
+        pe_id=str(state["pe_id"]),
+        branch=str(state["branch"]),
+        baseline=str(state["baseline"]),
+        lane=str(state["lane"]),
+        implementer=str(state["implementer"]),
+        validator=str(state["validator"]),
     )
 
     payload = json.loads(MODULE.render_contract_json(packet))
-    assert payload["pe_id"] == "PE-OPS-CURRENT-PE-STATE-01"
-    assert payload["branch"] == "feature/pe-ops-current-pe-state-01"
-    assert payload["objective"] == CURRENT_STATE["objective"]
+    assert payload["pe_id"] == state["pe_id"]
+    assert payload["branch"] == state["branch"]
+    assert payload["objective"] == state["objective"]
     assert payload["runtime_bootstrap_allowlist"] == list(
-        CURRENT_STATE["runtime_bootstrap_allowlist"]
+        state["runtime_bootstrap_allowlist"]
     )
-    assert payload["required_rules"] == list(CURRENT_STATE["required_rules"])
-    assert payload["tests"] == list(CURRENT_STATE["tests"])
+    assert payload["required_rules"] == list(state["required_rules"])
+    assert payload["tests"] == list(state["tests"])
 
 
 def test_classify_workspace_line_allows_preserved_runtime_bootstrap_noise() -> None:
@@ -173,23 +335,23 @@ def test_check_mode_passes_when_only_current_scope_and_allowed_noise_exist(
     tmp_path: Path,
 ) -> None:
     _init_git_repo(tmp_path)
-    _make_scoped_files(tmp_path, include_runtime_noise=True)
+    _make_scoped_files(tmp_path, state=ACTIVE_STATE, include_runtime_noise=True)
 
     result = subprocess.run(
         [
             str(SCRIPT),
             "--pe-id",
-            "PE-OPS-CURRENT-PE-STATE-01",
+            str(ACTIVE_STATE["pe_id"]),
             "--branch",
-            "feature/pe-ops-current-pe-state-01",
+            str(ACTIVE_STATE["branch"]),
             "--baseline",
-            "origin/main @ f686e92ac64f9d174d2cf64b781ce95312d7a090",
+            str(ACTIVE_STATE["baseline"]),
             "--lane",
-            "Strict",
+            str(ACTIVE_STATE["lane"]),
             "--implementer",
-            "infra-impl-b",
+            str(ACTIVE_STATE["implementer"]),
             "--validator",
-            "infra-val-a",
+            str(ACTIVE_STATE["validator"]),
             "--mode",
             "check",
             "--repo-root",
@@ -208,24 +370,24 @@ def test_check_mode_passes_when_only_current_scope_and_allowed_noise_exist(
 
 def test_check_mode_fails_on_dirty_files_outside_scope(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
-    _make_scoped_files(tmp_path, include_runtime_noise=True)
+    _make_scoped_files(tmp_path, state=ACTIVE_STATE, include_runtime_noise=True)
     _write_scope_file(tmp_path, "notes/todo.txt")
 
     result = subprocess.run(
         [
             str(SCRIPT),
             "--pe-id",
-            "PE-OPS-CURRENT-PE-STATE-01",
+            str(ACTIVE_STATE["pe_id"]),
             "--branch",
-            "feature/pe-ops-current-pe-state-01",
+            str(ACTIVE_STATE["branch"]),
             "--baseline",
-            "origin/main @ f686e92ac64f9d174d2cf64b781ce95312d7a090",
+            str(ACTIVE_STATE["baseline"]),
             "--lane",
-            "Strict",
+            str(ACTIVE_STATE["lane"]),
             "--implementer",
-            "infra-impl-b",
+            str(ACTIVE_STATE["implementer"]),
             "--validator",
-            "infra-val-a",
+            str(ACTIVE_STATE["validator"]),
             "--mode",
             "check",
             "--repo-root",
@@ -247,17 +409,17 @@ def test_generate_emits_current_state_json() -> None:
         [
             str(SCRIPT),
             "--pe-id",
-            "PE-OPS-CURRENT-PE-STATE-01",
+            str(ACTIVE_STATE["pe_id"]),
             "--branch",
-            "feature/pe-ops-current-pe-state-01",
+            str(ACTIVE_STATE["branch"]),
             "--baseline",
-            "origin/main @ f686e92ac64f9d174d2cf64b781ce95312d7a090",
+            str(ACTIVE_STATE["baseline"]),
             "--lane",
-            "Strict",
+            str(ACTIVE_STATE["lane"]),
             "--implementer",
-            "infra-impl-b",
+            str(ACTIVE_STATE["implementer"]),
             "--validator",
-            "infra-val-a",
+            str(ACTIVE_STATE["validator"]),
             "--mode",
             "generate",
         ],
@@ -268,6 +430,6 @@ def test_generate_emits_current_state_json() -> None:
 
     assert result.returncode == 0, result.stdout + result.stderr
     payload = json.loads(result.stdout)
-    assert payload["pe_id"] == "PE-OPS-CURRENT-PE-STATE-01"
-    assert payload["branch"] == "feature/pe-ops-current-pe-state-01"
-    assert payload["objective"] == CURRENT_STATE["objective"]
+    assert payload["pe_id"] == ACTIVE_STATE["pe_id"]
+    assert payload["branch"] == ACTIVE_STATE["branch"]
+    assert payload["objective"] == ACTIVE_STATE["objective"]

--- a/tests/test_pm_dispatch_contract.py
+++ b/tests/test_pm_dispatch_contract.py
@@ -7,20 +7,37 @@ import json
 from pathlib import Path
 
 
+ACTIVE_MARKERS = (
+    "PE-OPS-CURRENT-PE-STATE-01",
+    "feature/pe-ops-current-pe-state-01",
+    "infra-impl-b",
+    "infra-val-a",
+    "planning / awaiting implementer dispatch",
+)
+
+CLOSEOUT_MARKERS = (
+    "PE-OPS-CURRENT-PE-STATE-01",
+    "plan-complete / no active PE",
+    "merged on `origin/main`",
+    "| PE      | — |",
+    "| Branch  | — |",
+    "| — | — |",
+    "no active PE roles",
+)
+
+
+def _matches_active_state(text: str) -> bool:
+    return all(marker in text for marker in ACTIVE_MARKERS)
+
+
+def _matches_closeout_state(text: str) -> bool:
+    return all(marker in text for marker in CLOSEOUT_MARKERS)
+
+
 def test_current_pe_marks_the_active_pe_and_roles() -> None:
     text = Path("CURRENT_PE.md").read_text(encoding="utf-8")
 
-    active_state = all(
-        marker in text
-        for marker in (
-            "PE-OPS-CURRENT-PE-STATE-01",
-            "feature/pe-ops-current-pe-state-01",
-            "infra-impl-b",
-            "infra-val-a",
-            "planning / awaiting implementer dispatch",
-        )
-    )
-    assert active_state
+    assert _matches_active_state(text) or _matches_closeout_state(text)
 
 
 def test_current_pe_state_file_matches_current_pe_md() -> None:


### PR DESCRIPTION
Update tests to accept both active structured PE state and plan-complete / no-active-PE closeout state.

Changed files:
- tests/test_pm_dispatch.py
- tests/test_pm_dispatch_contract.py

Behaviour:
- subprocess coverage remains on the active CLI path
- closeout coverage is packet/contract-level
- PR #453 and closeout state files were left untouched

Validation:
- python -m pytest -q tests/test_pm_dispatch.py tests/test_pm_dispatch_contract.py
- python scripts/check_current_pe.py
- python -m json.tool .elis/state/current_pe.json

Safety:
- no runtime/config/auth/service changes
- no service restart