### PR TITLE
PE-OPS-A2A-RUNTIME-LOOPBACK-01: Gate 3 governed semantics and runtime loopback

### DIFF
--- a/elis/a2a/advisor/executor.py
+++ b/elis/a2a/advisor/executor.py
@@ -81,20 +81,24 @@ class AdvisorExecutor(AgentExecutor):
         # Step 3 — construct TaskUpdater as a convenience wrapper
         task_updater = TaskUpdater(event_queue, task_id, context_id)
 
-        # ── Gate 2E: policy validation ────────────────────────────────
+        # ── Gate 2E + Gate 3: policy validation ─────────────────────────
         metadata = context.message.metadata if context.message else None
         sender_role = None
         message_type = None
+        elis_sent_at = None
         if metadata is not None:
             if "elis_sender_role" in metadata:
                 sender_role = metadata["elis_sender_role"]  # type: ignore[assignment]
             if "elis_message_type" in metadata:
                 message_type = metadata["elis_message_type"]  # type: ignore[assignment]
+            if "elis_sent_at" in metadata:
+                elis_sent_at = metadata["elis_sent_at"]  # type: ignore[assignment]
 
         result = validate_message(
             sender_role=sender_role,  # type: ignore[arg-type]
             message_type=message_type,  # type: ignore[arg-type]
             recipient_role="advisor",
+            elis_sent_at=elis_sent_at,  # type: ignore[arg-type]
         )
 
         if not result.allowed:
@@ -123,7 +127,19 @@ class AdvisorExecutor(AgentExecutor):
             "This is a diagnostic response confirming the channel is operational."
         )
         part: Part = ParseDict({"text": ack_text}, Part())
-        response_message = task_updater.new_agent_message(parts=[part])
+        from datetime import datetime, timezone as _tz
+
+        response_message = task_updater.new_agent_message(
+            parts=[part],
+            metadata={
+                "elis_sender_role": "advisor",
+                "elis_message_type": "ack",
+                "elis_policy_version": "1.0.0",
+                "elis_processed_at": datetime.now(_tz.utc).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                ),
+            },
+        )
         await task_updater.complete(message=response_message)
 
         logger.info(

--- a/elis/a2a/pm/client.py
+++ b/elis/a2a/pm/client.py
@@ -19,6 +19,7 @@ No public URL accepted.
 
 import logging
 import uuid
+from datetime import datetime, timezone
 from typing import Any, Optional
 from urllib.parse import urlparse
 
@@ -67,6 +68,7 @@ def _build_governed_metadata(
         "elis_sender_role": sender_role,
         "elis_message_type": message_type,
         "elis_policy_version": policy_version,
+        "elis_sent_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
     if task_ref:
         meta_dict["elis_task_ref"] = task_ref

--- a/elis/a2a/policy.py
+++ b/elis/a2a/policy.py
@@ -1,21 +1,35 @@
 """
 ELIS A2A governed message semantics — shared policy module.
 
-Gate 2E: validates sender role, recipient role, and message type
-against the approved Advisor ↔ Supervisor loopback policy table.
+Gate 2E + Gate 3: validates sender role, recipient role, message type,
+and timestamp governance (elis_sent_at) against the approved
+Advisor ↔ Supervisor loopback policy table.
 
 Inbound message types: request, ack, status.
 policy_rejection is outbound-only — produced by TaskUpdater.reject().
+
+Timestamp governance (Gate 3):
+  - Inbound:  elis_sent_at (ISO 8601 UTC with literal Z)
+  - Outbound: elis_processed_at (ISO 8601 UTC with literal Z)
+  - Max stale age: 300 s
+  - Max future skew: 30 s
+  - Rejection codes: E_TS_MISSING, E_TS_MALFORMED, E_TS_STALE, E_TS_FUTURE
+  - Deterministic failure — no success completion on timestamp failure.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Optional
 
 ALLOWED_SENDER_ROLES = frozenset({"advisor", "supervisor", "pm"})
 ALLOWED_INBOUND_MESSAGE_TYPES = frozenset({"request", "ack", "status"})
 PM_ALLOWED_RECIPIENTS = frozenset({"advisor", "supervisor"})
+
+# Timestamp governance constants (Gate 3)
+MAX_STALE_AGE_S = 300
+MAX_FUTURE_SKEW_S = 30
 
 
 class RejectionCode:
@@ -25,6 +39,11 @@ class RejectionCode:
     UNSUPPORTED_TYPE = "REJECTED_UNSUPPORTED_TYPE"
     AUTONOMOUS_FOLLOW_ON = "REJECTED_AUTONOMOUS_FOLLOW_ON"
     DISALLOWED_RECIPIENT = "REJECTED_DISALLOWED_RECIPIENT"
+    # Gate 3 — timestamp governance
+    TS_MISSING = "E_TS_MISSING"
+    TS_MALFORMED = "E_TS_MALFORMED"
+    TS_STALE = "E_TS_STALE"
+    TS_FUTURE = "E_TS_FUTURE"
 
 
 @dataclass(frozen=True)
@@ -34,45 +53,143 @@ class PolicyResult:
     rejection_text: Optional[str] = None
 
 
+# ── Timestamp helpers ────────────────────────────────────────────────
+
+
+def _parse_iso8601_z(timestamp_str: str) -> Optional[datetime]:
+    """Parse an ISO 8601 UTC timestamp string.
+
+    Returns an aware UTC ``datetime``, or ``None`` on parse failure.
+    Accepts the literal ``Z`` suffix and ``+00:00``.
+    """
+    try:
+        normalised = timestamp_str.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalised)
+    except (ValueError, TypeError):
+        return None
+
+
+def _utcnow_aware() -> datetime:
+    """Return the current time as an aware UTC datetime."""
+    return datetime.now(timezone.utc)
+
+
+def validate_timestamp(
+    *,
+    elis_sent_at: Optional[str],
+) -> PolicyResult:
+    """Validate ``elis_sent_at`` against Gate 3 timestamp governance rules.
+
+    Args:
+        elis_sent_at: ISO 8601 UTC timestamp string (or ``None``).
+
+    Returns:
+        ``PolicyResult`` — allowed or rejected with one of
+        ``E_TS_MISSING``, ``E_TS_MALFORMED``, ``E_TS_STALE``, ``E_TS_FUTURE``.
+    """
+    if elis_sent_at is None:
+        return PolicyResult(
+            allowed=False,
+            rejection_code=RejectionCode.TS_MISSING,
+            rejection_text=(
+                "REJECTED: missing required timestamp field (elis_sent_at)."
+            ),
+        )
+
+    sent_at = _parse_iso8601_z(elis_sent_at)
+    if sent_at is None:
+        return PolicyResult(
+            allowed=False,
+            rejection_code=RejectionCode.TS_MALFORMED,
+            rejection_text=(
+                f"REJECTED: malformed timestamp {elis_sent_at!r}. "
+                "Expected ISO 8601 UTC (e.g. 2026-06-18T12:00:00Z)."
+            ),
+        )
+
+    now = _utcnow_aware()
+
+    # Stale check — message too old
+    age_s = (now - sent_at).total_seconds()
+    if age_s > MAX_STALE_AGE_S:
+        return PolicyResult(
+            allowed=False,
+            rejection_code=RejectionCode.TS_STALE,
+            rejection_text=(
+                f"REJECTED: timestamp too old "
+                f"({age_s:.0f}s > {MAX_STALE_AGE_S}s max stale age)."
+            ),
+        )
+
+    # Future-skew check — clock drift / misconfigured sender
+    if sent_at > now:
+        skew_s = (sent_at - now).total_seconds()
+        if skew_s > MAX_FUTURE_SKEW_S:
+            return PolicyResult(
+                allowed=False,
+                rejection_code=RejectionCode.TS_FUTURE,
+                rejection_text=(
+                    f"REJECTED: timestamp too far in the future "
+                    f"({skew_s:.0f}s > {MAX_FUTURE_SKEW_S}s max future skew)."
+                ),
+            )
+
+    return PolicyResult(allowed=True)
+
+
+# ── Message validation ───────────────────────────────────────────────
+
+
 def validate_message(
     *,
     sender_role: Optional[str],
     message_type: Optional[str],
     recipient_role: str,
     declared_target_role: Optional[str] = None,
+    elis_sent_at: Optional[str] = None,
 ) -> PolicyResult:
-    """Validate an incoming message against the Gate 2E policy table.
+    """Validate an incoming message against the Gate 2E+Gate 3 policy table.
 
     Args:
-        sender_role: Value of Message.metadata.elis_sender_role.
-        message_type: Value of Message.metadata.elis_message_type.
+        sender_role: Value of ``Message.metadata.elis_sender_role``.
+        message_type: Value of ``Message.metadata.elis_message_type``.
         recipient_role: The role of the agent receiving the message
-                        ("advisor" or "supervisor").
-        declared_target_role: Value of Message.metadata.elis_target_role,
+                        (``"advisor"`` or ``"supervisor"``).
+        declared_target_role: Value of ``Message.metadata.elis_target_role``,
                               if present.  Used for PM destination allowlist
-                              enforcement — PM must declare who it intends to
-                              reach, and that target must be in
-                              ``PM_ALLOWED_RECIPIENTS``.
+                              enforcement.
+        elis_sent_at: Value of ``Message.metadata.elis_sent_at`` (Gate 3).
+                       ISO 8601 UTC timestamp with literal ``Z``.
 
     Returns:
-        PolicyResult with allowed=True/False and rejection details if denied.
+        ``PolicyResult`` with allowed=True/False and rejection details if denied.
     """
-    # Malformed: missing metadata
+    # Malformed: missing core metadata
     if sender_role is None or message_type is None:
         return PolicyResult(
             allowed=False,
             rejection_code=RejectionCode.MALFORMED_ENVELOPE,
-            rejection_text="REJECTED: missing required metadata fields "
-            "(elis_sender_role, elis_message_type).",
+            rejection_text=(
+                "REJECTED: missing required metadata fields "
+                "(elis_sender_role, elis_message_type)."
+            ),
         )
+
+    # ── Gate 3: timestamp validation ──────────────────────────────────
+    ts_result = validate_timestamp(elis_sent_at=elis_sent_at)
+    if not ts_result.allowed:
+        return ts_result
+    # ── End Gate 3 ─────────────────────────────────────────────────────
 
     # Unknown sender
     if sender_role not in ALLOWED_SENDER_ROLES:
         return PolicyResult(
             allowed=False,
             rejection_code=RejectionCode.UNKNOWN_SENDER,
-            rejection_text=f"REJECTED: unknown sender role {sender_role!r}. "
-            f"Allowed: {sorted(ALLOWED_SENDER_ROLES)}.",
+            rejection_text=(
+                f"REJECTED: unknown sender role {sender_role!r}. "
+                f"Allowed: {sorted(ALLOWED_SENDER_ROLES)}."
+            ),
         )
 
     # PM destination allowlist — must declare intended target and it must be
@@ -94,8 +211,10 @@ def validate_message(
         return PolicyResult(
             allowed=False,
             rejection_code=RejectionCode.SELF_TARGET,
-            rejection_text=f"REJECTED: self-target not allowed "
-            f"({sender_role} → {recipient_role}).",
+            rejection_text=(
+                f"REJECTED: self-target not allowed "
+                f"({sender_role} → {recipient_role})."
+            ),
         )
 
     # Unsupported type
@@ -104,13 +223,15 @@ def validate_message(
             return PolicyResult(
                 allowed=False,
                 rejection_code=RejectionCode.AUTONOMOUS_FOLLOW_ON,
-                rejection_text="REJECTED: autonomous follow-on tasks not allowed.",
+                rejection_text=("REJECTED: autonomous follow-on tasks not allowed."),
             )
         return PolicyResult(
             allowed=False,
             rejection_code=RejectionCode.UNSUPPORTED_TYPE,
-            rejection_text=f"REJECTED: unsupported message type {message_type!r}. "
-            f"Allowed inbound: {sorted(ALLOWED_INBOUND_MESSAGE_TYPES)}.",
+            rejection_text=(
+                f"REJECTED: unsupported message type {message_type!r}. "
+                f"Allowed inbound: {sorted(ALLOWED_INBOUND_MESSAGE_TYPES)}."
+            ),
         )
 
     # All checks passed

--- a/elis/a2a/supervisor/executor.py
+++ b/elis/a2a/supervisor/executor.py
@@ -79,20 +79,24 @@ class SupervisorExecutor(AgentExecutor):
         # Step 3 — construct TaskUpdater as a convenience wrapper
         task_updater = TaskUpdater(event_queue, task_id, context_id)
 
-        # ── Gate 2E: policy validation ────────────────────────────────
+        # ── Gate 2E + Gate 3: policy validation ─────────────────────────
         metadata = context.message.metadata if context.message else None
         sender_role = None
         message_type = None
+        elis_sent_at = None
         if metadata is not None:
             if "elis_sender_role" in metadata:
                 sender_role = metadata["elis_sender_role"]  # type: ignore[assignment]
             if "elis_message_type" in metadata:
                 message_type = metadata["elis_message_type"]  # type: ignore[assignment]
+            if "elis_sent_at" in metadata:
+                elis_sent_at = metadata["elis_sent_at"]  # type: ignore[assignment]
 
         result = validate_message(
             sender_role=sender_role,  # type: ignore[arg-type]
             message_type=message_type,  # type: ignore[arg-type]
             recipient_role="supervisor",
+            elis_sent_at=elis_sent_at,  # type: ignore[arg-type]
         )
 
         if not result.allowed:
@@ -121,7 +125,19 @@ class SupervisorExecutor(AgentExecutor):
             "This is a diagnostic response confirming the channel is operational."
         )
         part: Part = ParseDict({"text": ack_text}, Part())
-        response_message = task_updater.new_agent_message(parts=[part])
+        from datetime import datetime, timezone as _tz
+
+        response_message = task_updater.new_agent_message(
+            parts=[part],
+            metadata={
+                "elis_sender_role": "supervisor",
+                "elis_message_type": "ack",
+                "elis_policy_version": "1.0.0",
+                "elis_processed_at": datetime.now(_tz.utc).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                ),
+            },
+        )
         await task_updater.complete(message=response_message)
 
         logger.info(

--- a/tests/a2a_sdk/test_pe_ops_a2a_multi_agent_02.py
+++ b/tests/a2a_sdk/test_pe_ops_a2a_multi_agent_02.py
@@ -13,8 +13,10 @@ Validates:
 import asyncio
 import sys
 import uuid
+from datetime import datetime, timezone
 
 import httpx
+from google.protobuf.struct_pb2 import Struct
 
 from a2a.client.card_resolver import A2ACardResolver
 from a2a.client.client_factory import ClientFactory
@@ -44,11 +46,25 @@ async def send_message_and_collect(client, text):
         and ``text`` (when present).
     """
     part = ParseDict({"text": text}, a2a_pb2.Part())
+    metadata = Struct()
+    metadata.update(
+        {
+            "elis_sender_role": "pm",
+            "elis_message_type": "request",
+            "elis_policy_version": "1.0.0",
+            "elis_sent_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+    )
     msg = ParseDict(
         {
             "message_id": str(uuid.uuid4()),
             "context_id": str(uuid.uuid4()),
             "role": a2a_pb2.Role.Value("ROLE_USER"),
+            "metadata": MessageToDict(
+                metadata,
+                preserving_proto_field_name=True,
+                always_print_fields_with_no_presence=False,
+            ),
             "parts": [
                 MessageToDict(
                     part,

--- a/tests/a2a_sdk/test_pe_ops_a2a_semantics_03.py
+++ b/tests/a2a_sdk/test_pe_ops_a2a_semantics_03.py
@@ -1,13 +1,17 @@
 """
-PE-OPS-A2A-PRODUCTION-01 — Gate 2E governed semantics validation.
+PE-OPS-A2A-RUNTIME-LOOPBACK-01 — Gate 3 governed semantics validation
+(includes Gate 2E policy + Gate 3 timestamp governance).
 
-Validates the 14-row policy decision table for the Advisor ↔ Supervisor
+Validates the 32-row policy decision table for the Advisor ↔ Supervisor
 loopback topology.  Assumes both servers are running on their canonical ports
 (Advisor 9500, Supervisor 9501).
 
-24 test cases:
+32 test cases:
   12 allowed → TASK_STATE_COMPLETED
-  11 rejected → TASK_STATE_REJECTED with correct REJECTED_* code in metadata
+  11 rejected (Gate 2E) → TASK_STATE_REJECTED
+   4 timestamp unit tests (validate_timestamp directly)
+   4 timestamp integration tests (live servers)
+   1 PM destination denial unit test (DISALLOWED_RECIPIENT)
 
 Run:
   cd /opt/elis/repo && PYTHONPATH=. /opt/elis/a2a/venv/bin/python \\
@@ -19,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import uuid
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import httpx
@@ -52,7 +57,29 @@ def fail(label: str, detail: str = "") -> None:
     print(msg)
 
 
-# ── Client helpers ─────────────────────────────────────────────────────────────
+# ── Timestamp helpers ────────────────────────────────────────────────────────
+
+
+def _utcnow_iso() -> str:
+    """Return the current UTC time as an ISO 8601 string with ``Z`` suffix."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _stale_timestamp(age_s: int = 600) -> str:
+    """Return an ISO 8601 UTC timestamp *age_s* seconds in the past."""
+    return (datetime.now(timezone.utc) - timedelta(seconds=age_s)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def _future_timestamp(offset_s: int = 120) -> str:
+    """Return an ISO 8601 UTC timestamp *offset_s* seconds in the future."""
+    return (datetime.now(timezone.utc) + timedelta(seconds=offset_s)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+# ── Client helpers ───────────────────────────────────────────────────────────
 
 
 async def fetch_card(http: httpx.AsyncClient, base_url: str) -> a2a_pb2.AgentCard:
@@ -67,15 +94,20 @@ async def send_governed_message(
     target_url: str,
     sender_role: str,
     message_type: str,
-    text: str = "Gate 2E diagnostic message.",
+    text: str = "Gate 3 diagnostic message.",
     task_ref: Optional[str] = None,
     target_role: Optional[str] = None,
+    elis_sent_at=None,  # type: ignore[assignment] — _NO_TS sentinel or str|None
 ) -> list[dict]:
     """Send a governed message with ELIS metadata and collect stream events.
 
     Args:
         target_role: If set, adds ``elis_target_role`` to metadata for
                      PM destination allowlist enforcement.
+        elis_sent_at: ISO 8601 UTC timestamp.  If ``None``, the field is
+                      **omitted entirely** (used for E_TS_MISSING tests).
+                      If not provided at all, defaults to ``_utcnow_iso()``
+                      for normal allowed/rejected traffic.
     """
     metadata = Struct()
     meta_dict: dict[str, str] = {
@@ -83,6 +115,12 @@ async def send_governed_message(
         "elis_message_type": message_type,
         "elis_policy_version": "1.0.0",
     }
+    # Only add elis_sent_at if a value was explicitly provided or we default it.
+    # We detect "not provided" by a special sentinel.
+    if elis_sent_at is not _NO_TS:  # type: ignore[comparison-overlap]
+        meta_dict["elis_sent_at"] = (
+            elis_sent_at if elis_sent_at is not None else _utcnow_iso()
+        )
     if task_ref:
         meta_dict["elis_task_ref"] = task_ref
     if target_role:
@@ -137,6 +175,15 @@ async def send_governed_message(
     return events
 
 
+# Sentinel: when elis_sent_at is NOT passed to send_governed_message at all,
+# we default to a fresh timestamp.  When the caller passes _NO_TS explicitly,
+# we omit the field entirely (for E_TS_MISSING tests).
+_NO_TS = object()
+
+
+# ── Assertion helpers ────────────────────────────────────────────────────────
+
+
 async def send_no_metadata(client, text: str = "No metadata message.") -> list[dict]:
     """Send a message WITHOUT any metadata field — malformed envelope test."""
     part = ParseDict({"text": text}, a2a_pb2.Part())
@@ -177,7 +224,7 @@ async def send_no_metadata(client, text: str = "No metadata message.") -> list[d
     return events
 
 
-# ── Assertion helpers ──────────────────────────────────────────────────────────
+# ── Assertion helpers ────────────────────────────────────────────────────────
 
 
 def assert_completed(events: list[dict], label: str) -> bool:
@@ -225,14 +272,14 @@ def assert_no_rejection_code(events: list[dict], label: str) -> bool:
     return True
 
 
-# ── Main test ──────────────────────────────────────────────────────────────────
+# ── Main test ────────────────────────────────────────────────────────────────
 
 
 async def main() -> int:
     global PASSES, FAILS
 
     print("=" * 60)
-    print("Gate 2E — Governed A2A Semantics Validation")
+    print("Gate 3 — Governed A2A Semantics + Timestamp Governance")
     print("=" * 60)
 
     # ── Step 0: Fetch Agent Cards ──────────────────────────────────────
@@ -256,7 +303,7 @@ async def main() -> int:
     pass_("Both A2A clients instantiated")
 
     # ═══════════════════════════════════════════════════════════════════
-    # ALLOWED CASES (rows 1–6): request, ack, status across roles
+    # ALLOWED CASES (rows 1–12): request, ack, status across roles
     # ═══════════════════════════════════════════════════════════════════
 
     print("\n── Allowed: Row 1 — advisor → supervisor request ──")
@@ -384,7 +431,7 @@ async def main() -> int:
     assert_no_rejection_code(events, "Row 12: no rejection code")
 
     # ═══════════════════════════════════════════════════════════════════
-    # REJECTED CASES (rows 13–22)
+    # REJECTED CASES — Gate 2E (rows 13–23)
     # ═══════════════════════════════════════════════════════════════════
 
     # ── Rows 13–14: Self-target ──────────────────────────────────────────
@@ -491,7 +538,7 @@ async def main() -> int:
         "Row 20: autonomous_follow_on → REJECTED_AUTONOMOUS_FOLLOW_ON",
     )
 
-    # ── Rows 21–23: PM rejected cases ───────────────────────────────────
+    # ── Rows 21–22: PM rejected cases ───────────────────────────────────
     print("\n── Rejected: Row 21 — pm→advisor unsupported type ──")
     events = await send_governed_message(
         advisor_client,
@@ -518,15 +565,16 @@ async def main() -> int:
         "Row 22: pm autonomous_follow_on → REJECTED_AUTONOMOUS_FOLLOW_ON",
     )
 
-    # ── Row 23: PM destination denial — policy unit test ──────────
+    # ── Row 23: PM destination denial — policy unit test ──────────────
     print("\n── Rejected: Row 23 — pm→github policy unit test ──")
-    from elis.a2a.policy import validate_message, RejectionCode as RC
+    from elis.a2a.policy import validate_message as vm, RejectionCode as RC
 
-    result = validate_message(
+    result = vm(
         sender_role="pm",
         message_type="request",
         recipient_role="advisor",
         declared_target_role="github",
+        elis_sent_at=_utcnow_iso(),
     )
     if not result.allowed and result.rejection_code == RC.DISALLOWED_RECIPIENT:
         pass_("Row 23: pm→github → REJECTED_DISALLOWED_RECIPIENT (unit)")
@@ -536,6 +584,124 @@ async def main() -> int:
             f"expected DISALLOWED_RECIPIENT, got "
             f"allowed={result.allowed} code={result.rejection_code!r}",
         )
+
+    # ═══════════════════════════════════════════════════════════════════
+    # GATE 3 — TIMESTAMP GOVERNANCE (rows 24–31)
+    # ═══════════════════════════════════════════════════════════════════
+
+    from elis.a2a.policy import validate_timestamp
+
+    # ── Unit tests: validate_timestamp() directly ──────────────────────
+    print("\n── Timestamp unit: E_TS_MISSING ──")
+    result = validate_timestamp(elis_sent_at=None)
+    if not result.allowed and result.rejection_code == RC.TS_MISSING:
+        pass_("Row 24: E_TS_MISSING — None timestamp (unit)")
+    else:
+        fail(
+            "Row 24: E_TS_MISSING unit",
+            f"expected TS_MISSING, got allowed={result.allowed} "
+            f"code={result.rejection_code!r}",
+        )
+
+    print("\n── Timestamp unit: E_TS_MALFORMED ──")
+    result = validate_timestamp(elis_sent_at="not-a-timestamp")
+    if not result.allowed and result.rejection_code == RC.TS_MALFORMED:
+        pass_("Row 25: E_TS_MALFORMED — garbage timestamp (unit)")
+    else:
+        fail(
+            "Row 25: E_TS_MALFORMED unit",
+            f"expected TS_MALFORMED, got allowed={result.allowed} "
+            f"code={result.rejection_code!r}",
+        )
+
+    print("\n── Timestamp unit: E_TS_STALE ──")
+    result = validate_timestamp(elis_sent_at=_stale_timestamp(age_s=600))
+    if not result.allowed and result.rejection_code == RC.TS_STALE:
+        pass_("Row 26: E_TS_STALE — 600s old timestamp (unit)")
+    else:
+        fail(
+            "Row 26: E_TS_STALE unit",
+            f"expected TS_STALE, got allowed={result.allowed} "
+            f"code={result.rejection_code!r}",
+        )
+
+    print("\n── Timestamp unit: E_TS_FUTURE ──")
+    result = validate_timestamp(elis_sent_at=_future_timestamp(offset_s=120))
+    if not result.allowed and result.rejection_code == RC.TS_FUTURE:
+        pass_("Row 27: E_TS_FUTURE — 120s future timestamp (unit)")
+    else:
+        fail(
+            "Row 27: E_TS_FUTURE unit",
+            f"expected TS_FUTURE, got allowed={result.allowed} "
+            f"code={result.rejection_code!r}",
+        )
+
+    print("\n── Timestamp unit: valid timestamp (acceptance) ──")
+    result = validate_timestamp(elis_sent_at=_utcnow_iso())
+    if result.allowed:
+        pass_("Row 28: valid timestamp → allowed (unit)")
+    else:
+        fail(
+            "Row 28: valid timestamp acceptance",
+            f"expected allowed=True, got code={result.rejection_code!r}",
+        )
+
+    # ── Integration tests: live servers with bad timestamps ────────────
+    print("\n── Timestamp integration: E_TS_MISSING (no elis_sent_at) ──")
+    events = await send_governed_message(
+        advisor_client,
+        target_url=ADVISOR_URL,
+        sender_role="supervisor",
+        message_type="request",
+        elis_sent_at=_NO_TS,
+    )
+    assert_rejected(
+        events,
+        "E_TS_MISSING",
+        "Row 29: no elis_sent_at → E_TS_MISSING (integration)",
+    )
+
+    print("\n── Timestamp integration: E_TS_MALFORMED (garbage) ──")
+    events = await send_governed_message(
+        advisor_client,
+        target_url=ADVISOR_URL,
+        sender_role="supervisor",
+        message_type="request",
+        elis_sent_at="garbage-not-iso",
+    )
+    assert_rejected(
+        events,
+        "E_TS_MALFORMED",
+        "Row 30: malformed timestamp → E_TS_MALFORMED (integration)",
+    )
+
+    print("\n── Timestamp integration: E_TS_STALE (old timestamp) ──")
+    events = await send_governed_message(
+        advisor_client,
+        target_url=ADVISOR_URL,
+        sender_role="supervisor",
+        message_type="request",
+        elis_sent_at=_stale_timestamp(age_s=600),
+    )
+    assert_rejected(
+        events,
+        "E_TS_STALE",
+        "Row 31: stale timestamp → E_TS_STALE (integration)",
+    )
+
+    print("\n── Timestamp integration: E_TS_FUTURE (far future) ──")
+    events = await send_governed_message(
+        advisor_client,
+        target_url=ADVISOR_URL,
+        sender_role="supervisor",
+        message_type="request",
+        elis_sent_at=_future_timestamp(offset_s=120),
+    )
+    assert_rejected(
+        events,
+        "E_TS_FUTURE",
+        "Row 32: future timestamp → E_TS_FUTURE (integration)",
+    )
 
     # ═══════════════════════════════════════════════════════════════════
     # RESULT


### PR DESCRIPTION
## PE-OPS-A2A-RUNTIME-LOOPBACK-01

**Scope:** Gate 3 governed A2A message semantics and runtime loopback validation.

### Files changed

| File | Δ |
|------|---|
| `elis/a2a/advisor/executor.py` | +19/-1 |
| `elis/a2a/pm/client.py` | +4/-0 |
| `elis/a2a/policy.py` | +165/-33 |
| `elis/a2a/supervisor/executor.py` | +19/-1 |
| `tests/a2a_sdk/test_pe_ops_a2a_multi_agent_02.py` | +16/-0 |
| `tests/a2a_sdk/test_pe_ops_a2a_semantics_03.py` | +198/-6 |

**Changes:** 6 files, +380/-41
**Base:** origin/main (f993f00)
**Status:** Implementation committed. No merge without explicit PO approval.

---

*This branch is a corrected replacement for PR #481 (which had divergence from origin/main).*